### PR TITLE
feat(splink): better match records missing "FLAT"

### DIFF
--- a/tests/test_flat_matching.py
+++ b/tests/test_flat_matching.py
@@ -432,7 +432,7 @@ def test_flat_number_letter_one_sided_penalty_not_fuzzy_equivalence():
 
 
 def test_same_letter_number_one_sided_scores_between_fuzzy_and_mismatch():
-    """2A vs FLAT 2A should beat a letter mismatch without outranking fuzzy equivalence."""
+    """2A vs FLAT 2A should beat a letter mismatch"""
     con = duckdb.connect()
 
     messy_values = ", ".join(

--- a/tests/test_flat_matching.py
+++ b/tests/test_flat_matching.py
@@ -240,6 +240,23 @@ ONE_SIDED_NUMBER_LETTER_CANONICAL = [
     ("c_flat_2_reference", "FLAT 2 10 KINGS ROAD LONDON", "SW3 4ND"),
 ]
 
+SAME_LETTER_NUMBER_ONESIDED_MESSY = [
+    ("m_missing_number_2a", "2A GARDENSVILLE THE ROAD LONDON", "EC1V 9NX"),
+]
+
+SAME_LETTER_NUMBER_ONESIDED_CANONICAL = [
+    (
+        "c_same_letter_match",
+        "FLAT 2A GARDENSVILLE THE ROAD LONDON",
+        "EC1V 9NX",
+    ),
+    (
+        "c_letter_mismatch",
+        "FLAT 2B GARDENSVILLE THE ROAD LONDON",
+        "EC1V 9NX",
+    ),
+]
+
 CARDIFF_ROOM_VS_BUILDING_MESSY = [
     (
         "m_cardiff_room_23",
@@ -411,6 +428,73 @@ def test_flat_number_letter_one_sided_penalty_not_fuzzy_equivalence():
         "Expected one-sided letter case to score lower than fuzzy equivalence; "
         f"got one_sided={one_sided_bf:.6f}, "
         f"fuzzy_reference={fuzzy_reference_bf:.6f}."
+    )
+
+
+def test_same_letter_number_one_sided_scores_between_fuzzy_and_mismatch():
+    """2A vs FLAT 2A should beat a letter mismatch without outranking fuzzy equivalence."""
+    con = duckdb.connect()
+
+    messy_values = ", ".join(
+        f"('{uid}'::VARCHAR, '{addr}'::VARCHAR, '{pc}'::VARCHAR)"
+        for uid, addr, pc in SAME_LETTER_NUMBER_ONESIDED_MESSY
+    )
+    messy_rel = con.sql(f"""
+        SELECT * FROM (VALUES {messy_values})
+        AS t(unique_id, address_concat, postcode)
+    """)
+
+    canon_values = ", ".join(
+        f"('{uid}'::VARCHAR, '{addr}'::VARCHAR, '{pc}'::VARCHAR)"
+        for uid, addr, pc in SAME_LETTER_NUMBER_ONESIDED_CANONICAL
+    )
+    canon_rel = con.sql(f"""
+        SELECT * FROM (VALUES {canon_values})
+        AS t(unique_id, address_concat, postcode)
+    """)
+
+    messy_cleaned = prepare_data_for_matching(messy_rel, con=con)
+    canon_cleaned = prepare_data_for_matching(canon_rel, con=con)
+
+    linker = _get_linker(
+        messy_cleaned,
+        canon_cleaned,
+        con=con,
+        include_full_postcode_block=True,
+        include_outside_postcode_block=False,
+        retain_intermediate_calculation_columns=True,
+    )
+    predictions = linker.inference.predict(threshold_match_probability=0.00001)
+    results_df = predictions.as_pandas_dataframe()
+
+    def _row_for(canonical_id: str):
+        row = results_df[
+            (results_df["unique_id_l"] == "m_missing_number_2a")
+            & (results_df["unique_id_r"] == canonical_id)
+            | (
+                (results_df["unique_id_r"] == "m_missing_number_2a")
+                & (results_df["unique_id_l"] == canonical_id)
+            )
+        ]
+        assert not row.empty, f"Missing comparison row for {canonical_id}"
+        return row.iloc[0]
+
+    same_letter_row = _row_for("c_same_letter_match")
+    mismatch_row = _row_for("c_letter_mismatch")
+    same_letter_bf = float(same_letter_row["bf_flat_identity"])
+    mismatch_bf = float(mismatch_row["bf_flat_identity"])
+
+    assert same_letter_bf > 1.0, (
+        "Expected 2A vs FLAT 2A to receive a positive flat-identity signal; "
+        f"got bf_flat_identity={same_letter_bf:.6f}."
+    )
+    assert same_letter_bf > mismatch_bf, (
+        "Expected same-letter one-sided-number case to score above a true letter "
+        f"mismatch; got same_letter={same_letter_bf:.6f}, mismatch={mismatch_bf:.6f}."
+    )
+    assert same_letter_bf < 13.0, (
+        "Expected same-letter one-sided-number case to stay below full fuzzy "
+        f"equivalence; got bf_flat_identity={same_letter_bf:.6f}."
     )
 
 

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -188,6 +188,14 @@
                     "fix_u_probability": true
                 },
                 {
+                    "sql_condition": "flat_letter_l IS NOT NULL\n    AND flat_letter_l = flat_letter_r\n    AND (\n        (flat_number_l IS NULL AND flat_number_r IS NOT NULL)\n        OR (flat_number_l IS NOT NULL AND flat_number_r IS NULL)\n    )\n    AND flat_positional_l IS NULL\n    AND flat_positional_r IS NULL",
+                    "label_for_charts": "Same letter, number one-sided",
+                    "m_probability": 4.0,
+                    "u_probability": 1,
+                    "fix_m_probability": true,
+                    "fix_u_probability": true
+                },
+                {
                     "sql_condition": "flat_positional_l IS NOT NULL\n    AND flat_positional_r IS NOT NULL\n    AND flat_positional_l != flat_positional_r",
                     "label_for_charts": "Both positional but different floors",
                     "m_probability": 0.00390625,


### PR DESCRIPTION
For example:
21A A HOUSE LONDON would not previously match consistently to FLAT 21A A HOUSE LONDON due to the negative penalty we were applying when the record wasn't being flagged as a "FLAT"

<img width="964" height="736" alt="Screenshot 2026-06-01 at 08 50 44" src="https://github.com/user-attachments/assets/02427775-34de-4a54-8781-07606b7a4c76" />
