### PR TITLE
feat(matching): add phase 1 exact + trie resolution

### DIFF
--- a/tests/test_post_linkage_metrics.py
+++ b/tests/test_post_linkage_metrics.py
@@ -1,0 +1,81 @@
+import duckdb
+import pytest
+
+from uk_address_matcher.post_linkage.analyse_results import (
+    calculate_exact_match_metrics,
+)
+
+
+def test_calculate_exact_match_metrics_basic_counts():
+    con = duckdb.connect(database=":memory:")
+    relation = con.sql(
+        """
+        SELECT *
+        FROM (VALUES
+            ('method_a'),
+            ('method_b'),
+            ('method_b')
+        ) AS t(match_method)
+        """
+    )
+
+    result_df = calculate_exact_match_metrics(relation).df()
+
+    assert set(result_df.columns) == {
+        "match_method",
+        "match_count",
+        "match_percentage",
+    }
+    assert list(result_df["match_method"]) == ["method_b", "method_a"]
+    counts = dict(zip(result_df["match_method"], result_df["match_count"]))
+    assert counts == {"method_b": 2, "method_a": 1}
+
+    percentages = dict(zip(result_df["match_method"], result_df["match_percentage"]))
+    assert pytest.approx(percentages["method_b"], rel=1e-6) == 66.67
+    assert pytest.approx(percentages["method_a"], rel=1e-6) == 33.33
+
+
+def test_calculate_exact_match_metrics_drops_null_methods():
+    con = duckdb.connect(database=":memory:")
+    relation = con.sql(
+        """
+        SELECT *
+        FROM (VALUES
+            ('method_a'),
+            (NULL)
+        ) AS t(match_method)
+        """
+    )
+
+    result_df = calculate_exact_match_metrics(relation).df()
+
+    assert result_df["match_method"].isnull().sum() == 0
+    assert dict(zip(result_df["match_method"], result_df["match_count"])) == {
+        "method_a": 1
+    }
+
+
+def test_calculate_exact_match_metrics_supports_ascending_order():
+    con = duckdb.connect(database=":memory:")
+    relation = con.sql(
+        """
+        SELECT *
+        FROM (VALUES
+            ('method_a'),
+            ('method_b'),
+            ('method_b')
+        ) AS t(match_method)
+        """
+    )
+
+    result_df = calculate_exact_match_metrics(relation, order="ascending").df()
+
+    assert list(result_df["match_method"]) == ["method_a", "method_b"]
+
+
+def test_calculate_exact_match_metrics_requires_column():
+    con = duckdb.connect(database=":memory:")
+    relation = con.sql("SELECT 1 AS different_column")
+
+    with pytest.raises(ValueError):
+        calculate_exact_match_metrics(relation)

