### PR TITLE
docs: enhance OS filtering guidance

### DIFF
--- a/benchmarking/constants.py
+++ b/benchmarking/constants.py
@@ -7,11 +7,32 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BENCHMARK_PROJECT_ROOT = _PROJECT_ROOT.as_posix()
 BENCHMARK_RESULTS_ROOT = (_PROJECT_ROOT / "benchmarking" / "results").as_posix()
 
+RESIDENTIAL_ONLY_CANONICAL_FILTER_SQL = "substr(classificationcode, 1, 1) = 'R'"
+RESIDENTIAL_WITHOUT_GARAGES_OR_PARENT_SHELLS_CANONICAL_FILTER_SQL = (
+    "substr(classificationcode, 1, 1) = 'R' "
+    "AND substr(classificationcode, 1, 2) <> 'RG' "
+    "AND substr(classificationcode, 1, 2) <> 'PP'"
+)
+RESIDENTIAL_WITHOUT_ANCILLARY_PREFIXES_CANONICAL_FILTER_SQL = (
+    "substr(classificationcode, 1, 1) = 'R' "
+    "AND clean_full_address NOT LIKE 'CAR PARK SPACE%' "
+    "AND clean_full_address NOT LIKE 'GARAGE %'"
+)
+RESIDENTIAL_CORE_CANONICAL_FILTER_SQL = (
+    "substr(classificationcode, 1, 1) = 'R' "
+    "AND substr(classificationcode, 1, 2) <> 'RG' "
+    "AND substr(classificationcode, 1, 2) <> 'PP' "
+    "AND clean_full_address NOT LIKE 'CAR PARK SPACE%' "
+    "AND clean_full_address NOT LIKE 'GARAGE %'"
+)
+
 # Optional Splink-only comparison table shown after benchmark summary.
 # Set to `None` to disable threshold-comparison output.
 SPLINK_BASELINE_WEIGHT: float | None = 10.0
 SPLINK_COMPARISON_WEIGHTS: list[float] | None = None
 TOP_K_PRECISION_AT_METRICS: list[int] = [1, 3, 5]
 
-APPLY_CANONICAL_FILTER = True
+# Set this to one of the recipe constants above to enable a benchmark filter.
+CANONICAL_FILTER_SQL: str | None = None
+APPLY_CANONICAL_FILTER = CANONICAL_FILTER_SQL is not None
 CLEANING_NUM_CHUNKS = 1

--- a/benchmarking/constants.py
+++ b/benchmarking/constants.py
@@ -33,6 +33,8 @@ SPLINK_COMPARISON_WEIGHTS: list[float] | None = None
 TOP_K_PRECISION_AT_METRICS: list[int] = [1, 3, 5]
 
 # Set this to one of the recipe constants above to enable a benchmark filter.
-CANONICAL_FILTER_SQL: str | None = None
+CANONICAL_FILTER_SQL: str | None = (
+    RESIDENTIAL_WITHOUT_ANCILLARY_PREFIXES_CANONICAL_FILTER_SQL
+)
 APPLY_CANONICAL_FILTER = CANONICAL_FILTER_SQL is not None
 CLEANING_NUM_CHUNKS = 1

