### PR TITLE
feat: move to creating SQL stages using pipeline_stage decorator

### DIFF
--- a/tests/cleaning/test_cleaning_steps.py
+++ b/tests/cleaning/test_cleaning_steps.py
@@ -4,13 +4,13 @@ from uk_address_matcher.cleaning.steps import (
     _parse_out_flat_position_and_letter,
     _remove_duplicate_end_tokens,
 )
-from uk_address_matcher.sql_pipeline.runner import DuckDBPipeline
+from uk_address_matcher.sql_pipeline.runner import DuckDBPipeline, RunOptions
 
 
 def _run_single_stage(stage_factory, input_relation, connection):
     pipeline = DuckDBPipeline(connection, input_relation)
     pipeline.add_step(stage_factory())
-    return pipeline.run(pretty_print_sql=False)
+    return pipeline.run(RunOptions(pretty_print_sql=False))
 
 
 def test_parse_out_flat_positional():
@@ -75,12 +75,12 @@ def test_parse_out_flat_positional():
     rows = result.fetchall()
 
     for (address, expected_pos, expected_letter), row in zip(test_cases, rows):
-        assert (
-            row[-2] == expected_pos
-        ), f"Address '{address}' expected positional '{expected_pos}' but got '{row[-2]}'"
-        assert (
-            row[-1] == expected_letter
-        ), f"Address '{address}' expected letter '{expected_letter}' but got '{row[-1]}'"
+        assert row[-2] == expected_pos, (
+            f"Address '{address}' expected positional '{expected_pos}' but got '{row[-2]}'"
+        )
+        assert row[-1] == expected_letter, (
+            f"Address '{address}' expected letter '{expected_letter}' but got '{row[-1]}'"
+        )
 
 
 def test_remove_duplicate_end_tokens():
@@ -122,6 +122,6 @@ def test_remove_duplicate_end_tokens():
     rows = result.fetchall()
 
     for (address, expected), row in zip(test_cases, rows):