--- a/uk_address_matcher/__init__.py
+++ b/uk_address_matcher/__init__.py
@@ -1,6 +1,4 @@
-__version__ = "1.0.0.dev20"
-
-import logging
+__version__ = "1.0.0.dev21"
 
 from uk_address_matcher.cleaning.pipelines import (
     clean_data_on_the_fly,
@@ -8,6 +6,7 @@ from uk_address_matcher.cleaning.pipelines import (
     get_address_token_frequencies_from_address_table,
     get_numeric_term_frequencies_from_address_table,
 )
+from uk_address_matcher.linking_model.exact_matching import run_deterministic_match_pass
 from uk_address_matcher.linking_model.splink_model import get_linker
 from uk_address_matcher.post_linkage.accuracy_from_labels import (
     evaluate_predictions_against_labels,
@@ -16,12 +15,11 @@ from uk_address_matcher.post_linkage.accuracy_from_labels import (
 from uk_address_matcher.post_linkage.analyse_results import (
     best_matches_summary,
     best_matches_with_distinguishability,
+    calculate_exact_match_metrics,
 )
 from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
     improve_predictions_using_distinguishing_tokens,
 )
-
-logging.getLogger("uk_address_matcher").addHandler(logging.NullHandler())
 
 __all__ = [
     "get_linker",
@@ -29,6 +27,8 @@ __all__ = [
     "clean_data_using_precomputed_rel_tok_freq",
     "get_numeric_term_frequencies_from_address_table",
     "get_address_token_frequencies_from_address_table",
+    "calculate_exact_match_metrics",
+    "run_deterministic_match_pass",
     "improve_predictions_using_distinguishing_tokens",
     "best_matches_with_distinguishability",
     "best_matches_summary",

--- a/uk_address_matcher/cleaning/steps/tokenisation.py
+++ b/uk_address_matcher/cleaning/steps/tokenisation.py
@@ -3,6 +3,22 @@ from __future__ import annotations
 from uk_address_matcher.sql_pipeline.steps import pipeline_stage
 
 
+# TODO(ThomasHepworth): Do we want this as a separate stage?
+@pipeline_stage(
+    name="create_tokenised_address_concat",
+    description="Combine our cleaned address into an array of tokens to be used for exact matching and token-level matching",
+    tags="tokenisation",
+)
+def _create_tokenised_address_concat():
+    sql = """
+    SELECT
+        *,
+       string_split(original_address_concat, ' ') AS address_tokens
+    FROM {input}
+    """
+    return sql
+
+
 @pipeline_stage(
     name="split_numeric_tokens_to_cols",
     description="Split numeric tokens array into separate columns (numeric_token_1, numeric_token_2, numeric_token_3)",

--- a/uk_address_matcher/linking_model/exact_matching/__init__.py
+++ b/uk_address_matcher/linking_model/exact_matching/__init__.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from uk_address_matcher.linking_model.exact_matching.exact_matching_model import (
+    _annotate_exact_matches,
+    _resolve_with_trie,
+)
+from uk_address_matcher.sql_pipeline.runner import InputBinding, create_sql_pipeline
+
+if TYPE_CHECKING:
+    import duckdb
+
+    from uk_address_matcher.sql_pipeline.runner import RunOptions
+
+
+def run_deterministic_match_pass(
+    con: duckdb.DuckDBPyConnection,
+    df_addresses_to_match: duckdb.DuckDBPyRelation,
+    df_addresses_to_search_within: duckdb.DuckDBPyRelation,
+    *,
+    run_options: Optional[RunOptions] = None,
+) -> duckdb.DuckDBPyRelation:
+    """
+    Run the exact matching pipeline stages to annotate fuzzy addresses with exact matches
+    from the canonical dataset, and then resolve remaining unmatched fuzzy addresses using
+    a trie-based approach.
+
+    Args:
+        con: DuckDB connection to use for running the pipeline.
+        df_fuzzy: Relation containing the fuzzy addresses to be matched.
+        df_canonical: Relation containing the canonical addresses to match against.
+        match_using_trie: Whether to run the trie resolution stage after exact matching.
+            Defaults to True. Trie matching will capture additional matches but may
+            also introduce some false positives and is more computationally intensive.
+
+    Returns:
+        Relation with fuzzy addresses annotated with exact matches and trie-resolved matches.
+    """
+
+    input_bindings = [
+        InputBinding("fuzzy_addresses", df_addresses_to_match),
+        InputBinding("canonical_addresses", df_addresses_to_search_within),
+    ]
+
+    two_phase_pipeline = create_sql_pipeline(
+        con,
+        input_bindings,
+        [_annotate_exact_matches, _resolve_with_trie],
+        pipeline_name="Exact + Trie",
+        pipeline_description="Exact matches followed by trie resolution",
+    )
+    if run_options is not None:
+        if run_options.debug_mode:
+            two_phase_pipeline.show_plan()
+    exact_match_results = two_phase_pipeline.run(options=run_options)
+    exact_match_results.create("fhrs_os_two_phase_results")
+
+    return exact_match_results
+
+
+__all__ = ["run_deterministic_match_pass"]

--- a/uk_address_matcher/linking_model/exact_matching/exact_matching_model.py
+++ b/uk_address_matcher/linking_model/exact_matching/exact_matching_model.py
@@ -1,0 +1,123 @@
+from typing import TYPE_CHECKING
+
+from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
+
+if TYPE_CHECKING:
+    pass
+
+
+@pipeline_stage(
+    name="annotate_exact_matches",
+    description=(
+        "Annotate fuzzy addresses with exact hash-join matches on "
+        "original_address_concat + postcode"
+    ),
+    tags=["phase_1", "exact_matching"],
+)
+def _annotate_exact_matches() -> list[CTEStep]:
+    annotated_sql = """
+        SELECT
+            f.*,
+            c.unique_id AS exact_match_canonical_id,
+            TRY_CAST(c.unique_id AS BIGINT) AS exact_match_canonical_id_bigint,
+            (c.unique_id IS NOT NULL) AS exact_match,
+            CASE
+                WHEN c.unique_id IS NOT NULL THEN 'exact'
+                ELSE 'unmatched'
+            END AS match_method,
+            (c.unique_id IS NOT NULL) AS has_match
+        FROM {input} AS f
+        LEFT JOIN {canonical_addresses} AS c
+          ON f.original_address_concat = c.original_address_concat
+         AND f.postcode = c.postcode
+    """
+    return annotated_sql
+
+
+@pipeline_stage(
+    name="resolve_with_trie",
+    description="Build tries for unmatched canonical addresses and resolve remaining fuzzy rows",
+    tags=["phase_1", "trie", "exact_matching"],
+    depends_on="annotate_exact_matches",
+)
+def _resolve_with_trie() -> list[CTEStep]:
+    unmatched_fuzzy_sql = """
+        SELECT
+            f.*
+        FROM {input} AS f
+        WHERE NOT f.exact_match
+    """
+
+    matched_canonical_ids_sql = """
+        SELECT DISTINCT exact_match_canonical_id AS canonical_unique_id
+        FROM {input}
+        WHERE exact_match_canonical_id IS NOT NULL
+    """
+
+    filtered_canonical_sql = """
+        SELECT
+            TRY_CAST(c.unique_id AS BIGINT) AS canonical_unique_id_bigint,
+            c.unique_id AS canonical_unique_id,
+            c.postcode,
+            LEFT(c.postcode, LENGTH(c.postcode) - 1) AS postcode_group,
+            c.address_tokens
+        FROM {canonical_addresses} AS c
+        WHERE TRY_CAST(c.unique_id AS BIGINT) IS NOT NULL
+          AND c.unique_id NOT IN (
+              SELECT canonical_unique_id FROM {canonical_ids_from_exact_matches}
+          )
+          AND c.postcode IN (
+              SELECT DISTINCT postcode
+              FROM {fuzzy_without_exact_matches}
+          )
+    """
+
+    tries_sql = """
+        SELECT
+            postcode_group,
+            build_suffix_trie(canonical_unique_id_bigint, address_tokens) AS trie
+        FROM {canonical_candidates_for_trie}
+        GROUP BY postcode_group
+    """
+
+    trie_matches_sql = """
+        SELECT
+            f.unique_id AS fuzzy_unique_id,
+            find_address(f.address_tokens, t.trie) AS trie_match_unique_id
+        FROM {fuzzy_without_exact_matches} AS f
+        JOIN {postcode_group_tries} AS t
+          ON LEFT(f.postcode, LENGTH(f.postcode) - 1) = t.postcode_group
+    """
+
+    combined_results_sql = """
+        SELECT
+            f.* EXCLUDE (match_method, has_match),
+            m.trie_match_unique_id AS trie_match_unique_id_bigint,
+            CAST(m.trie_match_unique_id AS VARCHAR) AS trie_match_unique_id,
+            COALESCE(
+                f.exact_match_canonical_id_bigint,
+                m.trie_match_unique_id
+            ) AS resolved_canonical_unique_id_bigint,
+            COALESCE(
+                f.exact_match_canonical_id,
+                CAST(m.trie_match_unique_id AS VARCHAR)
+            ) AS resolved_canonical_unique_id,
+            CASE
+                WHEN f.exact_match THEN 'exact'
+                WHEN m.trie_match_unique_id IS NOT NULL THEN 'trie_match'
+                ELSE 'unmatched'
+            END AS match_method,
+            (f.has_match OR m.trie_match_unique_id IS NOT NULL) AS has_match
+        FROM {input} AS f
+        LEFT JOIN {trie_match_candidates} AS m
+          ON f.unique_id = m.fuzzy_unique_id
+    """
+
+    return [
+        CTEStep("fuzzy_without_exact_matches", unmatched_fuzzy_sql),
+        CTEStep("canonical_ids_from_exact_matches", matched_canonical_ids_sql),
+        CTEStep("canonical_candidates_for_trie", filtered_canonical_sql),
+        CTEStep("postcode_group_tries", tries_sql),
+        CTEStep("trie_match_candidates", trie_matches_sql),
+        CTEStep("fuzzy_with_resolved_matches", combined_results_sql),
+    ]


### PR DESCRIPTION
Add two pipeline stages, orchestrated in `run_deterministic_match_pass`
- annotate_exact_matches: joins on original_address_concat + postcode to flag deterministic hits.
- resolve_with_trie: builds postcode-group tries for remaining unmatched records and resolves via token search.

Minor updates:
- Analyse match results using `calculate_exact_match_metrics`