--- a/benchmarking/run_benchmarking.py
+++ b/benchmarking/run_benchmarking.py
@@ -5,6 +5,7 @@ import logging
 from benchmarking.constants import (
     APPLY_CANONICAL_FILTER,
     BENCHMARK_RESULTS_ROOT,
+    CANONICAL_FILTER_SQL,
     CLEANING_NUM_CHUNKS,
     SPLINK_BASELINE_WEIGHT,
     SPLINK_COMPARISON_WEIGHTS,
@@ -16,7 +17,6 @@ from benchmarking.insights.reporting import (
 from benchmarking.insights.types import BenchmarkOutputOptions
 from benchmarking.runner import print_available_datasets, run_selected_datasets
 from benchmarking.settings import (
-    CANONICAL_FILTER_SQL,
     CANONICAL_PATH,
     SAMPLE_MODE,
 )
@@ -29,16 +29,17 @@ logger = logging.getLogger(__name__)
 
 # SELECTED_DATASETS: str | list[str] = "all"
 SELECTED_DATASETS: str | list[str] = "hackney"
+# SELECTED_DATASETS: str | list[str] = "aberdeenshire"
 # SELECTED_DATASETS: str | list[str] = "lambeth_llpg"
 STAGES = [
-    ExactMatchStage(),
+    ExactMatchStage(True),
     PeeledAddressStage(),
     SplinkStage(final_match_weight_threshold=SPLINK_BASELINE_WEIGHT),
 ]
 # Set to a persisted run hash to force a specific baseline, or use "latest"
 # to compare against the latest other persisted run for the same dataset.
 # Run IDs are preferred; internal dedupe hashes are still accepted for older runs.
-COMPARISON_BASELINE_RUN_ID: str | None = "latest"
+COMPARISON_BASELINE_RUN_ID: str | None = "bc216071cb56fb21"
 
 
 # Defaults: print benchmark summaries and persistence output.
@@ -49,6 +50,7 @@ OUTPUT_OPTIONS = BenchmarkOutputOptions(
     show_similarity_score_checks=False,
     show_successful_matches=False,
     show_unmatched_records=False,
+    show_splink_comparisons=False,
 )
 
 print(f"Applying canonical filter: {APPLY_CANONICAL_FILTER}")

--- a/benchmarking/settings.py
+++ b/benchmarking/settings.py
@@ -6,6 +6,3 @@ apply_env_from_private_config()
 
 SAMPLE_MODE = False
 CANONICAL_PATH = get_env_setting("UKAM_OS_CANONICAL_PREPARED")
-
-APPLY_CANONICAL_FILTER = False
-CANONICAL_FILTER_SQL: str | None = None

--- a/docs/site/optimising_accuracy.md
+++ b/docs/site/optimising_accuracy.md
@@ -32,6 +32,8 @@ There are two primary ways to filter your input data:
 - **Geographically**.  If your input data comes from a known geographical area such as a local authority, use an extract of Ordnance Survey data for that area only.
 - **By classification or other metadata**.  Ordnance Survey data contains rich metadata about each address, such as its [classification](https://docs.os.uk/osngd/code-lists/code-lists-overview/addressclassificationcodevalue).  For example, if you know your messy data is residential only, filter out non-residential addresses from the canonical dataset.
 
+For Ordnance Survey data, see [Working with Ordnance Survey data](ordnance_survey.md#filtering-before-canonical-preparation) for guidance on filtering by `classificationcode`, excluding parent shells, and deciding whether a rule belongs in canonical preparation or only at match time.
+
 #### How to filter
 
 The mechanism for filtering depends on whether you are [pre-processing your canonical dataset or processing it on the fly](https://moj-analytical-services.github.io/uk_address_matcher/get_started/#choose-whether-to-pre-process-your-canonical-dataset).
@@ -43,7 +45,7 @@ If you are processing data on-the-fly, then you can simply filter your data befo
 
 ```python
 import duckdb
-from uk_address_matcher import AddressMatcher, prepare_canonical_folder
+from uk_address_matcher import AddressMatcher
 
 con = duckdb.connect()
 
@@ -54,7 +56,7 @@ df_canonical = df_canonical.filter("substr(classificationcode, 1, 1) = 'R'")
 df_messy = con.read_csv("path/to/messy.csv")
 
 matcher = AddressMatcher(
-    canonical_addresses=output_folder,
+    canonical_addresses=df_canonical,
     addresses_to_match=df_messy,
     con=con,
 )
@@ -64,25 +66,35 @@ result = matcher.match()
 
 #### Filtering a pre-prepared datasets
 
-If your are pre-processing your canonical dataset, consider whether users of the preprocessed file will always want a filter applied.  If so, apply this filter using prior to passing the data to the `prepare_canonical_folder` folder.
+If you are pre-processing your canonical dataset, first decide whether the rule is a stable policy or only an ad hoc subset.
+
+Use this rule of thumb:
+
+- If all users should inherit the exclusion, apply it before `prepare_canonical_folder()`.
+- If different users need different subsets, keep a broader prepared folder and use `canonical_address_filter=` later.
+- If the rule is about which records should be eligible to match, do not implement it by stripping text during cleaning.
+
+If users of the preprocessed file will always want a filter applied, apply this filter before passing the data to `prepare_canonical_folder()`.
 
 ```python
 import duckdb
-import os
 import tempfile
-from uk_address_matcher import AddressMatcher, prepare_canonical_folder
+from uk_address_matcher import prepare_canonical_folder
 
 con = duckdb.connect()
 df_canonical = con.read_csv("path/to/canonical.csv")
 df_canonical = df_canonical.filter("substr(classificationcode, 1, 1) = 'R'")
 
-output_folder = tempfile.mkdtemp()
 prepare_canonical_folder(
     df_canonical,
-    output_folder=output_folder,
-    con=con
+    output_folder=tempfile.mkdtemp(),
+    con=con,
 )
 ```
+
+For concrete recipe-style filters, including residential-only, parent-shell
+exclusion, and `CAR PARK SPACE`-style heuristics, see [Working with Ordnance
+Survey data](ordnance_survey.md#filtering-recipes).
 
 However, if different users will need different filters, you can also apply a filter _after_ pre-processing the whole dataset.  This will result in a small degradation in accuracy because indices and term frequencies will be computed globally, making them less discriminative.
 
@@ -105,6 +117,23 @@ matcher = AddressMatcher(
 )
 result = matcher.match()
 ```
+
+### Candidate-pool policy versus cleaning
+
+Be careful with rules that look like cleaning rules but are really eligibility rules.
+
+For example, if your organisation never wants to match to records such as car
+park spaces, garages, or parent shells, that is usually best implemented as a
+canonical filter, not as a string-cleaning step that edits address text.
+
+As a general rule:
+
+- use cleaning to normalise text
+- use filtering to decide which canonical records may participate in matching
+
+If you are considering a new heuristic exclusion such as `CAR PARK SPACE%`,
+benchmark it first on a representative dataset and inspect the overlay
+precision-recall chart before treating it as standard policy.
 
 
 

--- a/docs/site/ordnance_survey.md
+++ b/docs/site/ordnance_survey.md
@@ -84,7 +84,7 @@ matching.
 You can use it as follows.  Make sure you have your `package_id`, `version_id`, and API key/secret to hand from step 1.
 
 ```bash
-# Config wizard — point the tool to your data package
+# Config wizard: point the tool to your data package
 uvx --from ukam-os-builder ukam-os-setup
 ```
 
@@ -103,7 +103,7 @@ If you're linking to a small canonical dataset (of say, less than 500,000 rows),
 
 If you're linking to a large canonical dataset (for example, national-scale NGD), then we recommend a one-time pre-processing step. It computes reusable datasets (indices and feature tables) once, so subsequent matching runs are fast.
 
-For a local council region, skip this step — everything runs on the fly.
+For a local council region, skip this step. Everything runs on the fly.
 
 
 
@@ -123,6 +123,201 @@ prepare_canonical_folder(
 ```
 
 The prepared folder can be used for all subsequent matching runs.
+
+## Filtering before canonical preparation
+
+If you already know that some Ordnance Survey records should never be eligible
+matches for your use case, it is usually better to filter them out before
+calling `prepare_canonical_folder()`.
+
+This is the right place for organisation-wide policy decisions such as:
+
+- residential-only matching
+- excluding parent shells
+- excluding clearly unwanted residential subtypes such as garages
+- excluding known nuisance classes that your users would not expect to match to
+
+Applying these exclusions before preparation has two advantages:
+
+1. Term frequencies and the inverted index are built on the reduced canonical
+    pool, which usually improves discrimination.
+2. The prepared folder itself becomes policy-aligned, so downstream users are
+    less likely to leave unwanted records in by accident.
+
+By contrast, `canonical_address_filter=` on `AddressMatcher` is most useful when
+different users need different subsets from the same prepared folder, or when
+you are running exploratory experiments.
+
+### Do not treat policy exclusions as text cleaning
+
+Be careful not to mix up two different concerns:
+
+- text cleaning, such as normalising abbreviations or whitespace
+- candidate-pool policy, such as deciding that `RG` garages or `P` parent shells
+  should not be eligible matches
+
+If a record should not participate in matching, prefer filtering the canonical
+rows rather than stripping words from `clean_full_address`.
+
+For example, excluding records that start with `CAR PARK SPACE` is usually a
+candidate-pool decision, not a string-normalisation rule.
+
+### AddressBase classification codes
+
+The `classificationcode` column is the main Ordnance Survey field to use for
+this. Officially, Ordnance Survey defines the scheme as a hierarchical code with
+primary, secondary, tertiary, and quaternary levels.
+
+- Official OS classification documentation:
+  [addressclassificationcodevalue](https://docs.os.uk/osngd/code-lists/code-lists-overview/addressclassificationcodevalue)
+- Practical AddressBase summary:
+  [Ideal Postcodes classification guide](https://docs.ideal-postcodes.co.uk/docs/data/classification-codes/)
+
+The main top-level groups are:
+
+| Code prefix | Meaning | Typical matching implication |
+|---|---|---|
+| `C` | Commercial | Usually exclude for residential-only matching |
+| `L` | Land | Usually exclude unless your messy data contains land parcels or parks |
+| `M` | Military | Usually exclude unless you expect military addresses |
+| `O` | Other, Ordnance Survey only | Usually exclude |
+| `P` | Parent shell | Often exclude from candidate pools |
+| `R` | Residential | Usually include for residential matching |
+| `U` | Unclassified | Review carefully before including |
+| `X` | Dual use | Review carefully, may be useful in mixed datasets |
+| `Z` | Object of interest | Usually exclude from postal-style matching |
+
+The most important residential secondary groups are:
+
+| Code | Meaning | Typical matching implication |
+|---|---|---|
+| `RD` | Dwelling | Usually include |
+| `RG` | Garage | Often exclude for household or council-tax matching |
+| `RH` | House in multiple occupation | Often include, depending on the source data |
+| `RI` | Residential institution | Include only if your messy data covers care homes, halls, prisons, and similar settings |
+
+Common commercial secondary groups include:
+
+| Code | Meaning |
+|---|---|
+| `CA` | Agricultural |
+| `CB` | Ancillary building |
+| `CC` | Community services |
+| `CE` | Education |
+| `CH` | Hotel, motel, boarding, guest house |
+| `CI` | Industrial |
+| `CL` | Leisure |
+| `CM` | Medical |
+| `CN` | Animal centre |
+| `CO` | Office |
+| `CR` | Retail |
+| `CT` | Transport |
+| `CU` | Utility |
+| `CX` | Emergency or rescue service |
+
+Other commonly relevant non-residential groups are:
+
+| Code | Meaning |
+|---|---|
+| `LD` | Land, development |
+| `LP` | Land, park |
+| `PP` | Parent shell, property shell |
+| `OR` | Royal Mail infrastructure |
+| `UC` | Awaiting classification |
+| `UP` | Pending internal investigation |
+
+Ordnance Survey also defines deeper levels. For example:
+
+- `RD02` means detached house
+- `CE01` means college
+- `RI01` means care home
+
+For a full, maintained list of tertiary and quaternary codes, use the official
+OS page above rather than copying the entire code set into local documentation.
+
+### Recommended filtering approach
+
+For most projects, use this order of preference:
+
+1. Filter the raw canonical data before `prepare_canonical_folder()` if the rule
+    is stable and should apply to all users.
+2. Use `canonical_address_filter=` only when different users need different
+    subsets from the same prepared folder.
+3. Avoid implementing record-level policy by stripping address prefixes during
+    cleaning unless you are certain the prefix is lexical noise rather than a
+    meaningful subtype.
+
+### Filtering recipes
+
+Treat the following as starting-point recipes rather than universal rules.
+Prefer classification-based exclusions where the source supports them, and use
+text-pattern exclusions as a fallback heuristic that you validate on your own
+data.
+
+Residential only:
+
+```python
+df_canonical = df_canonical.filter("substr(classificationcode, 1, 1) = 'R'")
+```
+
+Residential only, excluding garages and parent shells:
+
+```python
+from uk_address_matcher import prepare_canonical_folder
+
+prepare_canonical_folder(
+    df_canonical.filter(
+        "substr(classificationcode, 1, 1) = 'R' "
+        "AND substr(classificationcode, 1, 2) <> 'RG' "
+        "AND substr(classificationcode, 1, 2) <> 'PP'"
+    ),
+    output_folder="./ukam_prepared_canonical",
+    con=con,
+    overwrite=True,
+)
+```
+
+Residential only, excluding ancillary residential records with a local prefix
+heuristic:
+
+```python
+from uk_address_matcher import prepare_canonical_folder
+
+prepare_canonical_folder(
+    df_canonical.filter(
+        "substr(classificationcode, 1, 1) = 'R' "
+        "AND clean_full_address NOT LIKE 'CAR PARK SPACE%' "
+        "AND clean_full_address NOT LIKE 'GARAGE %'"
+    ),
+    output_folder="./ukam_prepared_canonical",
+    con=con,
+    overwrite=True,
+)
+```
+
+Parent shells only:
+
+```python
+df_parent_shells = df_canonical.filter("substr(classificationcode, 1, 2) = 'PP'")
+```
+
+If you need different subsets for different users, keep the broader prepared
+folder and apply the restriction later with `canonical_address_filter=`.
+
+### Benchmark local heuristics before standardising them
+
+Text-pattern exclusions such as `CAR PARK SPACE%` are often useful, but they are
+not as stable as top-level classification filters. Before adopting one as an
+organisation-wide policy:
+
+1. Benchmark it against the same-stage baseline for your target dataset.
+2. Read the overlay precision-recall chart, not just the headline metrics.
+3. Check whether gains are broad or only come from a narrow recall band.
+4. Promote it into standard documentation or helper code only if it helps
+   consistently across more than one representative dataset.
+
+This keeps the core API generic while still letting you build up a catalogue of
+tested filtering recipes over time.
 
 ## Step 5: Match
 

--- a/uv.lock
+++ b/uv.lock
@@ -3002,7 +3002,7 @@ wheels = [
 
 [[package]]
 name = "uk-address-matcher"
-version = "1.1.2"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## PR Summary

This PR adds further notes and instructions on how to better handle the canonical OS dataset. From what I can see, there are lots of examples where car park and garage spaces are being labelled under RD06 (residential subdomains). This is also noted in https://github.com/moj-analytical-services/uk_address_matcher/issues/364.

When removed, we are seeing a significant overall improvement to match rates:
<img width="1012" height="751" alt="Screenshot 2026-05-29 at 16 46 31" src="https://github.com/user-attachments/assets/a5bf6cdc-752e-463f-af38-2478e7e2c502" />

To compliment this, I've also added some notes on classification codes in the OS data and how users can easily filter data using these.
