### PR TITLE
feat: #365 Abbreviation Expansion of RC & HMP

### DIFF
--- a/tests/cleaning/test_abbreviation_replacement.py
+++ b/tests/cleaning/test_abbreviation_replacement.py
@@ -100,7 +100,7 @@ def test_abbreviations_expand_to_multi_word_business_shells(duck_con):
         "ROMAN CATHOLIC CHURCH 5 EXAMPLE ROAD LONDON",
         "ST MARYS ROMAN CATHOLIC PRIMARY SCHOOL CHURCH LANE",
         "FLAT 2 ROMAN CATHOLIC PRESBYTERY 9 CHAPEL STREET",
-        "SHOP FIRST FLOOR 10 HIGH STREET"
+        "SHOP FIRST FLOOR 10 HIGH STREET",
     ]
 
 

--- a/tests/cleaning/test_abbreviation_replacement.py
+++ b/tests/cleaning/test_abbreviation_replacement.py
@@ -69,12 +69,12 @@ def test_abbreviation_normalisation_sql(duck_con, test_abbr_data):
         assert row[clean_idx] == expected
 
 
-def test_rc_and_hmp_abbreviation_expansion(duck_con):
-    """RC -> ROMAN CATHOLIC and HMP -> HIS MAJESTYS PRISON (issue #365).
+def test_single_token_abbreviations_expand_to_multi_word_business_shells(duck_con):
+    """Single token abbreviations can expand inside business/unit shells.
 
-    Both are single-token keys whose replacement expands to multiple words. The
-    surrounding tokens (CHURCH, PRESBYTERY, ARMLEY, ...) must be left untouched, and the
-    expansion must fire wherever the token appears, not only at the start of the string.
+    The replacement may add multiple words, but surrounding tokens such as CHURCH,
+    PRESBYTERY, ARMLEY, SHOP, and street names must be preserved. The expansion
+    should also fire wherever the token appears, not only at the start of the string.
     """
     input_rel = duck_con.sql(
         """
@@ -82,8 +82,9 @@ def test_rc_and_hmp_abbreviation_expansion(duck_con):
             ('RC CHURCH 5 EXAMPLE ROAD LONDON'),
             ('ST MARYS RC PRIMARY SCHOOL CHURCH LANE'),
             ('FLAT 2 RC PRESBYTERY 9 CHAPEL STREET'),
-            ('HMP LEEDS ARMLEY'),
-            ('HMP WORMWOOD SCRUBS 160 DU CANE ROAD LONDON')
+            ('HM PRISON LEEDS ARMLEY'),
+            ('HM PRISON WORMWOOD SCRUBS 160 DU CANE ROAD LONDON'),
+            ('SHOP FF 10 HIGH STREET')
         ) AS t(clean_full_address)
     """
     )
@@ -101,8 +102,9 @@ def test_rc_and_hmp_abbreviation_expansion(duck_con):
         "ROMAN CATHOLIC CHURCH 5 EXAMPLE ROAD LONDON",
         "ST MARYS ROMAN CATHOLIC PRIMARY SCHOOL CHURCH LANE",
         "FLAT 2 ROMAN CATHOLIC PRESBYTERY 9 CHAPEL STREET",
-        "HIS MAJESTYS PRISON LEEDS ARMLEY",
-        "HIS MAJESTYS PRISON WORMWOOD SCRUBS 160 DU CANE ROAD LONDON",
+        "HMP LEEDS ARMLEY",
+        "HMP WORMWOOD SCRUBS 160 DU CANE ROAD LONDON",
+        "SHOP FIRST FLOOR 10 HIGH STREET",
     ]
 
 

--- a/tests/cleaning/test_abbreviation_replacement.py
+++ b/tests/cleaning/test_abbreviation_replacement.py
@@ -69,8 +69,8 @@ def test_abbreviation_normalisation_sql(duck_con, test_abbr_data):
         assert row[clean_idx] == expected
 
 
-def test_single_token_abbreviations_expand_to_multi_word_business_shells(duck_con):
-    """Single token abbreviations can expand inside business/unit shells.
+def test_abbreviations_expand_to_multi_word_business_shells(duck_con):
+    """Abbreviations can expand inside business/unit shells.
 
     The replacement may add multiple words, but surrounding tokens such as CHURCH,
     PRESBYTERY, ARMLEY, SHOP, and street names must be preserved. The expansion
@@ -82,9 +82,11 @@ def test_single_token_abbreviations_expand_to_multi_word_business_shells(duck_co
             ('RC CHURCH 5 EXAMPLE ROAD LONDON'),
             ('ST MARYS RC PRIMARY SCHOOL CHURCH LANE'),
             ('FLAT 2 RC PRESBYTERY 9 CHAPEL STREET'),
+            ('HMP LEEDS ARMLEY'),
             ('HM PRISON LEEDS ARMLEY'),
-            ('HM PRISON WORMWOOD SCRUBS 160 DU CANE ROAD LONDON'),
-            ('SHOP FF 10 HIGH STREET')
+            ('H M PRISON WORMWOOD SCRUBS 160 DU CANE ROAD LONDON'),
+            ('SHOP FF 10 HIGH STREET'),
+            ('YOUNG OFFENDER INSTITUTION BEDFONT ROAD, FELTHAM, MIDDLESEX, TW13 4ND')
         ) AS t(clean_full_address)
     """
     )
