### PR TITLE
feat: refine how our pipeline plans are rendered

### DIFF
--- a/tests/sql_pipeline/test_runner_show_plan.py
+++ b/tests/sql_pipeline/test_runner_show_plan.py
@@ -69,8 +69,8 @@ def test_show_plan_renders_stage_metadata(monkeypatch):
     assert "stage_one [alpha]" in output
     assert "↳ First stage" in output
     assert "stage_two [beta, gamma]" in output
-    assert "depends on: stage_one" in output
-    assert "(checkpoint)" in output
+    assert "depends on:" in output and "• stage_one" in output
+    assert "checkpoint" in output
 
 
 def test_show_plan_handles_empty_pipeline(monkeypatch):

--- a/uk_address_matcher/sql_pipeline/steps.py
+++ b/uk_address_matcher/sql_pipeline/steps.py
@@ -115,10 +115,7 @@ class Stage:
         if len(self.steps) <= 1:
             return []
 
-        lines = ["│ CTE Steps:"]
-        for step in self.steps:
-            lines.append(f"│  • {step.name}")
-        return lines
+        return [step.name for step in self.steps]
 
     def format_plan_block(self, max_name: int = 60, dep_width: int = 60) -> str:
         """Render a formatted multi-line summary block for this stage.
@@ -126,11 +123,14 @@ class Stage:
         This is used by the pipeline plan view to present each queued SQL stage
         in a human-friendly way.
 
-        For example, a `Stage` titled "tokenise_addresses" might render as:
-        tokenise_addresses [cleaning]
-        ↳ Split address into tokens
-        │ depends on: load_raw
-        │ (checkpoint)
+        For example, a `Stage` titled "build_trie" might render as:
+        1. build_trie [trie]
+            ↳ Test building a trie
+            ├─ depends on:
+            │  • test1
+            └─ CTEs:
+                • distinct_postcodes_fuzzy
+                • filtered_canonical
         """
         meta = self.stage_metadata or StageMeta()
         display_name = (
@@ -141,19 +141,36 @@ class Stage:
         lines: List[str] = []
         tags_part = f" [{', '.join(meta.tags)}]" if meta.tags else ""
         lines.append(f"{display_name}{tags_part}")
+
+        entries: List[Tuple[str, List[str]]] = []
         if meta.description:
             lines.append(f"↳ {meta.description}")
-        # (input/output columns intentionally omitted for now)
+
         if meta.depends_on:
-            deps = ", ".join(meta.depends_on)
-            if len(deps) > dep_width:
-                deps = deps[: dep_width - 3] + "..."
-            lines.append(f"│ depends on: {deps}")
+            deps_list = []
+            for dep in meta.depends_on:
+                deps_list.append(
+                    dep if len(dep) <= dep_width else dep[: dep_width - 3] + "..."
+                )
+            entries.append(("depends on", deps_list))
+
         step_summaries = self._format_cte_steps()
         if step_summaries:
-            lines.extend(step_summaries)
+            entries.append(("CTEs", step_summaries))
+
         if self.checkpoint:
-            lines.append("│ (checkpoint)")
+            entries.append(("checkpoint", ["enabled"]))
+
+        for idx, (label, values) in enumerate(entries):
+            is_last = idx == len(entries) - 1
+            branch = "└─" if is_last else "├─"
+            if values:
+                lines.append(f"{branch} {label}:")
+                continuation = "   " if is_last else "│  "
+                for item in values:
+                    lines.append(f"{continuation}• {item}")
+            else:
+                lines.append(f"{branch} {label}")
         return "\n".join(lines)
 
 


### PR DESCRIPTION
## PR Overview

Simple PR that refines how our pipelines are rendered. You can see the old formatting of pipeline plans in https://github.com/moj-analytical-services/uk_address_matcher/pull/97.

The new format will produce something that looks like so:
```
┌─────────────────────────────┐
│ 🔧 Pipeline Plan (2 stages) │
│ Multi input join            │
└─────────────────────────────┘

Demonstrate aliased sources inside a pipeline
---------------------------------------------

 1. build_trie [trie]
    ↳ Test building a trie
    ├─ depends on:
    │  • test1
    │  • test2
    └─ CTEs:
       • distinct_postcodes_fuzzy
       • filtered_canonical
       • build_trie_from_filtered_canonical

 2. search_trie [trie]
    ↳ Lookup fuzzy tokens against the canonical trie
    └─ depends on:
       • _build_trie_from_canonical_addresses
```

See dummy code from pull request 97 if you want to run it locally.