### PR TITLE
Remove Splink UDFs and 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Removed automatic `splink_udfs` installation because the matcher only uses DuckDB built-ins and the test suite passes without the community extension.
-- Removed unnecessary Splink input rematerialisation of `address_without_numbers`, which could trigger large DuckDB temporary spill files before `predict()`.  Rough 2x speed boost when matching to full UK dataset.
+- Removed unnecessary Splink input rematerialisation of `address_without_numbers`, which could trigger large DuckDB temporary spill files before `predict()`.
 
-## [1.0.1] -
+## [1.1.1] - 2026-04-18
+
+### Added
+
+- New benchmarking datasets: Aberdeenshire council tax, Mid Sussex business rates, and Rhondda.
+- Excel loader support for DuckDB-backed benchmarking datasets.
+- No-whitespace matching logic in the exact match stage to catch addresses that differ only by spacing.
+- Flat handling improvements: retraction of redundant `FLAT`/`APARTMENT` tokens during exact matching and parsing of additional flat-style variations.
+- Benchmarking README and agent-facing instructions describing how to run benchmark experiments and audits.
+- Time-based persistence hashes for benchmarking runs, with overlay precision–recall charts when comparing persisted runs.
+
+### Changed
+
+- Simplified the `run_selected_datasets` API and removed the separate `enable_diagnostics` flag.
+- Renamed dataset keys from `s3_key` to `file_name` and extracted path configuration into dedicated helpers.
+- Warn (rather than error) when a benchmarking run references an unknown persistence hash.
 
 ### Fixed
 
+- Accuracy table now correctly accounts for unmatched records when reporting matched-row counts and precision.
+- Resolved a performance regression in benchmark diagnostics output.
+
+## [1.1.0] - 2026-04-03
+
+### Added
+
+- Stage timings emitted at debug level to make pipeline performance easier to monitor.
+- `ukam_label` validation decorator to catch mislabelled inputs early.
+- Inverted index exposed on the address matcher class for downstream inspection.
+- Splink top-k comparison mode in benchmarking, alongside richer accuracy and stage-diagnostics outputs.
+- Precision–recall, stacked, and overlay charts for comparing runs, with support for HTML chart inputs and waterfall-as-text rendering.
+- "EXCLUDING" token handling (including basement scenarios) and expansion of `RR` / `R/O` abbreviations to `rear`.
+- Reporting of alternative matches and a false-positive report view.
+
+### Changed
+
+- Simplified loading of the Splink `Linker` object and tightened table management around predictions (`_splink_predictions`).
+- Removed support for pre-cleaned canonical parquet inputs in favour of the standard cleaning pipeline.
+- Suppressed a noisy Splink warning emitted during normal use.
+- Cast `match_reason` to a stable string for display and switched internal usage to the `MatchReason` enum.
+
+### Fixed
+
+- Distinguishability calculations now behave consistently when `best_match_only=False`.
+- Jaccard comparison no longer errors on empty strings.
+- Canonical folders can now be read from `https://` locations.
+- Corrected the project licence metadata.
+
+## [1.0.1] - 2026-03-13
+
+### Added
+
+- Documentation for choosing a matching threshold and optimising accuracy.
+- Updated examples to use downloadable `ukam` datasets.
+- CI concurrency rules to cancel stale workflow runs.
+
+### Changed
+
+- `ukam_address_id` is now `int32` rather than a UUID.
+- Renamed materialised/transient table conventions, using a `__ukam__tmp` prefix for transient tables.
+- Refactored and simplified the benchmarking modules (moved analysis into `insights`, simplified data loading).
+- Bumped minimum Splink to `4.0.16`.
+
+### Fixed
+
+- Exploding blocking rules no longer fail on certain inputs.
+- Fixed a materialisation bug surfaced by issue #301.
+- Benchmark fixes including UPRNs no longer being cast as floats.
+- Typos in the README.
 
 ## [1.0.0] - 2026-03-04
 