-        assert (
-            row[0] == expected
-        ), f"Address '{address}' expected '{expected}' but got '{row[0]}'"
+        assert row[0] == expected, (
+            f"Address '{address}' expected '{expected}' but got '{row[0]}'"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import duckdb
+import pytest
+
+
+@pytest.fixture
+def duck_con():
+    con = duckdb.connect(database=":memory:")
+    yield con
+    con.close()

--- a/tests/sql_pipeline/test_multiple_inputs.py
+++ b/tests/sql_pipeline/test_multiple_inputs.py
@@ -1,0 +1,129 @@
+import duckdb
+import pytest
+
+from uk_address_matcher.sql_pipeline.runner import (
+    DuckDBPipeline,
+    InputBinding,
+    create_sql_pipeline,
+)
+from uk_address_matcher.sql_pipeline.steps import pipeline_stage
+
+
+@pipeline_stage()
+def join_lookup_stage():
+    return """
+		SELECT a.id, b.extra
+		FROM {primary} AS a
+		JOIN {lookup} AS b
+		  ON a.id = b.id
+	"""
+
+
+@pipeline_stage()
+def root_join_lookup_stage():
+    return """
+        SELECT p.id, l.extra
+        FROM {root} AS p
+        JOIN {lookup} AS l
+          ON p.id = l.id
+    """
+
+
+def _setup_primary_lookup(duck_con: duckdb.DuckDBPyConnection) -> None:
+    duck_con.execute("CREATE TABLE primary_input (id INTEGER)")
+    duck_con.execute("INSERT INTO primary_input VALUES (1),(2)")
+    duck_con.execute("CREATE TABLE lookup_input (id INTEGER, extra INTEGER)")
+    duck_con.execute("INSERT INTO lookup_input VALUES (1, 100),(2, 200)")
+
+
+def test_multiple_input_bindings_register_aliases(duck_con):
+    _setup_primary_lookup(duck_con)
+
+    bindings = [
+        InputBinding("primary", duck_con.table("primary_input")),
+        InputBinding("lookup", duck_con.table("lookup_input")),
+    ]
+
+    pipeline = DuckDBPipeline(duck_con, bindings)
+    pipeline.add_step(join_lookup_stage())
+
+    result = pipeline.run().df().sort_values("id").reset_index(drop=True)
+
+    assert list(result.extra) == [100, 200]
+
+    alias_map = pipeline.input_alias_map
+    assert set(alias_map) >= {"primary", "lookup", "root"}
+    assert alias_map["root"] == alias_map["primary"]
+    for name in ("primary", "lookup"):
+        duck_con.execute(f"SELECT COUNT(*) FROM {alias_map[name]}")
+
+    assert pipeline.root_alias == alias_map["root"]
+
+
+@pipeline_stage()
+def slugged_join_stage():
+    return (
+        "joined",
+        """
+			SELECT p.id, l.extra
+			FROM {primary_input} AS p
+			JOIN {lookup_table} AS l
+			  ON p.id = l.id
+		""",
+    )
+
+
+def test_input_bindings_with_slugged_placeholders(duck_con):
+    _setup_primary_lookup(duck_con)
+
+    bindings = [
+        InputBinding("Primary Input", duck_con.table("primary_input")),
+        InputBinding("lookup-table", duck_con.table("lookup_input")),
+    ]
+
+    pipeline = create_sql_pipeline(
+        duck_con,
+        bindings,
+        [slugged_join_stage],
+        pipeline_name="slug-demo",
+    )
+
+    result = pipeline.run().df().sort_values("id").reset_index(drop=True)
+
+    assert list(result.extra) == [100, 200]
+
+    alias_map = dict(pipeline.input_alias_map)
+    assert "Primary Input" not in alias_map
+    assert "lookup-table" not in alias_map
+    assert alias_map.keys() >= {"primary_input", "lookup_table", "root"}
+    for name in ("primary_input", "lookup_table"):
+        duck_con.execute(f"SELECT COUNT(*) FROM {alias_map[name]}")
+
+
+def test_multi_input_pipeline_allows_root_placeholder(duck_con):
+    _setup_primary_lookup(duck_con)
+
+    bindings = [
+        InputBinding("primary", duck_con.table("primary_input")),
+        InputBinding("lookup", duck_con.table("lookup_input")),
+    ]
+
+    pipeline = DuckDBPipeline(duck_con, bindings)
+    pipeline.add_step(root_join_lookup_stage())
+
+    result = pipeline.run().df().sort_values("id").reset_index(drop=True)
+    assert list(result.extra) == [100, 200]
+
+
+def test_duplicate_input_placeholder_raises(duck_con):
+    _setup_primary_lookup(duck_con)
+
+    bindings = [
+        InputBinding("primary", duck_con.table("primary_input")),
+        InputBinding("primary", duck_con.table("lookup_input")),
+    ]
+
+    with pytest.raises(ValueError) as err:
+        DuckDBPipeline(duck_con, bindings)
+
+    assert "Duplicate input placeholder" in str(err.value)

--- a/tests/sql_pipeline/test_runner_show_plan.py
+++ b/tests/sql_pipeline/test_runner_show_plan.py
@@ -1,0 +1,92 @@
+import duckdb
+
+from uk_address_matcher.sql_pipeline.runner import create_sql_pipeline
+from uk_address_matcher.sql_pipeline.steps import pipeline_stage
+
+
+def _make_stage(name: str, description: str = "", **kwargs):
+    tags = kwargs.pop("tags", None)
+    depends_on = kwargs.pop("depends_on", None)
+    checkpoint = kwargs.pop("checkpoint", False)
+
+    @pipeline_stage(
+        name=name,
+        description=description,
+        tags=tags,
+        depends_on=depends_on,
+        checkpoint=checkpoint,
+    )
+    def stage_factory():
+        return "SELECT * FROM {input}"
+
+    return stage_factory()
+
+
+def _capture_plan_output(pipeline, monkeypatch):
+    captured: list[str] = []
+
+    def fake_emit(message: str):
+        captured.append(message)
+        return None
+
+    monkeypatch.setattr("uk_address_matcher.sql_pipeline.runner._emit_debug", fake_emit)
+
+    pipeline.show_plan()
+    assert captured, "show_plan should emit formatted output"
+    return captured[0]
+
+
+def test_show_plan_renders_stage_metadata(monkeypatch):
+    con = duckdb.connect()
+    try:
+        rel = con.sql("SELECT 1 AS id")
+        stage_one = _make_stage(
+            "stage_one",
+            description="First stage",
+            tags="alpha",
+        )
+        stage_two = _make_stage(
+            "stage_two",
+            description="Second stage",
+            tags=["beta", "gamma"],
+            depends_on="stage_one",
+            checkpoint=True,
+        )
+
+        pipeline = create_sql_pipeline(
+            con,
+            rel,
+            [stage_one, stage_two],
+            pipeline_name="Example pipeline",
+            pipeline_description="Demo pipeline",
+        )
+
+        output = _capture_plan_output(pipeline, monkeypatch)
+    finally:
+        con.close()
+
+    assert "Example pipeline" in output
+    assert "stage_one [alpha]" in output
+    assert "↳ First stage" in output
+    assert "stage_two [beta, gamma]" in output
+    assert "depends on:" in output and "• stage_one" in output
+    assert "checkpoint" in output
+
+
+def test_show_plan_handles_empty_pipeline(monkeypatch):
+    con = duckdb.connect()
+    try:
+        rel = con.sql("SELECT 1 AS id")
+        pipeline = create_sql_pipeline(
+            con,
+            rel,
+            [],
+            pipeline_name="Empty pipeline",
+        )
+
+        output = _capture_plan_output(pipeline, monkeypatch)
+    finally:
+        con.close()
+
+    assert "Empty pipeline" in output
+    assert "(no stages added)" in output

--- a/tests/sql_pipeline/test_sql_pipeline.py
+++ b/tests/sql_pipeline/test_sql_pipeline.py
@@ -1,4 +1,3 @@
-import duckdb
 import pytest
 
 from uk_address_matcher.sql_pipeline.runner import DuckDBPipeline
@@ -6,13 +5,6 @@ from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
 
 
 # ---------- Helpers ----------
-@pytest.fixture
-def duck_con():
-    con = duckdb.connect(database=":memory:")
-    yield con
-    con.close()
-
-
 @pytest.fixture
 def base_rel(duck_con):
     duck_con.execute("CREATE TABLE base (id INTEGER, val INTEGER)")

--- a/tests/sql_pipeline/test_updated_stage_decorators.py
+++ b/tests/sql_pipeline/test_updated_stage_decorators.py
@@ -1,0 +1,92 @@
+import pytest
+
+from uk_address_matcher.sql_pipeline.steps import (
+    CTEStep,
+    Stage,
+    pipeline_stage,
+)
+
+
+def test_pipeline_stage_from_string_returns_stage():
+    @pipeline_stage(
+        name="random_stage",
+        description="A random stage for testing",
+        tags="test",
+        depends_on="seed_stage",
+    )
+    def random_stage():
+        return "SELECT 1 AS col"
+
+    stage = random_stage()
+
+    assert isinstance(stage, Stage)
+    assert stage.name == "random_stage"
+    assert len(stage.steps) == 1
+    assert stage.steps[0].sql == "SELECT 1 AS col"
+    assert stage.stage_metadata.description == "A random stage for testing"
+    assert stage.stage_metadata.tags == ["test"]
+    assert stage.stage_metadata.depends_on == ["seed_stage"]
+
+
+def test_pipeline_stage_from_named_tuple_spec():
+    @pipeline_stage()
+    def named_fragment_stage():
+        return ("custom_fragment", "SELECT 2 AS col")
+
+    stage = named_fragment_stage()
+
+    assert isinstance(stage, Stage)
+    assert stage.steps[0].name == "custom_fragment"
+    assert stage.steps[0].sql == "SELECT 2 AS col"
+
+
+def test_pipeline_stage_from_iterable_spec():
+    @pipeline_stage()
+    def iterable_stage():
+        return [
+            ("first_fragment", "SELECT 1 AS col"),
+            CTEStep("second_fragment", "SELECT * FROM {first_fragment}"),
+        ]
+
+    stage = iterable_stage()
+
+    assert [step.name for step in stage.steps] == [
+        "first_fragment",
+        "second_fragment",
+    ]
+    assert stage.steps[1].sql == "SELECT * FROM {first_fragment}"
+
+
+def test_pipeline_stage_copies_registers_and_preludes():
+    sentinel = object()
+    registers = {"temp_rel": sentinel}
+    preludes = [lambda con: None]
+
+    @pipeline_stage(
+        stage_registers=registers,
+        preludes=preludes,
+        checkpoint=True,
+        stage_output="final_output",
+        tags=("alpha", "beta"),
+    )
+    def stage_with_registers():
+        return "SELECT 1"
+
+    stage = stage_with_registers()
+
+    assert stage.registers == registers
+    assert stage.registers is not registers
+    assert stage.preludes is not preludes
+    assert callable(stage.preludes[0])
+    assert stage.checkpoint is True
+    assert stage.output == "final_output"
+    assert stage.stage_metadata.tags == ["alpha", "beta"]
+
+
+def test_pipeline_stage_invalid_return_type_raises():
+    @pipeline_stage()
+    def bad_stage():
+        return {"invalid": "spec"}
+
+    with pytest.raises(TypeError):
+        bad_stage()

--- a/uk_address_matcher/cleaning/pipelines.py
+++ b/uk_address_matcher/cleaning/pipelines.py
@@ -1,7 +1,5 @@
-import random
-import string
 from importlib import resources
-from typing import Iterable
+from typing import Optional
 
 from duckdb import DuckDBPyConnection, DuckDBPyRelation
 
@@ -28,56 +26,8 @@ from uk_address_matcher.cleaning.steps import (
     _upper_case_address_and_postcode,
     _use_first_unusual_token_if_no_numeric_token,
 )
-from uk_address_matcher.sql_pipeline.runner import DuckDBPipeline, StageFactory
-
-
-def _generate_random_identifier(length: int = 8) -> str:
-    characters = string.ascii_letters + string.digits
-    return "".join(random.choice(characters) for _ in range(length))
-
-
-def _materialise_input_table(
-    con: DuckDBPyConnection, address_table: DuckDBPyRelation
-) -> tuple[DuckDBPyRelation, str]:
-    uid = _generate_random_identifier()
-    con.register("__address_table_in", address_table)
-    materialised_table_name = f"__address_table_{uid}"
-    con.execute(
-        f"""
-        create or replace temporary table {materialised_table_name} as
-        select * from __address_table_in
-        """
-    )
-    input_table = con.table(materialised_table_name)
-    return input_table, uid
-
-
-def _materialise_output_table(
-    con: DuckDBPyConnection, rel: DuckDBPyRelation, uid: str
-) -> DuckDBPyRelation:
-    con.register("__address_table_res", rel)
-    has_source_dataset = "source_dataset" in rel.columns
-    exclude_clause = "EXCLUDE (source_dataset)" if has_source_dataset else ""
-    materialised_name = f"__address_table_cleaned_{uid}"
-    con.execute(
-        f"""
-        create or replace temporary table {materialised_name} as
-        select * {exclude_clause} from __address_table_res
-        """
-    )
-    return con.table(materialised_name)
-
-
-def _run_stage_queue(
-    con: DuckDBPyConnection,
-    input_rel: DuckDBPyRelation,
-    stage_factories: Iterable[StageFactory],
-) -> DuckDBPyRelation:
-    pipeline = DuckDBPipeline(con, input_rel)
-    for stage_fn in stage_factories:
-        pipeline.add_step(stage_fn())
-    return pipeline.run(pretty_print_sql=False)
-
+from uk_address_matcher.sql_pipeline.helpers import _uid
+from uk_address_matcher.sql_pipeline.runner import RunOptions, create_sql_pipeline
 
 QUEUE_PRE_TF = [
     _trim_whitespace_address_and_postcode,
@@ -109,17 +59,44 @@ QUEUE_POST_TF = [
 ]
 
 
+def _materialise_output_table(
+    con: DuckDBPyConnection, rel: DuckDBPyRelation, uid: str
+) -> DuckDBPyRelation:
+    con.register("__address_table_res", rel)
+    has_source_dataset = "source_dataset" in rel.columns
+    exclude_clause = "EXCLUDE (source_dataset)" if has_source_dataset else ""
+    materialised_name = f"__address_table_cleaned_{uid}"
+    con.execute(
+        f"""
+        create or replace temporary table {materialised_name} as
+        select * {exclude_clause} from __address_table_res
+        """
+    )
+    return con.table(materialised_name)
+
+
 def clean_data_on_the_fly(
     address_table: DuckDBPyRelation,
     con: DuckDBPyConnection,
+    *,
+    run_options: Optional[RunOptions] = None,
 ) -> DuckDBPyRelation:
     stage_queue = (
         QUEUE_PRE_TF + [_add_term_frequencies_to_address_tokens] + QUEUE_POST_TF
     )
 
-    input_table, uid = _materialise_input_table(con, address_table)
-    result_rel = _run_stage_queue(con, input_table, stage_queue)
-    return _materialise_output_table(con, result_rel, uid)
+    pipeline = create_sql_pipeline(
+        con,
+        address_table,
+        stage_queue,
+        pipeline_name="Clean data on the fly",
+        pipeline_description=(
+            "Clean address data using term frequencies computed "
+            "on the fly from the input data"
+        ),
+    )
+    table_rel = pipeline.run(run_options)
+    return _materialise_output_table(con, table_rel, _uid())
 
 
 def clean_data_using_precomputed_rel_tok_freq(
@@ -127,6 +104,8 @@ def clean_data_using_precomputed_rel_tok_freq(
     con: DuckDBPyConnection,
     rel_tok_freq_table: DuckDBPyRelation | None = None,
     derive_distinguishing_wrt_adjacent_records: bool = False,
+    *,
+    run_options: Optional[RunOptions] = None,
 ) -> DuckDBPyRelation:
     if rel_tok_freq_table is None:
         default_tf_path = (
@@ -150,14 +129,24 @@ def clean_data_using_precomputed_rel_tok_freq(
         + QUEUE_POST_TF
     )
 
-    input_table, uid = _materialise_input_table(con, address_table)
-    result_rel = _run_stage_queue(con, input_table, stage_queue)
-    return _materialise_output_table(con, result_rel, uid)
+    pipeline = create_sql_pipeline(
+        con,
+        address_table,
+        stage_queue,
+        pipeline_name="Clean data using precomputed term frequencies",
+        pipeline_description=(
+            "Clean address data using a supplied table of relative token frequencies"
+        ),
+    )
+    result_rel = pipeline.run(run_options)
+    return _materialise_output_table(con, result_rel, _uid())
 
 
 def get_numeric_term_frequencies_from_address_table(
     df_address_table: DuckDBPyRelation,
     con: DuckDBPyConnection,
+    *,
+    run_options: Optional[RunOptions] = None,
 ) -> DuckDBPyRelation:
     stage_queue = [
         _trim_whitespace_address_and_postcode,
@@ -167,11 +156,16 @@ def get_numeric_term_frequencies_from_address_table(
         _parse_out_numbers,
     ]
 
-    numeric_tokens_rel = _run_stage_queue(
+    pipeline = create_sql_pipeline(
         con,
         df_address_table,
         stage_queue,
+        pipeline_name="Get numeric term frequencies",
+        pipeline_description=(
+            "Derive numeric tokens and compute frequency distribution"
+        ),
     )
+    numeric_tokens_rel = pipeline.run(run_options)
     numeric_tokens_rel.show()
     con.register("numeric_tokens_df", numeric_tokens_rel)
 
@@ -193,6 +187,8 @@ def get_numeric_term_frequencies_from_address_table(
 def get_address_token_frequencies_from_address_table(
     df_address_table: DuckDBPyRelation,
     con: DuckDBPyConnection,
+    *,
+    run_options: Optional[RunOptions] = None,
 ) -> DuckDBPyRelation:
     stage_queue = [
         _trim_whitespace_address_and_postcode,
@@ -206,4 +202,11 @@ def get_address_token_frequencies_from_address_table(
         _get_token_frequeny_table,
     ]
 
-    return _run_stage_queue(con, df_address_table, stage_queue)
+    pipeline = create_sql_pipeline(
+        con,
+        df_address_table,
+        stage_queue,
+        pipeline_name="Get address token frequencies",
+        pipeline_description=("Tokenise addresses and compute frequency distribution"),
+    )
+    return pipeline.run(run_options)

--- a/uk_address_matcher/cleaning/steps/normalisation.py
+++ b/uk_address_matcher/cleaning/steps/normalisation.py
@@ -16,7 +16,11 @@ from uk_address_matcher.cleaning.steps.regexes import (
 from uk_address_matcher.sql_pipeline.steps import pipeline_stage
 
 
-@pipeline_stage(name="trim_whitespace_address_and_postcode")
+@pipeline_stage(
+    name="trim_whitespace_address_and_postcode",
+    description="Remove leading and trailing whitespace from address and postcode fields",
+    tags=["normalisation", "cleaning"],
+)
 def _trim_whitespace_address_and_postcode() -> str:
     sql = r"""
     SELECT
@@ -28,7 +32,11 @@ def _trim_whitespace_address_and_postcode() -> str:
     return sql
 
 
-@pipeline_stage(name="canonicalise_postcode")
+@pipeline_stage(
+    name="canonicalise_postcode",
+    description="Standardise UK postcodes by ensuring single space between outward and inward codes",
+    tags=["normalisation", "cleaning"],
+)
 def _canonicalise_postcode() -> str:
     """
     Ensures that any postcode matching the UK format has a single space
@@ -48,7 +56,11 @@ def _canonicalise_postcode() -> str:
     return sql
 
 
-@pipeline_stage(name="upper_case_address_and_postcode")
+@pipeline_stage(
+    name="upper_case_address_and_postcode",
+    description="Convert address and postcode fields to uppercase for consistent formatting",
+    tags=["normalisation", "formatting"],
+)
 def _upper_case_address_and_postcode() -> str:
     sql = r"""
     SELECT
@@ -60,7 +72,11 @@ def _upper_case_address_and_postcode() -> str:
     return sql
 
 
-@pipeline_stage(name="clean_address_string_first_pass")
+@pipeline_stage(
+    name="clean_address_string_first_pass",
+    description="Apply initial address cleaning operations: remove punctuation, standardise separators, and normalise formatting",
+    tags=["cleaning", "normalisation"],
+)
 def _clean_address_string_first_pass() -> str:
     fn_call = construct_nested_call(
         "address_concat",
@@ -86,7 +102,11 @@ def _clean_address_string_first_pass() -> str:
     return sql
 
 
-@pipeline_stage(name="remove_duplicate_end_tokens")
+@pipeline_stage(
+    name="remove_duplicate_end_tokens",
+    description="Remove duplicated tokens at the end of addresses (e.g. 'HIGH STREET ST ALBANS ST ALBANS' -> 'HIGH STREET ST ALBANS')",
+    tags=["cleaning"],
+)
 def _remove_duplicate_end_tokens() -> str:
     """
     Removes duplicated tokens at the end of the address.
@@ -114,7 +134,11 @@ def _remove_duplicate_end_tokens() -> str:
     return sql
 
 
-@pipeline_stage(name="derive_original_address_concat")
+@pipeline_stage(
+    name="derive_original_address_concat",
+    description="Create a backup copy of the cleaned address before further processing",
+    tags=["data_preparation", "cleaning"],
+)
 def _derive_original_address_concat() -> str:
     sql = r"""
     SELECT
@@ -125,7 +149,11 @@ def _derive_original_address_concat() -> str:
     return sql
 
 
-@pipeline_stage(name="clean_address_string_second_pass")
+@pipeline_stage(
+    name="clean_address_string_second_pass",
+    description="Apply final cleaning operations to address without numbers: remove extra spaces and trim",
+    tags=["cleaning"],
+)
 def _clean_address_string_second_pass() -> str:
     fn_call = construct_nested_call(
         "address_without_numbers",

--- a/uk_address_matcher/cleaning/steps/term_frequencies.py
+++ b/uk_address_matcher/cleaning/steps/term_frequencies.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import importlib.resources as pkg_resources
 
-from uk_address_matcher.sql_pipeline.steps import CTEStep, Stage
+from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
 
 
-def _add_term_frequencies_to_address_tokens() -> Stage:
+@pipeline_stage(
+    name="add_term_frequencies_to_address_tokens",
+    description="Compute token-level relative frequencies and attach them to each record",
+    tags="term_frequency_analysis",
+)
+def _add_term_frequencies_to_address_tokens():
     """Compute token-level relative frequencies and attach them to each record."""
 
     base_sql = """
@@ -73,12 +78,15 @@ def _add_term_frequencies_to_address_tokens() -> Stage:
         CTEStep("final", final_sql),
     ]
 
-    return Stage(
-        name="add_term_frequencies_to_address_tokens", steps=steps, output="final"
-    )
+    return steps
 
 
-def _add_term_frequencies_to_address_tokens_using_registered_df() -> Stage:
+@pipeline_stage(
+    name="add_term_frequencies_to_address_tokens_using_registered_df",
+    description="Attach precomputed token frequencies from registered DataFrame rel_tok_freq",
+    tags="term_frequency_analysis",
+)
+def _add_term_frequencies_to_address_tokens_using_registered_df():
     """Attach precomputed token frequencies registered as rel_tok_freq."""
 
     base_sql = """
@@ -133,14 +141,15 @@ def _add_term_frequencies_to_address_tokens_using_registered_df() -> Stage:
         CTEStep("final", final_sql),
     ]
 
-    return Stage(
-        name="add_term_frequencies_to_address_tokens_using_registered_df",
-        steps=steps,
-        output="final",
-    )
+    return steps
 
 
-def _move_common_end_tokens_to_field() -> Stage:
+@pipeline_stage(
+    name="move_common_end_tokens_to_field",
+    description="Move frequently occurring trailing tokens (e.g. counties) into a dedicated field and remove from token frequency array",
+    tags="term_frequency_analysis",
+)
+def _move_common_end_tokens_to_field():
     """
     Move frequently occurring trailing tokens (e.g. counties) into a dedicated field and
     remove them from the token frequency array so missing endings aren't over-penalised.
@@ -200,14 +209,15 @@ def _move_common_end_tokens_to_field() -> Stage:
         CTEStep("final", final_sql),
     ]
 
-    return Stage(
-        name="move_common_end_tokens_to_field",
-        steps=steps,
-        output="final",
-    )
+    return steps
 
 
-def _first_unusual_token() -> Stage:
+@pipeline_stage(
+    name="first_unusual_token",
+    description="Attach the first token below the frequency threshold (0.001) if present",
+    tags="term_frequency_analysis",
+)
+def _first_unusual_token():
     """Attach the first token below the frequency threshold (0.001) if present."""
 
     first_token_expr = (
@@ -220,11 +230,15 @@ def _first_unusual_token() -> Stage:
         *
     FROM {{input}}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="first_unusual_token", steps=[step])
+    return sql
 
 
-def _use_first_unusual_token_if_no_numeric_token() -> Stage:
+@pipeline_stage(
+    name="use_first_unusual_token_if_no_numeric_token",
+    description="Fallback to the unusual token when numeric_token_1 is missing",
+    tags="term_frequency_analysis",
+)
+def _use_first_unusual_token_if_no_numeric_token():
     """Fallback to the unusual token when numeric_token_1 is missing."""
 
     sql = """
@@ -244,14 +258,15 @@ def _use_first_unusual_token_if_no_numeric_token() -> Stage:
         END AS token_rel_freq_arr
     FROM {input}
     """
-    step = CTEStep("1", sql)
-    return Stage(
-        name="use_first_unusual_token_if_no_numeric_token",
-        steps=[step],
-    )
+    return sql
 
 
-def _separate_unusual_tokens() -> Stage:
+@pipeline_stage(
+    name="separate_unusual_tokens",
+    description="Split token list into frequency bands for matching heuristics",
+    tags="term_frequency_analysis",
+)
+def _separate_unusual_tokens():
     """Split token list into frequency bands for matching heuristics."""
 
     sql = """
@@ -289,11 +304,15 @@ def _separate_unusual_tokens() -> Stage:
         ) AS extremely_unusual_tokens_arr
     FROM {input}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="separate_unusual_tokens", steps=[step])
+    return sql
 
 
-def _generalised_token_aliases() -> Stage:
+@pipeline_stage(
+    name="generalised_token_aliases",
+    description="Apply token aliasing/normalisation over distinguishing tokens",
+    tags="token_transformation",
+)
+def _generalised_token_aliases():
     """Apply token aliasing/normalisation over distinguishing tokens."""
 
     GENERALISED_TOKEN_ALIASES_CASE_STATEMENT = """
@@ -315,11 +334,15 @@ def _generalised_token_aliases() -> Stage:
         ) AS distinguishing_adj_token_aliases
     FROM {{input}}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="generalised_token_aliases", steps=[step])
+    return sql
 
 
-def _final_column_order() -> Stage:
+@pipeline_stage(
+    name="final_column_order",
+    description="Reorder and aggregate columns to match the legacy final layout",
+    tags="data_preparation",
+)
+def _final_column_order():
     """Reorder and aggregate columns to match the legacy final layout."""
 
     sql = """
@@ -342,11 +365,15 @@ def _final_column_order() -> Stage:
         )
     FROM {input}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="final_column_order", steps=[step])
+    return sql
 
 
-def get_token_frequeny_table() -> Stage:
+@pipeline_stage(
+    name="get_token_frequeny_table",
+    description="Build a token frequency table from numeric and non-numeric tokens",
+    tags="term_frequency_analysis",
+)
+def get_token_frequeny_table():
     """Build a token frequency table from numeric and non-numeric tokens."""
 
     sql = """
@@ -388,4 +415,4 @@ def get_token_frequeny_table() -> Stage:
         CTEStep("final", sql),
     ]
 
-    return Stage(name="get_token_frequeny_table", steps=steps, output="final")
+    return steps

--- a/uk_address_matcher/cleaning/steps/token_parsing.py
+++ b/uk_address_matcher/cleaning/steps/token_parsing.py
@@ -5,12 +5,15 @@ from uk_address_matcher.cleaning.steps.regexes import (
     remove_multiple_spaces,
     trim,
 )
-from uk_address_matcher.sql_pipeline.steps import CTEStep, Stage
+from uk_address_matcher.sql_pipeline.steps import CTEStep, Stage, pipeline_stage
 
 
-def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records() -> (
-    Stage
-):
+@pipeline_stage(
+    name="separate_distinguishing_start_tokens_from_with_respect_to_adjacent_recrods",
+    description="Identify common suffixes between addresses and separate them into unique and common token parts",
+    tags=["token_analysis", "address_comparison"],
+)
+def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records():
     """
     Identifies common suffixes between addresses and separates them into unique and common parts.
     This function analyzes each address in relation to its neighbors (previous and next addresses
@@ -109,14 +112,15 @@ def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records(
         CTEStep("final", final_sql),
     ]
 
-    return Stage(
-        name="separate_distinguishing_start_tokens_from_with_respect_to_adjacent_recrods",
-        steps=steps,
-        output="final",
-    )
+    return steps
 
 
-def _parse_out_flat_position_and_letter() -> Stage:
+@pipeline_stage(
+    name="parse_out_flat_position_and_letter",
+    description="Extract flat positions and letters from address strings into separate columns",
+    tags=["token_extraction", "flat_parsing"],
+)
+def _parse_out_flat_position_and_letter():
     """
     Extracts flat positions and letters from address strings into separate columns.
 
@@ -167,10 +171,15 @@ def _parse_out_flat_position_and_letter() -> Stage:
         CTEStep("final", final_sql),
     ]
 
-    return Stage(name="parse_out_flat_position_and_letter", steps=steps, output="final")
+    return steps
 
 
-def _parse_out_numbers() -> Stage:
+@pipeline_stage(
+    name="parse_out_numbers",
+    description="Extract and process numeric tokens from addresses, handling ranges and alphanumeric patterns",
+    tags="token_extraction",
+)
+def _parse_out_numbers():
     """
     Extracts and processes numeric tokens from address strings, ensuring the max length
     of the number+letter is 6 with no more than 1 letter which can be at the start or end.
@@ -205,11 +214,15 @@ def _parse_out_numbers() -> Stage:
         END AS numeric_tokens
     FROM {{input}}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="parse_out_numbers", steps=[step])
+    return sql
 
 
-def _clean_address_string_second_pass() -> Stage:
+@pipeline_stage(
+    name="clean_address_string_second_pass",
+    description="Apply final cleaning to address without numbers: remove multiple spaces and trim",
+    tags="cleaning",
+)
+def _clean_address_string_second_pass():
     fn_call = construct_nested_call(
         "address_without_numbers",
         [remove_multiple_spaces, trim],
@@ -220,11 +233,15 @@ def _clean_address_string_second_pass() -> Stage:
         {fn_call} as address_without_numbers
     from {{input}}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="clean_address_string_second_pass", steps=[step])
+    return sql
 
 
-def _split_numeric_tokens_to_cols() -> Stage:
+@pipeline_stage(
+    name="split_numeric_tokens_to_cols",
+    description="Split numeric tokens array into separate columns (numeric_token_1, numeric_token_2, numeric_token_3)",
+    tags="token_transformation",
+)
+def _split_numeric_tokens_to_cols():
     sql = """
     SELECT
         * EXCLUDE (numeric_tokens),
@@ -233,11 +250,15 @@ def _split_numeric_tokens_to_cols() -> Stage:
         regexp_extract_all(array_to_string(numeric_tokens, ' '), '\\d+')[3] as numeric_token_3
     FROM {input}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="split_numeric_tokens_to_cols", steps=[step])
+    return sql
 
 
-def _tokenise_address_without_numbers() -> Stage:
+@pipeline_stage(
+    name="tokenise_address_without_numbers",
+    description="Split the address_without_numbers field into an array of tokens",
+    tags="tokenisation",
+)
+def _tokenise_address_without_numbers():
     sql = """
     select
         * exclude (address_without_numbers),
@@ -245,8 +266,7 @@ def _tokenise_address_without_numbers() -> Stage:
             AS address_without_numbers_tokenised
     from {input}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="tokenise_address_without_numbers", steps=[step])
+    return sql
 
 
 GENERALISED_TOKEN_ALIASES_CASE_STATEMENT = """
@@ -260,7 +280,12 @@ GENERALISED_TOKEN_ALIASES_CASE_STATEMENT = """
 """
 
 
-def _generalised_token_aliases() -> Stage:
+@pipeline_stage(
+    name="generalised_token_aliases",
+    description="Map specific tokens to more general categories for better matching heuristics",
+    tags="token_transformation",
+)
+def _generalised_token_aliases():
     """
     Maps specific tokens to more general categories to create a generalised representation
     of the unique tokens in an address.
@@ -304,8 +329,7 @@ def _generalised_token_aliases() -> Stage:
         ) AS distinguishing_adj_token_aliases
     FROM {{input}}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="generalised_token_aliases", steps=[step])
+    return sql
 
 
 def _get_token_frequeny_table() -> Stage:

--- a/uk_address_matcher/cleaning/steps/tokenisation.py
+++ b/uk_address_matcher/cleaning/steps/tokenisation.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from uk_address_matcher.sql_pipeline.steps import CTEStep, Stage
+from uk_address_matcher.sql_pipeline.steps import pipeline_stage
 
 
-def _split_numeric_tokens_to_cols() -> Stage:
+@pipeline_stage(
+    name="split_numeric_tokens_to_cols",
+    description="Split numeric tokens array into separate columns (numeric_token_1, numeric_token_2, numeric_token_3)",
+    tags="tokenisation",
+)
+def _split_numeric_tokens_to_cols():
     sql = """
     SELECT
         * EXCLUDE (numeric_tokens),
@@ -12,11 +17,15 @@ def _split_numeric_tokens_to_cols() -> Stage:
         regexp_extract_all(array_to_string(numeric_tokens, ' '), '\\d+')[3] as numeric_token_3
     FROM {input}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="split_numeric_tokens_to_cols", steps=[step])
+    return sql
 
 
-def _tokenise_address_without_numbers() -> Stage:
+@pipeline_stage(
+    name="tokenise_address_without_numbers",
+    description="Split the address_without_numbers field into an array of tokens",
+    tags="tokenisation",
+)
+def _tokenise_address_without_numbers():
     sql = """
     select
         * exclude (address_without_numbers),
@@ -24,5 +33,4 @@ def _tokenise_address_without_numbers() -> Stage:
             AS address_without_numbers_tokenised
     from {input}
     """
-    step = CTEStep("1", sql)
-    return Stage(name="tokenise_address_without_numbers", steps=[step])
+    return sql

--- a/uk_address_matcher/sql_pipeline/runner.py
+++ b/uk_address_matcher/sql_pipeline/runner.py
@@ -2,8 +2,22 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+import duckdb
 
 from uk_address_matcher.sql_pipeline.helpers import (
     _duckdb_table_exists,
@@ -14,13 +28,54 @@ from uk_address_matcher.sql_pipeline.helpers import (
 )
 from uk_address_matcher.sql_pipeline.steps import Stage
 
-if TYPE_CHECKING:
-    import duckdb
-
-
 logger = logging.getLogger("uk_address_matcher")
 
 StageFactory = Callable[[], Stage]
+StageLike = Union[Stage, StageFactory]
+
+
+class InputBinding(NamedTuple):
+    placeholder: str
+    relation: duckdb.DuckDBPyRelation
+
+    def normalised_placeholder(self) -> str:
+        name = _slug(self.placeholder)
+        if not name:
+            raise ValueError(
+                "InputBinding placeholder must be a non-empty, slug-compatible string"
+            )
+        if name[0].isdigit():
+            name = f"t_{name}"
+        return name
+
+    def register(
+        self,
+        con: duckdb.DuckDBPyConnection,
+        registered_aliases: set[str],
+    ) -> str:
+        alias_candidate = getattr(self.relation, "alias", None) or self.placeholder
+        alias_candidate = _slug(alias_candidate) or self.normalised_placeholder()
+        if alias_candidate[0].isdigit():
+            alias_candidate = f"t_{alias_candidate}"
+
+        alias = alias_candidate
+        while alias in registered_aliases:
+            alias = f"{alias_candidate}_{_uid(4)}"
+
+        if not _duckdb_table_exists(con, alias):
+            con.register(alias, self.relation)
+
+        registered_aliases.add(alias)
+        return alias
+
+    def __str__(self) -> str:
+        # TODO(ThomasHepworth): improve representation at some point
+        return (
+            f"InputBinding(placeholder={self.placeholder!r},\n"
+            f"  relation=\n{self.relation.limit(5)})"
+        )
+
+    __repr__ = __str__
 
 
 class CTEPipeline:
@@ -64,21 +119,24 @@ class CTEPipeline:
 
 
 def render_step_to_ctes(
-    step: Stage, step_idx: int, prev_alias: str
+    step: Stage,
+    step_idx: int,
+    prev_alias: str,
+    alias_map: Dict[str, str],
 ) -> Tuple[List[Tuple[str, str]], str]:
     """Instantiate templated fragments into concrete, namespaced CTEs."""
+
     ctes: List[Tuple[str, str]] = []
     frag_aliases: Dict[str, str] = {}
-    mapping = {"input": prev_alias}
+    base_mapping = {"input": prev_alias, **alias_map}
 
     for frag in step.steps:
         alias = f"s{step_idx}_{_slug(step.name)}__{_slug(frag.name)}"
+        replacements = {**base_mapping, **frag_aliases}
 
-        # apply placeholders
-        sql = frag.sql.replace("{input}", mapping["input"])
-        # then any prior fragment references
-        for k, v in frag_aliases.items():
-            sql = sql.replace(f"{{{k}}}", v)
+        sql = frag.sql
+        for key, target in replacements.items():
+            sql = sql.replace(f"{{{key}}}", target)
 
         ctes.append((sql, alias))
         frag_aliases[frag.name] = alias
@@ -136,17 +194,28 @@ class DuckDBPipeline(CTEPipeline):
     def __init__(
         self,
         con: duckdb.DuckDBPyConnection,
-        input_rel: duckdb.DuckDBPyRelation,
+        input_rel: Union[
+            duckdb.DuckDBPyRelation,
+            Sequence[InputBinding],
+        ],
         *,
         name: Optional[str] = None,
         description: str = "",
     ):
         super().__init__()
         self.con = con
-        self._src_name = input_rel.alias or f"src_{_uid()}"
-        if not _duckdb_table_exists(self.con, self._src_name):
-            self.con.register(self._src_name, input_rel)
 
+        bindings = self._normalise_inputs(input_rel)
+        if not bindings:
+            raise ValueError("input_rel must contain at least one DuckDB relation.")
+
+        self._registered_relation_aliases: set[str] = set()
+        self._input_alias_map: Dict[str, str] = {}
+        self._input_alias_map_view: Mapping[str, str]
+
+        self._bootstrap_inputs(bindings)
+
+        self._src_name = self._root_alias
         seed = f"seed_{_uid()}"
         self.enqueue_sql(f"SELECT * FROM {self._src_name}", seed)
         self._current_output_alias = seed
@@ -158,12 +227,91 @@ class DuckDBPipeline(CTEPipeline):
         # Keep an ordered list of stages as they are added (excluding seed)
         self._stages: List[Stage] = []
 
-    def show_pipeline_plan(self) -> str:
+    def _normalise_inputs(
+        self,
+        input_rel: Union[
+            duckdb.DuckDBPyRelation,
+            Sequence[InputBinding],
+        ],
+    ) -> List[InputBinding]:
+        if isinstance(input_rel, duckdb.DuckDBPyRelation):
+            return [InputBinding("root", input_rel)]
+        if isinstance(input_rel, Sequence) and not isinstance(input_rel, (str, bytes)):
+            if not input_rel:
+                raise ValueError("input_rel sequence must not be empty.")
+            bindings: List[InputBinding] = []
+            for idx, item in enumerate(input_rel):
+                if not isinstance(item, InputBinding):
+                    raise TypeError(
+                        "Sequences of inputs must contain InputBinding instances; "
+                        f"got {type(item)!r} at index {idx}."
+                    )
+                bindings.append(item)
+            if len(bindings) == 1:
+                if not bindings[0].placeholder:
+                    raise ValueError(
+                        "Single InputBinding must define a placeholder or provide a standalone relation."
+                    )
+                return bindings
+
+            for binding in bindings:
+                if not binding.placeholder:
+                    raise ValueError(
+                        "All InputBinding entries must have an explicit placeholder when providing multiple inputs."
+                    )
+            return bindings
+        else:
+            raise TypeError(
+                "input_rel must be a DuckDBPyRelation or a sequence of InputBinding entries."
+            )
+
+    def _bootstrap_inputs(self, bindings: Sequence[InputBinding]) -> None:
+        alias_map: Dict[str, str] = {}
+        seen_placeholders: set[str] = set()
+
+        for binding in bindings:
+            key = binding.normalised_placeholder()
+            if key == "input":
+                raise ValueError(
+                    "The placeholder name 'input' is reserved; please choose a different alias."
+                )
+            if key in seen_placeholders:
+                raise ValueError(f"Duplicate input placeholder detected: {key}")
+            seen_placeholders.add(key)
+
+            alias = binding.register(self.con, self._registered_relation_aliases)
+            alias_map[key] = alias
+
+        first_key = next(iter(alias_map))
+        root_alias = alias_map[first_key]
+
+        alias_map.setdefault("root", root_alias)
+
+        self._input_bindings: Tuple[InputBinding, ...] = tuple(bindings)
+        self._input_alias_map = alias_map
+        self._root_alias = root_alias
+        self._input_alias_map_view = MappingProxyType(self._input_alias_map)
+
+    @property
+    def input_alias_map(self) -> Mapping[str, str]:
+        return self._input_alias_map_view
+
+    @property
+    def root_alias(self) -> str:
+        return self._root_alias
+
+    @property
+    def input_bindings(self) -> Tuple[InputBinding, ...]:
+        return self._input_bindings
+
+    def show_plan(self) -> None:
         """Return a human-friendly multi-line description of the pipeline.
 
         Format example:
-            My Pipeline
-            ==========
+            ┌──────────────────────────────┐
+            │ 🔧 Pipeline Plan (11 stages) │
+            │ My pipeline's name           │
+            └──────────────────────────────┘
 
             A description of the pipeline.
             -----------------------------
@@ -201,7 +349,6 @@ class DuckDBPipeline(CTEPipeline):
             lines.append("")
         if not self._stages:
             lines.append("(no stages added)")
-            return "\n".join(lines)
         for idx, stage in enumerate(self._stages, start=1):
             block = stage.format_plan_block()
             first_line, *rest = block.splitlines()
@@ -210,7 +357,8 @@ class DuckDBPipeline(CTEPipeline):
                 lines.append(f"    {rl}")
             if idx < len(self._stages):
                 lines.append("")
-        return _emit_debug("\n".join(lines))
+        plan_text = "\n".join(lines)
+        _emit_debug(plan_text)
 
     def add_step(self, step: Stage) -> None:
         # run any preludes / registers
@@ -223,7 +371,12 @@ class DuckDBPipeline(CTEPipeline):
 
         prev_alias = self.output_table_name
         step_idx = self._step_counter
-        ctes, out_alias = render_step_to_ctes(step, step_idx, prev_alias)
+        ctes, out_alias = render_step_to_ctes(
+            step,
+            step_idx,
+            prev_alias,
+            self._input_alias_map,
+        )
         for sql, alias in ctes:
             self.enqueue_sql(sql, alias)
         self._current_output_alias = out_alias
@@ -309,8 +462,47 @@ class DuckDBPipeline(CTEPipeline):
             return self.con.table(work_items[-1][1])
         return None
 
-    def run_with_options(self, options: RunOptions):
-        """Preferred entry: run pipeline using the given RunOptions."""
+    def run(
+        self,
+        options: Optional[RunOptions] = None,
+        **legacy_kwargs,
+    ) -> duckdb.DuckDBPyRelation:
+        """Run the pipeline using the provided options (or defaults)."""
+
+        allowed_legacy_keys = {
+            "pretty_print_sql",
+            "debug_mode",
+            "debug_show_sql",
+            "debug_max_rows",
+            "debug_incremental",
+        }
+
+        if legacy_kwargs:
+            invalid = set(legacy_kwargs) - allowed_legacy_keys
+            if invalid:
+                raise TypeError(
+                    "Unsupported keyword arguments for DuckDBPipeline.run: "
+                    + ", ".join(sorted(invalid))
+                )
+            if options is not None:
+                raise TypeError(
+                    "Cannot provide both RunOptions instance and legacy keyword overrides."
+                )
+            base = self._default_run_options
+            overrides = {
+                key: legacy_kwargs.get(key, getattr(base, key))
+                for key in allowed_legacy_keys
+            }
+            options = replace(base, **overrides)
+
+        if options is None:
+            options = self._default_run_options
+        elif not isinstance(options, RunOptions):
+            raise TypeError(
+                "options must be a RunOptions instance when provided; "
+                f"got {type(options)!r}."
+            )
+
         # Incremental/materialising path
         if options.debug_incremental:
             return self.debug(
@@ -349,44 +541,58 @@ class DuckDBPipeline(CTEPipeline):
                 _emit_debug("\n===============================\n")
         return self.con.sql(final_sql)
 
-    def run(
-        self,
-        *,
-        pretty_print_sql: Optional[bool] = None,
-        debug_mode: Optional[bool] = None,
-        debug_show_sql: Optional[bool] = None,
-        debug_max_rows: Optional[int] = None,
-        debug_incremental: Optional[bool] = None,
-    ):
-        """
-        Backwards-compatible wrapper that builds RunOptions from args merged
-        with environment-derived defaults. Prefer run_with_options.
-        """
-        opts = RunOptions(
-            pretty_print_sql=(
-                pretty_print_sql
-                if pretty_print_sql is not None
-                else self._default_run_options.pretty_print_sql
-            ),
-            debug_mode=(
-                debug_mode
-                if debug_mode is not None
-                else self._default_run_options.debug_mode
-            ),
-            debug_show_sql=(
-                debug_show_sql
-                if debug_show_sql is not None
-                else self._default_run_options.debug_show_sql
-            ),
-            debug_max_rows=(
-                debug_max_rows
-                if debug_max_rows is not None
-                else self._default_run_options.debug_max_rows
-            ),
-            debug_incremental=(
-                debug_incremental
-                if debug_incremental is not None
-                else self._default_run_options.debug_incremental
-            ),
+
+def _ensure_stage(stage_like: StageLike) -> Stage:
+    """Normalise a stage reference into a concrete `Stage` instance."""
+    if isinstance(stage_like, Stage):
+        return stage_like
+
+    if callable(stage_like):
+        candidate = stage_like()
+        if isinstance(candidate, Stage):
+            return candidate
+        raise TypeError(
+            "Stage factory callable must return a `Stage` instance; "
+            f"got {type(candidate)!r}."
         )
-        return self.run_with_options(opts)
+
+    raise TypeError(
+        "Stages must be provided as `Stage` instances or zero-argument factories that "
+        "return a `Stage`."
+    )
+
+
+def create_sql_pipeline(
+    con: duckdb.DuckDBPyConnection,
+    input_rel: Union[duckdb.DuckDBPyRelation, Sequence[InputBinding]],
+    stage_specs: Iterable[StageLike],
+    *,
+    pipeline_name: str | None = None,
+    pipeline_description: str | None = None,
+) -> DuckDBPipeline:
+    """Construct a `DuckDBPipeline` from the provided stage specifications.
+
+    Parameters
+    ----------
+    con:
+        Active DuckDB connection used for executing SQL.
+    input_rel:
+        Either a single `DuckDBPyRelation` (for simple pipelines) or a sequence
+        of `InputBinding` objects when multiple named inputs are required.
+    stage_specs:
+        Iterable of stages or stage factories to add to the pipeline in order.
+    pipeline_name / pipeline_description:
+        Optional metadata used when rendering plans or debug output.
+    """
+
+    pipeline = DuckDBPipeline(
+        con,
+        input_rel,
+        name=pipeline_name,
+        description=pipeline_description or "",
+    )
+
+    for stage_like in stage_specs:
+        pipeline.add_step(_ensure_stage(stage_like))
+
+    return pipeline

--- a/uk_address_matcher/sql_pipeline/runner.py
+++ b/uk_address_matcher/sql_pipeline/runner.py
@@ -210,7 +210,7 @@ class DuckDBPipeline(CTEPipeline):
                 lines.append(f"    {rl}")
             if idx < len(self._stages):
                 lines.append("")
-        return "\n".join(lines)
+        return _emit_debug("\n".join(lines))
 
     def add_step(self, step: Stage) -> None:
         # run any preludes / registers


### PR DESCRIPTION
## PR Overview
Formally implements the logic set out in https://github.com/moj-analytical-services/uk_address_matcher/pull/97. This PR is focussed around adding decorator tags and some initial metadata to each SQL returning function. This gives us a framework from which we can expand our debugging and printouts in future releases.

It should in theory make debugging and understanding pipelines far simpler, whilst also making the registration of SQL functions significantly simpler.

## Code example

```py
import duckdb

from uk_address_matcher.cleaning.steps.normalisation import (
    _canonicalise_postcode,
    _clean_address_string_first_pass,
    _derive_original_address_concat,
    _trim_whitespace_address_and_postcode,
    _upper_case_address_and_postcode,
)
from uk_address_matcher.sql_pipeline.runner import DuckDBPipeline

print("=== SQL Pipeline Queueing Demo ===\n")

# Create sample input data
con = duckdb.connect()
con.execute(
    """
    CREATE OR REPLACE TEMP TABLE temp_inputs AS
    SELECT * FROM (VALUES
        ('1', ' 10 Downing St ', 'SW1A2AA'),
        ('2', ' Flat B, 12-14 Queen''s Rd', 'E16AN'),
        ('3', '  5 Baker Street  ', ' NW1 6XE'),
        ('4', 'Apt 3, 221b Baker St', 'NW16XE ')
    ) AS t(id, address_concat, postcode)
"""
)

QUEUE = [
    _trim_whitespace_address_and_postcode,
    _upper_case_address_and_postcode,
    _canonicalise_postcode,
    _clean_address_string_first_pass,
    _derive_original_address_concat,
]
pipeline = DuckDBPipeline(
    con,
    con.table("temp_inputs"),
    name="Demo cleaning pipeline",
    description="A demo of the SQL pipeline queueing system",
)
for stage_fn in QUEUE:
    pipeline.add_step(stage_fn())


pipeline_plan = pipeline.show_plan()
print(pipeline_plan)
```