### PR TITLE
feat(abbr): add more common flat abbreviations to expand

### DIFF
--- a/uk_address_matcher/data/address_abbreviations.json
+++ b/uk_address_matcher/data/address_abbreviations.json
@@ -75,6 +75,7 @@
   { "token": "FAC", "replacement": "FACTORY" },
 
   { "token": "FF", "replacement": "FIRST FLOOR" },
+  { "token": "FT", "replacement": "FRONT" },
 
   { "token": "FL", "replacement": "FLOOR" },
   { "token": "FLR", "replacement": "FLOOR" },
@@ -137,6 +138,9 @@
 
   { "token": "LIB", "replacement": "LIBRARY" },
 
+  { "token": "LHS", "replacement": "LEFT HAND SIDE" },
+  { "token": "LT", "replacement": "LEFT" },
+
   { "token": "LN", "replacement": "LANE" },
 
   { "token": "LTD", "replacement": "LIMITED" },
@@ -180,6 +184,9 @@
   { "token": "RDG", "replacement": "RIDGE" },
 
   { "token": "RVR", "replacement": "RIVER" },
+
+  { "token": "RHS", "replacement": "RIGHT HAND SIDE" },
+  { "token": "RT", "replacement": "RIGHT" },
 
   { "token": "SCH", "replacement": "SCHOOL" },
 


### PR DESCRIPTION
This PR adds some more common abbreviations to be expanded. For example, we've found records like this in our messy data:
`flat 1st flr ft 176 lower clapton road london`


```
FT -> FRONT
LT -> LEFT
RT -> RIGHT
LHS -> LEFT HAND SIDE
RHS -> RIGHT HAND SIDE
```