@@ -103,8 +105,10 @@ def test_single_token_abbreviations_expand_to_multi_word_business_shells(duck_co
         "ST MARYS ROMAN CATHOLIC PRIMARY SCHOOL CHURCH LANE",
         "FLAT 2 ROMAN CATHOLIC PRESBYTERY 9 CHAPEL STREET",
         "HMP LEEDS ARMLEY",
+        "HMP LEEDS ARMLEY",
         "HMP WORMWOOD SCRUBS 160 DU CANE ROAD LONDON",
         "SHOP FIRST FLOOR 10 HIGH STREET",
+        "YOI BEDFONT ROAD, FELTHAM, MIDDLESEX, TW13 4ND",
     ]
 
 

--- a/tests/cleaning/test_abbreviation_replacement.py
+++ b/tests/cleaning/test_abbreviation_replacement.py
@@ -82,11 +82,7 @@ def test_abbreviations_expand_to_multi_word_business_shells(duck_con):
             ('RC CHURCH 5 EXAMPLE ROAD LONDON'),
             ('ST MARYS RC PRIMARY SCHOOL CHURCH LANE'),
             ('FLAT 2 RC PRESBYTERY 9 CHAPEL STREET'),
-            ('HMP LEEDS ARMLEY'),
-            ('HM PRISON LEEDS ARMLEY'),
-            ('H M PRISON WORMWOOD SCRUBS 160 DU CANE ROAD LONDON'),
-            ('SHOP FF 10 HIGH STREET'),
-            ('YOUNG OFFENDER INSTITUTION BEDFONT ROAD, FELTHAM, MIDDLESEX, TW13 4ND')
+            ('SHOP FF 10 HIGH STREET')
         ) AS t(clean_full_address)
     """
     )
@@ -104,11 +100,7 @@ def test_abbreviations_expand_to_multi_word_business_shells(duck_con):
         "ROMAN CATHOLIC CHURCH 5 EXAMPLE ROAD LONDON",
         "ST MARYS ROMAN CATHOLIC PRIMARY SCHOOL CHURCH LANE",
         "FLAT 2 ROMAN CATHOLIC PRESBYTERY 9 CHAPEL STREET",
-        "HMP LEEDS ARMLEY",
-        "HMP LEEDS ARMLEY",
-        "HMP WORMWOOD SCRUBS 160 DU CANE ROAD LONDON",
-        "SHOP FIRST FLOOR 10 HIGH STREET",
-        "YOI BEDFONT ROAD, FELTHAM, MIDDLESEX, TW13 4ND",
+        "SHOP FIRST FLOOR 10 HIGH STREET"
     ]
 
 

--- a/tests/cleaning/test_abbreviation_replacement.py
+++ b/tests/cleaning/test_abbreviation_replacement.py
@@ -69,6 +69,43 @@ def test_abbreviation_normalisation_sql(duck_con, test_abbr_data):
         assert row[clean_idx] == expected
 
 
+def test_rc_and_hmp_abbreviation_expansion(duck_con):
+    """RC -> ROMAN CATHOLIC and HMP -> HIS MAJESTYS PRISON (issue #365).
+
+    Both are single-token keys whose replacement expands to multiple words. The
+    surrounding tokens (CHURCH, PRESBYTERY, ARMLEY, ...) must be left untouched, and the
+    expansion must fire wherever the token appears, not only at the start of the string.
+    """
+    input_rel = duck_con.sql(
+        """
+        SELECT * FROM (VALUES
+            ('RC CHURCH 5 EXAMPLE ROAD LONDON'),
+            ('ST MARYS RC PRIMARY SCHOOL CHURCH LANE'),
+            ('FLAT 2 RC PRESBYTERY 9 CHAPEL STREET'),
+            ('HMP LEEDS ARMLEY'),
+            ('HMP WORMWOOD SCRUBS 160 DU CANE ROAD LONDON')
+        ) AS t(clean_full_address)
+    """
+    )
+
+    pipeline = create_sql_pipeline(
+        con=duck_con,
+        input_rel=input_rel,
+        stage_specs=[_normalise_abbreviations_and_units],
+    )
+    result_rel = pipeline.run()
+    clean_idx = result_rel.columns.index("clean_full_address")
+    actual = [row[clean_idx] for row in result_rel.fetchall()]
+
+    assert actual == [
+        "ROMAN CATHOLIC CHURCH 5 EXAMPLE ROAD LONDON",
+        "ST MARYS ROMAN CATHOLIC PRIMARY SCHOOL CHURCH LANE",
+        "FLAT 2 ROMAN CATHOLIC PRESBYTERY 9 CHAPEL STREET",
+        "HIS MAJESTYS PRISON LEEDS ARMLEY",
+        "HIS MAJESTYS PRISON WORMWOOD SCRUBS 160 DU CANE ROAD LONDON",
+    ]
+
+
 def test_excluding_token_is_joined_with_following_token(duck_con):
     input_rel = duck_con.sql(
         """

--- a/uk_address_matcher/cleaning/steps/normalisation.py
+++ b/uk_address_matcher/cleaning/steps/normalisation.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import re
+from importlib import resources
 from typing import Final
 
 from uk_address_matcher.cleaning.steps.regexes import (
@@ -16,6 +19,39 @@ from uk_address_matcher.cleaning.steps.regexes import (
 )
 from uk_address_matcher.sql_pipeline.helpers import package_resource_read_sql
 from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
+
+
+def _sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _normalise_abbreviation_phrase_expr(address_expr: str) -> str:
+    with resources.files("uk_address_matcher.data").joinpath(
+        "address_abbreviations.json"
+    ).open("r", encoding="utf-8") as f:
+        rows = json.load(f)
+
+    phrase_rows = [
+        (row["token"].strip().upper(), row["replacement"].strip())
+        for row in rows
+        if " " in row["token"].strip()
+    ]
+    phrase_rows.sort(key=lambda row: (-len(row[0]), row[0]))
+
+    expr = address_expr
+    for token, replacement in phrase_rows:
+        token_pattern = r"\s+".join(re.escape(part) for part in token.split())
+        pattern = rf"(^|\s){token_pattern}(\s|$)"
+        replacement_pattern = rf"\1{replacement}\2"
+        expr = (
+            "regexp_replace("
+            f"{expr}, "
+            f"{_sql_literal(pattern)}, "
+            f"{_sql_literal(replacement_pattern)}, "
+            "'g'"
+            ")"
+        )
+    return expr
 
 
 @pipeline_stage(
@@ -362,19 +398,23 @@ def _normalise_abbreviations_and_units() -> list[CTEStep]:
     FROM {abbr_lookup}
     """
 
-    # 3) Vectorised transform over token list, then join back to a string
-    cleaned_sql = """
+    phrase_normalised_address = _normalise_abbreviation_phrase_expr(
+        "COALESCE(address.clean_full_address, '')"
+    )
+
+    # 3) Apply phrase replacements, then vectorise over token list and join to a string
+    cleaned_sql = f"""
     SELECT
       address.* EXCLUDE (clean_full_address),
       array_to_string(
         list_transform(
-        string_split(COALESCE(address.clean_full_address, ''), ' '),
+        string_split({phrase_normalised_address}, ' '),
         x -> COALESCE(map_extract(m.abbr_map, x)[1], x)
         ),
         ' '
       ) AS clean_full_address
-    FROM {input} address
-    CROSS JOIN {abbr_map} m
+    FROM {{input}} address
+    CROSS JOIN {{abbr_map}} m
     """
 
     steps = [

--- a/uk_address_matcher/cleaning/steps/normalisation.py
+++ b/uk_address_matcher/cleaning/steps/normalisation.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import json
-import re
-from importlib import resources
 from typing import Final
 
 from uk_address_matcher.cleaning.steps.regexes import (
@@ -19,39 +16,6 @@ from uk_address_matcher.cleaning.steps.regexes import (
 )
 from uk_address_matcher.sql_pipeline.helpers import package_resource_read_sql
 from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
-
-
-def _sql_literal(value: str) -> str:
-    return "'" + value.replace("'", "''") + "'"
-
-
-def _normalise_abbreviation_phrase_expr(address_expr: str) -> str:
-    with resources.files("uk_address_matcher.data").joinpath(
-        "address_abbreviations.json"
-    ).open("r", encoding="utf-8") as f:
-        rows = json.load(f)
-
-    phrase_rows = [
-        (row["token"].strip().upper(), row["replacement"].strip())
-        for row in rows
-        if " " in row["token"].strip()
-    ]
-    phrase_rows.sort(key=lambda row: (-len(row[0]), row[0]))
-
-    expr = address_expr
-    for token, replacement in phrase_rows:
-        token_pattern = r"\s+".join(re.escape(part) for part in token.split())
-        pattern = rf"(^|\s){token_pattern}(\s|$)"
-        replacement_pattern = rf"\1{replacement}\2"
-        expr = (
-            "regexp_replace("
-            f"{expr}, "
-            f"{_sql_literal(pattern)}, "
-            f"{_sql_literal(replacement_pattern)}, "
-            "'g'"
-            ")"
-        )
-    return expr
 
 
 @pipeline_stage(
@@ -398,23 +362,19 @@ def _normalise_abbreviations_and_units() -> list[CTEStep]:
     FROM {abbr_lookup}
     """
 
-    phrase_normalised_address = _normalise_abbreviation_phrase_expr(
-        "COALESCE(address.clean_full_address, '')"
-    )
-
-    # 3) Apply phrase replacements, then vectorise over token list and join to a string
-    cleaned_sql = f"""
+    # 3) Vectorised transform over token list, then join back to a string
+    cleaned_sql = """
     SELECT
       address.* EXCLUDE (clean_full_address),
       array_to_string(
         list_transform(
-        string_split({phrase_normalised_address}, ' '),
+        string_split(COALESCE(address.clean_full_address, ''), ' '),
         x -> COALESCE(map_extract(m.abbr_map, x)[1], x)
         ),
         ' '
       ) AS clean_full_address
-    FROM {{input}} address
-    CROSS JOIN {{abbr_map}} m
+    FROM {input} address
+    CROSS JOIN {abbr_map} m
     """
 
     steps = [

--- a/uk_address_matcher/data/address_abbreviations.json
+++ b/uk_address_matcher/data/address_abbreviations.json
@@ -132,10 +132,6 @@
 
   { "token": "HTL", "replacement": "HOTEL" },
 
-  {"token": "HM PRISON", "replacement": "HMP"},
-  {"token": "H M PRISON", "replacement": "HMP"},
-
-
   { "token": "INC", "replacement": "INCORPORATED" },
 
   { "token": "INST", "replacement": "INSTITUTE" },
@@ -242,7 +238,5 @@
 
   { "token": "WKS", "replacement": "WORKS" },
 
-  { "token": "WY", "replacement": "WAY" },
-
-  { "token": "YOUNG OFFENDER INSTITUTION", "replacement": "YOI" }
+  { "token": "WY", "replacement": "WAY" }
 ]

--- a/uk_address_matcher/data/address_abbreviations.json
+++ b/uk_address_matcher/data/address_abbreviations.json
@@ -132,7 +132,7 @@
 
   { "token": "HTL", "replacement": "HOTEL" },
 
-  {"token": "HMP", "replacement": "HIS MAJESTYS PRISON"},
+  {"token": "HM PRISON", "replacement": "HMP"},
 
   { "token": "INC", "replacement": "INCORPORATED" },
 

--- a/uk_address_matcher/data/address_abbreviations.json
+++ b/uk_address_matcher/data/address_abbreviations.json
@@ -133,6 +133,8 @@
   { "token": "HTL", "replacement": "HOTEL" },
 
   {"token": "HM PRISON", "replacement": "HMP"},
+  {"token": "H M PRISON", "replacement": "HMP"},
+
 
   { "token": "INC", "replacement": "INCORPORATED" },
 
@@ -240,5 +242,7 @@
 
   { "token": "WKS", "replacement": "WORKS" },
 
-  { "token": "WY", "replacement": "WAY" }
+  { "token": "WY", "replacement": "WAY" },
+
+  { "token": "YOUNG OFFENDER INSTITUTION", "replacement": "YOI" }
 ]

--- a/uk_address_matcher/data/address_abbreviations.json
+++ b/uk_address_matcher/data/address_abbreviations.json
@@ -132,6 +132,8 @@
 
   { "token": "HTL", "replacement": "HOTEL" },
 
+  {"token": "HMP", "replacement": "HIS MAJESTYS PRISON"},
+
   { "token": "INC", "replacement": "INCORPORATED" },
 
   { "token": "INST", "replacement": "INSTITUTE" },
@@ -187,6 +189,8 @@
 
   { "token": "RHS", "replacement": "RIGHT HAND SIDE" },
   { "token": "RT", "replacement": "RIGHT" },
+
+  {"token": "RC",  "replacement": "ROMAN CATHOLIC"},
 
   { "token": "SCH", "replacement": "SCHOOL" },
 


### PR DESCRIPTION
This is the abbreviation espansion of RC & HMP.

i.e:

`[{'token': 'HMP', 'replacement': 'HIS MAJESTYS PRISON'}, {'token': 'RC', 'replacement': 'ROMAN CATHOLIC'}]` 

The test ran passed:

````

(playground) PS C:\Users\Dee\arche\oss\uk_address_matcher> python -m  pytest .\tests\cleaning\test_abbreviation_replacement.py
================================================================================================================================== test session starts ===================================================================================================================================
platform win32 -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: C:\Users\Dee\arche\oss\uk_address_matcher
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 10 items                                                                                                                                                                                                                                                                        

tests/cleaning/test_abbreviation_replacement.py::test_abbreviation_normalisation_sql PASSED                                                                                                                                                                                         [ 10%]
tests/cleaning/test_abbreviation_replacement.py::test_rc_and_hmp_abbreviation_expansion PASSED                                                                                                                                                                                      [ 20%]
tests/cleaning/test_abbreviation_replacement.py::test_excluding_token_is_joined_with_following_token PASSED                                                                                                                                                                         [ 30%]
tests/cleaning/test_abbreviation_replacement.py::test_first_pass_splits_non_numeric_underscores_only PASSED                                                                                                                                                                         [ 40%]
tests/cleaning/test_abbreviation_replacement.py::test_full_cleaning_queue_preserves_underscore_split_before_expansion PASSED                                                                                                                                                        [ 50%]
tests/cleaning/test_abbreviation_replacement.py::test_no_exact_duplicate_rows_in_json PASSED                                                                                                                                                                                        [ 60%]
tests/cleaning/test_abbreviation_replacement.py::test_no_token_collisions_after_normalisation PASSED                                                                                                                                                                                [ 70%]
tests/cleaning/test_abbreviation_replacement.py::test_no_two_way_circular_pairs PASSED                                                                                                                                                                                              [ 80%]
tests/cleaning/test_abbreviation_replacement.py::test_no_cycles_in_abbreviation_chains PASSED                                                                                                                                                                                       [ 90%]
tests/cleaning/test_abbreviation_replacement.py::test_mapping_converges PASSED       
```