### PR TITLE
feat(splink): remove superfluous blocking rules

### DIFF
--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -23,14 +23,6 @@
             "sql_dialect": "duckdb"
         },
         {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and list_extract(l.unusual_tokens_arr, 2) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-            "sql_dialect": "duckdb"
-        },
-        {
             "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
             "sql_dialect": "duckdb"
         },
@@ -48,14 +40,6 @@
         },
         {
             "blocking_rule": "l.numeric_token_2 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_2 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
             "sql_dialect": "duckdb"
         },
         {

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -14,57 +14,45 @@
     "unique_id_column_name": "ukam_address_id",
     "source_dataset_column_name": "source_dataset",
     "blocking_rules_to_generate_predictions": [
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and list_extract(l.unusual_tokens_arr, 2) = list_extract(r.unusual_tokens_arr, 2) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and l.postcode = r.postcode",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_2 and l.postcode = r.postcode",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and l.postcode = r.postcode",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_2 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_2 = r.numeric_token_2 and l.postcode = r.postcode",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and l.numeric_token_2 = r.numeric_token_2 and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and l.numeric_token_2 = r.numeric_token_2 and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "list_extract(l.extremely_unusual_tokens_arr, 1) = list_extract(r.extremely_unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-            "sql_dialect": "duckdb"
-        },
-        {
-            "blocking_rule": "l.exploding_unique_ids = r.exploding_unique_ids",
-            "sql_dialect": "duckdb",
-            "arrays_to_explode": [
-                "exploding_unique_ids"
-            ]
-        }
+            {
+                "blocking_rule": "l.postcode = r.postcode and ((l.numeric_token_1 = r.numeric_token_1) or (l.numeric_token_2 = r.numeric_token_2))",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "l.postcode = r.postcode and ((l.numeric_token_2 = r.numeric_token_1) or (l.numeric_token_1 = r.numeric_token_2))",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and list_extract(l.unusual_tokens_arr, 2) = list_extract(r.unusual_tokens_arr, 2) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "l.numeric_token_1 = r.numeric_token_1 and l.postcode = r.postcode",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and l.postcode = r.postcode",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "l.numeric_token_2 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "list_extract(l.extremely_unusual_tokens_arr, 1) = list_extract(r.extremely_unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
+                "sql_dialect": "duckdb"
+            },
+            {
+                "blocking_rule": "l.exploding_unique_ids = r.exploding_unique_ids",
+                "sql_dialect": "duckdb",
+                "arrays_to_explode": [
+                    "exploding_unique_ids"
+                ]
+            }
     ],
     "comparisons": [
         {

--- a/uk_address_matcher/linking_model/blocking.py
+++ b/uk_address_matcher/linking_model/blocking.py
@@ -1,86 +1,14 @@
 old_blocking_rules = [
-    """
-    l.numeric_token_1 = r.numeric_token_1
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1)
-    AND list_extract(l.unusual_tokens_arr, 2) = list_extract(r.unusual_tokens_arr, 2)
-    AND split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)
-    """,
-    """
-    l.numeric_token_1 = r.numeric_token_2
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1)
-    AND split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)
-    """,
-    """
-    l.numeric_token_1 = r.numeric_token_2
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1)
-    AND split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)
-    """,
-    """
-    l.numeric_token_1 = r.numeric_token_1
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2)
-    AND list_extract(l.unusual_tokens_arr, 2) = list_extract(r.unusual_tokens_arr, 1)
-    AND split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)
-    """,
-    """
-    l.numeric_token_1 = r.numeric_token_1
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2)
-    AND split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)
-    """,
-    "l.numeric_token_1 = r.numeric_token_1 and l.postcode = r.postcode",
-    "l.numeric_token_1 = r.numeric_token_2 and l.postcode = r.postcode",
     (
-        "list_extract(l.unusual_tokens_arr, 1) = "
-        "list_extract(r.unusual_tokens_arr, 2) and l.postcode = r.postcode"
+        "l.postcode = r.postcode and ((l.numeric_token_1 = r.numeric_token_1) "
+        "or (l.numeric_token_2 = r.numeric_token_2))"
     ),
     (
-        "list_extract(l.very_unusual_tokens_arr, 1) = "
-        "list_extract(r.very_unusual_tokens_arr, 1) and "
-        "l.numeric_token_1 = r.numeric_token_1"
+        "l.postcode = r.postcode and ((l.numeric_token_2 = r.numeric_token_1) "
+        "or (l.numeric_token_1 = r.numeric_token_2))"
     ),
     (
-        "list_extract(l.very_unusual_tokens_arr, 1) = "
-        "list_extract(r.very_unusual_tokens_arr, 2) and "
-        "l.numeric_token_1 = r.numeric_token_1"
+        "l.numeric_token_1 = list_extract(r.very_unusual_tokens_arr, 1) "
+        "and l.postcode = r.postcode"
     ),
-    """
-    l.numeric_token_2 = r.numeric_token_2
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1)
-    AND split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)
-    """,
-    """
-    l.numeric_token_1 = r.numeric_token_1
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1)
-    AND split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)
-    """,
-    """
-    l.numeric_token_2 = r.numeric_token_2
-    AND list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1)
-    AND split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)
-    """,
-    "l.numeric_token_2 = r.numeric_token_2 and l.postcode = r.postcode",
-    # "l.numeric_token_1 = r.numeric_1_alt and l.postcode = r.postcode",
-    # "l.numeric_1_alt = r.numeric_token_1 and l.postcode = r.postcode",
-    # "l.numeric_token_1 = r.numeric_1_alt and l.numeric_token_2 = r.numeric_token_2"
-    # " and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-    # "l.numeric_1_alt = r.numeric_token_1 and l.numeric_token_2 = r.numeric_token_2"
-    # " and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)",
-    # "l.numeric_token_1 = r.numeric_1_alt and l.numeric_token_2 = r.numeric_token_2"
-    # " and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
-    # "l.numeric_1_alt = r.numeric_token_1 and l.numeric_token_2 = r.numeric_token_2"
-    # " and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)",
-    """
-    l.numeric_token_1 = r.numeric_token_1
-    AND l.numeric_token_2 = r.numeric_token_2
-    AND split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)
-    """,
-    """
-    l.numeric_token_1 = r.numeric_token_1
-    AND l.numeric_token_2 = r.numeric_token_2
-    AND split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2)
-    """,
-    """
-    list_extract(l.extremely_unusual_tokens_arr, 1) =
-        list_extract(r.extremely_unusual_tokens_arr, 1)
-    AND split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1)
-    """,
 ]


### PR DESCRIPTION
I've conservatively removed some of our superfluous blocking rules that were adding no real value to our matching. This takes our blocking rules down to 9, consolidating a few and extricate some that added little-to-no value.

This shows the before and after effects of this changes:
<img width="949" height="738" alt="Screenshot 2026-05-26 at 16 27 00" src="https://github.com/user-attachments/assets/5d46aef0-e17b-446e-9c8f-36eaf04a7fdb" />

In practice, this is shaving off about 1 second of runtime on my machine and results in no performance cost.

I've also run some further experiments with optional pruning that we may look to introduce that I detail in a separate issue and we will discuss in more detail before merging.

#### Metrics for original vs conservative blocking pruning
```
| Metric | Baseline `de22dbb1d7155109` | Pruned `bb6f38beac60e905` | Delta |
| --- | ---: | ---: | ---: |
| Correct matches | 107,900 | 107,935 | +35 |
| Matched rows | 109,354 | 109,389 | +35 |
| Precision | 98.6704% | 98.6708% | +0.0004 pp |
| Recall | 93.6656% | 93.6960% | +0.0304 pp |
| F1 | 96.1029% | 96.1191% | +0.0162 pp |
| Total runtime | 23.8704s | 22.7537s | -1.1167s |
```

#### Metrics keeping only four blocking rules

The 4 rules under test were:

1. `l.postcode = r.postcode and ((l.numeric_token_1 = r.numeric_token_1) or (l.numeric_token_2 = r.numeric_token_2))`
2. `l.postcode = r.postcode and ((l.numeric_token_2 = r.numeric_token_1) or (l.numeric_token_1 = r.numeric_token_2))`
3. `l.numeric_token_1 = list_extract(r.very_unusual_tokens_arr, 1) and l.postcode = r.postcode`
4. `l.exploding_unique_ids = r.exploding_unique_ids`

Rules included:
```
| Rule | New comparisons | Cumulative comparisons | Isolated true matches |
| --- | ---: | ---: | ---: |
| Same-position postcode numeric rule | 1,720,692 | 1,720,692 | 68,006 |
| Bidirectional swap rule | 92,676 | 1,813,368 | 7,698 |
| Venue-anchor rule | 17,811 | 1,831,179 | 6 |
| Inverted-index rule | 933,534 | 2,764,713 | 52,429 |
```

```
| Rule | Isolated comparisons | Exclusive comparisons | Exclusive share | Exclusive true matches |
| --- | ---: | ---: | ---: | ---: |
| Same-position postcode numeric rule | 1,720,692 | 1,289,483 | 74.94% | 13,559 |
| Bidirectional swap rule | 158,314 | 60,554 | 38.25% | 103 |
| Venue-anchor rule | 17,811 | 16,753 | 94.06% | 2 |
| Inverted-index rule | 1,357,319 | 933,534 | 68.78% | 28 |
```

---

### Additional metrics produced from the comparison process

These only look at true matches captured, but give an insight into how many records are being captured by different rules:

## Cross-Dataset Rollup: True Matches by Rule (Isolated)

| Rule # | Rule Family | Total True Matches (All Datasets) | 
| --- | --- | ---: |
| 1 | same-position + 2 unusual tokens + postcode area | 1,090 |
| 2 | cross-position swap + unusual token + postcode area | 594 |
| 3 | cross-position swap (alt position) + postcode area | 561 |
| 4 | same-position numeric + 2 unusual swapped + postcode area | 91 |
| 5 | same-position numeric + unusual swap + postcode sector | 1,138 |
| 6 | numeric_token_1 + full postcode | 150,530 |
| 7 | numeric_token_1 ↔ numeric_token_2 + full postcode | 3,518 |
| 8 | unusual token swap + postcode | 1,242 |
| 9 | numeric_token_2 + unusual token + postcode area | 4,503 |
| 10 | numeric_token_1 + unusual token + postcode sector | 22,476 |
| 11 | numeric_token_2 + unusual token + postcode sector | 4,163 |
| 12 | numeric_token_2 + full postcode | 32,722 |
| 13 | both numeric tokens + postcode area | 33,986 |
| 14 | both numeric tokens + postcode area (alt split) | 32,477 |
| 15 | extremely unusual token + postcode area | 2,614 |
| 16 | inverted index (exploding_unique_ids) | 125,242 |

## Hackney: Rules in Isolation

| # | Kind | Isolated runtime s | Isolated comparisons | Isolated true matches | Rule |
| --- | --- | ---: | ---: | ---: | --- |
| 1 | standard | 4.351 | 452 | 146 | l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and list_extract(l.unusual_tokens_arr, 2) = list_extract(r.unusual_tokens_arr, 2) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1) |
| 2 | standard | 3.832 | 31,344 | 81 | l.numeric_token_1 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1) |
| 3 | standard | 3.719 | 8,723 | 81 | l.numeric_token_1 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2) |
| 4 | standard | 3.688 | 155 | 43 | l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and list_extract(l.unusual_tokens_arr, 2) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1) |
| 5 | standard | 3.684 | 490 | 105 | l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2) |
| 6 | standard | 3.972 | 428,864 | 67,923 | l.numeric_token_1 = r.numeric_token_1 and l.postcode = r.postcode |
| 7 | standard | 3.592 | 79,595 | 816 | l.numeric_token_1 = r.numeric_token_2 and l.postcode = r.postcode |
| 8 | standard | 3.491 | 14,243 | 107 | list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 2) and l.postcode = r.postcode |
| 9 | standard | 3.741 | 170,642 | 2,499 | l.numeric_token_2 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1) |
| 10 | standard | 3.967 | 51,561 | 8,814 | l.numeric_token_1 = r.numeric_token_1 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2) |
| 11 | standard | 3.958 | 166,854 | 2,499 | l.numeric_token_2 = r.numeric_token_2 and list_extract(l.unusual_tokens_arr, 1) = list_extract(r.unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2) |
| 12 | standard | 5.392 | 1,347,527 | 18,434 | l.numeric_token_2 = r.numeric_token_2 and l.postcode = r.postcode |
| 13 | standard | 4.419 | 251,070 | 18,344 | l.numeric_token_1 = r.numeric_token_1 and l.numeric_token_2 = r.numeric_token_2 and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1) |
| 14 | standard | 4.313 | 93,682 | 18,344 | l.numeric_token_1 = r.numeric_token_1 and l.numeric_token_2 = r.numeric_token_2 and split_part(l.postcode, ' ', 2) = split_part(r.postcode, ' ', 2) |
| 15 | standard | 3.866 | 4,873 | 198 | list_extract(l.extremely_unusual_tokens_arr, 1) = list_extract(r.extremely_unusual_tokens_arr, 1) and split_part(l.postcode, ' ', 1) = split_part(r.postcode, ' ', 1) |
| 16 | exploding | 5.871 | 1,357,319 | 52,429 | l.exploding_unique_ids = r.exploding_unique_ids |