### PR TITLE
fix(cleaning): reuse registered inverted index

### DIFF
--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -15,6 +15,7 @@ from uk_address_matcher import (
     UniqueTrigramStage,
     prepare_canonical_folder,
 )
+from uk_address_matcher.cleaning.pipelines import _register_inverted_index_table
 from uk_address_matcher.post_linkage.match_result import MatchResult
 
 CANONICAL_RECORDS = [
@@ -267,6 +268,33 @@ def test_match_from_prepared_folder_path_object(con, canonical_data, messy_data)
         )
         result = matcher.match()
         assert result.matches().count("*").fetchone()[0] > 0
+
+
+def test_cleaning_reuses_existing_inverted_index_table(con):
+    con.execute(
+        """
+        CREATE TABLE prepared_inverted_index AS
+        SELECT
+            'SW1A' AS key,
+            ['C1']::VARCHAR[] AS unique_ids,
+            'postcode' AS index_strategy
+        """
+    )
+
+    table_name = _register_inverted_index_table(
+        con,
+        con.table("prepared_inverted_index"),
+    )
+
+    assert table_name == "__ukam_inverted_index"
+    tables = {
+        row[0]: row[1]
+        for row in con.execute(
+            "SELECT table_name, table_type FROM information_schema.tables"
+        ).fetchall()
+    }
+    assert tables["prepared_inverted_index"] == "BASE TABLE"
+    assert tables["__ukam_inverted_index"] == "VIEW"
 
 
 def test_inverted_index_property_returns_registered_relation(

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -624,8 +624,8 @@ def prepare_data_for_matching(
     con.execute(f"DROP TABLE IF EXISTS {cleaned_table_name}")
 
     # Clean up inverted index table if it was registered
-    if inv_idx_table_name is not None:
-        con.execute(f"DROP TABLE IF EXISTS {inv_idx_table_name}")
+    if inv_idx_table_name == "__ukam_inverted_index":
+        _drop_table_and_registered_aliases(con, inv_idx_table_name)
 
     return con.table(processed_table)
 

--- a/uk_address_matcher/cleaning/pipelines.py
+++ b/uk_address_matcher/cleaning/pipelines.py
@@ -35,7 +35,10 @@ from uk_address_matcher.cleaning.steps import (
 from uk_address_matcher.cleaning.steps.term_frequencies import (
     _create_histograms_from_token_frequencies,
 )
-from uk_address_matcher.sql_pipeline.helpers import package_resource_read_sql
+from uk_address_matcher.sql_pipeline.helpers import (
+    _duckdb_table_exists,
+    package_resource_read_sql,
+)
 from uk_address_matcher.sql_pipeline.runner import DebugOptions, create_sql_pipeline
 
 _NUMERIC_TOKENS_WORK_NAME = "__ukam__numeric_tokens_work"
@@ -356,6 +359,15 @@ def _register_inverted_index_table(
     """
     if inverted_index is None:
         return None
+
+    existing_alias = getattr(inverted_index, "alias", None)
+    if isinstance(existing_alias, str) and _duckdb_table_exists(con, existing_alias):
+        con.sql("DROP VIEW IF EXISTS __ukam_inverted_index")
+        con.execute(
+            "CREATE TEMP VIEW __ukam_inverted_index AS "
+            f"SELECT * FROM {existing_alias}"
+        )
+        return "__ukam_inverted_index"
 
     # Materialise to avoid lazy evaluation issues
     con.sql("DROP TABLE IF EXISTS __ukam_inverted_index")

--- a/uk_address_matcher/cleaning/pipelines.py
+++ b/uk_address_matcher/cleaning/pipelines.py
@@ -364,8 +364,7 @@ def _register_inverted_index_table(
     if isinstance(existing_alias, str) and _duckdb_table_exists(con, existing_alias):
         con.sql("DROP VIEW IF EXISTS __ukam_inverted_index")
         con.execute(
-            "CREATE TEMP VIEW __ukam_inverted_index AS "
-            f"SELECT * FROM {existing_alias}"
+            f"CREATE TEMP VIEW __ukam_inverted_index AS SELECT * FROM {existing_alias}"
         )
         return "__ukam_inverted_index"
 


### PR DESCRIPTION
Avoid copying an already materialised inverted-index table during messy-address preparation.

Register the cleaning alias as a temporary view and keep focused coverage for preserving the caller-owned table.

Improves performance for me locally by approx 3 seconds avoiding an expensive copy.