@@ -25,5 +90,7 @@ Initial stable release.
 
 [Unreleased]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.1.2...HEAD
 [1.1.2]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/moj-analytical-services/uk_address_matcher/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.2] - 2026-04-29
+
 ### Fixed
 
+- Removed automatic `splink_udfs` installation because the matcher only uses DuckDB built-ins and the test suite passes without the community extension.
 - Removed unnecessary Splink input rematerialisation of `address_without_numbers`, which could trigger large DuckDB temporary spill files before `predict()`.  Rough 2x speed boost when matching to full UK dataset.
 
 ## [1.0.1] -
@@ -20,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial stable release.
 
-[Unreleased]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.1.1...v1.1.2
 [1.0.1]: https://github.com/moj-analytical-services/uk_address_matcher/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/moj-analytical-services/uk_address_matcher/releases/tag/v1.0.0

--- a/benchmarking/utils/io.py
+++ b/benchmarking/utils/io.py
@@ -125,10 +125,8 @@ def load_duckdb_excel(con: duckdb.DuckDBPyConnection) -> None:
 
 
 def setup_connection() -> duckdb.DuckDBPyConnection:
-    """Initialise DuckDB connection with required extensions for benchmarking."""
-    con = duckdb.connect(database=":memory:")
-    con.execute("INSTALL splink_udfs FROM community; LOAD splink_udfs;")
-    return con
+    """Initialise DuckDB connection for benchmarking."""
+    return duckdb.connect(database=":memory:")
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uk_address_matcher"
-version = "1.1.1"
+version = "1.1.2"
 description = "A package for matching UK addresses using a pretrained Splink model"
 authors = [{name = "Robin Linacre", email = "robinlinacre@hotmail.com"}]
 readme = "readme.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ def _test_calculate_chunk_size(total_records: int, num_of_chunks: int) -> int:
 @pytest.fixture
 def duck_con():
     con = duckdb.connect(database=":memory:")
-    con.execute("INSTALL splink_udfs FROM community; LOAD splink_udfs;")
 
     # Patch chunk size calculation to allow small test datasets to be chunked
     with patch(

--- a/uk_address_matcher/__init__.py
+++ b/uk_address_matcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 # === Primary API ===
 from uk_address_matcher.address_matcher import AddressMatcher

--- a/uk_address_matcher/address_matcher.py
+++ b/uk_address_matcher/address_matcher.py
@@ -29,17 +29,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger("uk_address_matcher")
 
 
-def _ensure_splink_udfs(con: duckdb.DuckDBPyConnection) -> None:
-    """Installs and loads the splink_udfs community extension if needed."""
-    loaded = con.execute(
-        "SELECT * FROM duckdb_extensions() "
-        "WHERE extension_name = 'splink_udfs' AND loaded"
-    ).fetchone()
-    if loaded is None:
-        con.execute("INSTALL splink_udfs FROM community")
-        con.execute("LOAD splink_udfs")
-
-
 def _default_stages() -> list[MatchingStage]:
     """Return the default stage sequence: exact match then Splink."""
     from uk_address_matcher.linking_model.matching.stages import ExactMatchStage
@@ -158,7 +147,6 @@ class AddressMatcher:
         cleaning_num_chunks: int = 10,
     ):
         self.con = con
-        _ensure_splink_udfs(self.con)
         self.stages = stages if stages is not None else _default_stages()
         self.debug_options = debug_options
         self.canonical_address_filter = canonical_address_filter

--- a/uv.lock
+++ b/uv.lock
@@ -3002,7 +3002,7 @@ wheels = [
 
 [[package]]
 name = "uk-address-matcher"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -573,6 +573,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -3001,7 +3002,7 @@ wheels = [
 
 [[package]]
 name = "uk-address-matcher"
-version = "1.0.1"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
`splink_udfs` is no longer being used.

In airgapped environments it causes an error

If we reintroduce it at any point, we need to give user option to load themselves from a file an instructions on how to do it