### PR TITLE
docs: add comprehensive Copilot guidance for prompts + skills

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,48 @@
+# Copilot Customizations
+
+This folder contains project-specific Copilot guidance for `uk_address_matcher`.
+
+## What Lives Here
+
+- `copilot-instructions.md`
+  - lean top-level routing
+- `instructions/`
+  - always-on or file-scoped rules via `applyTo`
+- `prompts/`
+  - short user-invocable routers for common task shapes
+- `skills/`
+  - on-demand workflow bundles for repeated multi-step work
+- `workflows/`
+  - GitHub Actions and repository automation
+
+## How To Choose The Right Surface
+
+- Use `instructions` for file-scoped conventions that should apply automatically.
+- Use `skills` for repeated multi-step workflows that would otherwise require repo exploration.
+- Use `prompts` only as thin routers when a short user-invocable entrypoint is still useful.
+
+## Current High-Value Skills
+
+- `skills/benchmark-experiment/`
+  - benchmark runs, replay audits, overlay charts, loser viewers, env vars, and persisted artefacts
+
+## Why This Structure Exists
+
+The goal is to keep always-loaded context small and move heavy workflows into on-demand assets.
+
+That means:
+
+- broad instructions should stay lean
+- prompts should avoid restating long workflows
+- recurring procedures should live in skills or developer docs rather than being rediscovered from scripts each time
+
+## Developer-Facing Measurement Notes
+
+See:
+
+- `docs/developer/copilot-session-measurement.md`
+- `docs/developer/copilot-token-estimation.md`
+
+Those notes explain how to estimate Copilot task cost in this repo and compare before-and-after efficiency changes.
+
+Release work is intentionally left out of the Skills layer for now. In this repo it is primarily a human-run local workflow, so the release scripts and developer docs are a better home than an agent-facing Skill.

--- a/.github/instructions/data-handling.instructions.md
+++ b/.github/instructions/data-handling.instructions.md
@@ -1,10 +1,10 @@
 ---
 applyTo:
-  - "**/*.py"
-  - "**/*.sql"
+  - "benchmarking/**/*.py"
+  - "docs/findings/**/*.md"
   - "example_data/**/*"
   - "tests/**/*"
-  - "scripts/**/*"
+  - "scripts/reduced_canonical.py"
 ---
 
 # Data handling and safety

--- a/.github/instructions/repo-workflow.instructions.md
+++ b/.github/instructions/repo-workflow.instructions.md
@@ -1,6 +1,15 @@
 ---
 applyTo:
-  - "**"
+  - "**/*.py"
+  - "**/*.sql"
+  - ".github/**/*.md"
+  - "docs/developer/**/*.md"
+  - "docs/findings/**/*.md"
+  - "CHANGELOG.md"
+  - "pyproject.toml"
+  - "shell/**/*.sh"
+  - ".github/workflows/**/*.yml"
+  - ".github/workflows/**/*.yaml"
 ---
 
 # Repository workflow and change hygiene

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,6 +1,8 @@
 ---
 applyTo:
-  - "**"
+  - "**/*.py"
+  - "**/*.sql"
+  - "tests/**/*"
 ---
 
 # Testing expectations

--- a/.github/prompts/benchmark-experiment.prompt.md
+++ b/.github/prompts/benchmark-experiment.prompt.md
@@ -1,68 +1,23 @@
 ---
 mode: ask
-description: "Run a benchmark experiment end-to-end: optionally rebuild the reduced canonical, execute benchmarking/run_benchmarking.py, persist the comparison, and summarise the run directory outputs."
+description: "Use the benchmark-experiment skill for benchmark runs, persisted comparisons, and benchmark workflow routing with minimal prompt duplication."
 ---
 
-Run a benchmark experiment for `uk_address_matcher` using this workflow:
+Use the `benchmark-experiment` skill for benchmark experiment work in `uk_address_matcher`.
 
-1. **Read the right instructions first**
-   - Read `.github/instructions/benchmark-experiments.instructions.md`.
-   - Then read any additionally relevant instruction files for SQL, Python, testing, and data handling.
+Goal:
 
-2. **Confirm the experiment surface**
-   - Identify the dataset(s), model/stage change, threshold change, and comparison baseline.
-   - State whether a reduced-canonical rebuild is required.
+- resolve the benchmark request end to end with the canonical workflow and the minimum necessary repo exploration
 
-3. **Rebuild canonical only when needed**
-   - If upstream cleaned features or canonical-side fields changed, rebuild the reduced canonical via `uv run python scripts/reduced_canonical.py`.
-   - Do not invent a new rebuild workflow unless the existing script is broken.
+Success means:
 
-4. **Use `benchmarking/run_benchmarking.py` as the entrypoint**
-   - Make only the smallest edits needed to set:
-     - `SELECTED_DATASETS`,
-     - `STAGES`,
-     - `COMPARISON_BASELINE_RUN_ID`.
-   - Keep persistence enabled.
+- `.github/instructions/benchmark-experiments.instructions.md` is read first
+- the benchmark skill assets provide the exact commands, env vars, and artefact paths
+- persisted artefacts are used before rerunning work
+- rebuilds and reruns happen only when the existing evidence is insufficient or stale
 
-5. **Run the experiment with `uv`**
-   - Prefer `uv run python benchmarking/run_benchmarking.py`.
-   - Capture the resulting run ID and run directory.
+Stop rules:
 
-6. **Persist and inspect outputs**
-   - Point to the run directory under `benchmarking/results/<dataset>/<date>/<run_id>/`.
-   - Summarise the key artefacts there, not just the terminal output.
-   - Record the exact run IDs, exact changed settings, and the exact files written.
-
-7. **Write an experiment record, not just a summary**
-   - Include:
-     - the question being tested,
-     - exact changes made,
-     - no-change controls,
-     - headline metrics before and after,
-     - model-versus-threshold effect split when relevant,
-     - paths to the persisted artefacts.
-   - Use concrete numbers, not qualitative phrases alone.
-
-8. **Use the overlay precision-recall chart as the primary chart**
-   - Prefer the chart produced via the comparison flow that uses `uk_address_matcher/analysis/overlay_precision_recall_charts.py`.
-   - Read the persisted overlay Vega-Lite spec at `charts/precision_recall_overlay_<baseline>_vs_<current>.vl.json` when it exists.
-   - Base the final conclusion on that overlay spec first, not only on headline metric deltas.
-   - Interpret it explicitly:
-     - where the comparison is better or worse,
-     - whether the gain is broad or localised,
-     - whether false positives rise materially.
-   - If the overlay spec and the headline summary disagree, say so explicitly and treat the overlay as the primary evidence.
-
-9. **If the user wants explanation, split the effect cleanly**
-   - Separate model-change effect from threshold-change effect.
-   - Use persisted comparison artefacts and reruns only where necessary.
-
-10. **Validate**
-   - Run targeted tests for any persistence/reporting or model changes.
-   - Report commands run and any blockers.
-
-Constraints:
-- Prefer persisted artefacts over one-off notebook output.
-- Keep diffs minimal and reversible.
-- Do not create bespoke experiment scripts when the repo already has the right entrypoints.
-- If provenance is missing from persisted reports, fix the persistence/reporting path rather than working around it.
+- do not rebuild canonical data unless upstream cleaned features or canonical-side fields changed
+- do not rerun a benchmark just to restate numbers already available in persisted artefacts
+- if the task is not really a benchmark experiment, do not force this workflow

--- a/.github/prompts/bugfix.prompt.md
+++ b/.github/prompts/bugfix.prompt.md
@@ -1,21 +1,30 @@
 ---
 mode: ask
+description: "Resolve a bug in uk_address_matcher with a root-cause-first fix and targeted validation."
 ---
 
-Fix a bug in `uk_address_matcher` with a root-cause-first approach:
+Resolve the bug end to end with a root-cause-first approach.
 
-1. **Reproduce**
-   - Capture failing behaviour with a targeted test (or identify existing failing test).
-2. **Diagnose**
-   - Explain root cause briefly, citing the affected module/stage.
-3. **Patch**
-   - Apply the smallest safe code change to fix the root cause.
-4. **Validate**
-   - Run targeted `uv run pytest ...` tests, then broader relevant tests.
-5. **Guard**
-   - Add/adjust regression coverage so the bug does not reappear.
-6. **Summarise**
-   - Bug, root cause, fix, and test evidence.
+Success means:
+
+- the failing behaviour is reproduced or anchored to an existing failing test
+- the owning defect is fixed with the smallest safe code change
+- regression coverage is added or updated where applicable
+- targeted `uv run pytest ...` validation passes before any broader check
+
+Working rules:
+
+- start from the failing command, test, file, symbol, or nearby implementation surface
+- fix the root cause rather than layering on defensive patches
+- keep the diff minimal and focused
+- if SQL stages are involved, follow the matching `.github/instructions/*.instructions.md` guidance
+
+Report:
+
+- bug summary
+- root cause
+- fix
+- validation evidence
 
 Constraints:
 - Keep changes minimal and focused.

--- a/.github/prompts/new-feature.prompt.md
+++ b/.github/prompts/new-feature.prompt.md
@@ -1,24 +1,30 @@
 ---
 mode: ask
+description: "Implement a focused feature in uk_address_matcher with clear success criteria and targeted validation."
 ---
 
-Implement a new feature for `uk_address_matcher` using this structure:
+Implement the feature with the smallest design that satisfies the request.
 
-1. **Confirm scope**
-   - Restate feature goal, in-scope/out-of-scope items, and acceptance criteria.
-2. **Read context**
-   - Check relevant `.github/instructions/*.instructions.md` files and relevant modules (`cleaning`, `linking_model`, `sql_pipeline`, tests).
-3. **Plan**
-   - Propose minimal design aligned with existing patterns.
-   - Identify files to change and tests to add/update.
-4. **Implement**
-   - Make surgical edits only.
-   - Reuse existing helpers and conventions.
-5. **Test**
-   - Run targeted tests first, then wider tests where risk warrants.
-   - Use `uv run pytest` commands only.
-6. **Report**
-   - Summarise changes, test results, and any follow-up risks.
+Success means:
+
+- scope and acceptance criteria are clear before the main edit
+- the implementation follows existing `cleaning`, `linking_model`, `sql_pipeline`, and test patterns
+- only the necessary files are changed
+- targeted `uv run pytest ...` validation is run for the touched behaviour
+
+Working rules:
+
+- read the relevant `.github/instructions/*.instructions.md` files first
+- prefer the existing abstraction that already owns the behaviour
+- reuse helpers and conventions before adding new ones
+- keep follow-up risks and open questions explicit if they materially affect the design
+
+Report:
+
+- feature scope
+- main design choice
+- changed behaviour
+- validation evidence
 
 Constraints:
 - British English.

--- a/.github/prompts/rebuild-reduced-canonical.prompt.md
+++ b/.github/prompts/rebuild-reduced-canonical.prompt.md
@@ -1,28 +1,25 @@
 ---
 mode: ask
-description: "Quickly rebuild the reduced canonical dataset using the repository's standard script and report the exact source, output, and readiness for benchmarking."
+description: "Use the benchmark-experiment skill to rebuild the reduced canonical dataset with the standard workflow and report readiness for benchmarking."
 ---
 
-Rebuild the reduced canonical dataset for `uk_address_matcher` with the standard repository workflow:
+Use the `benchmark-experiment` skill for this workflow.
 
-1. **Read the experiment workflow instructions**
-   - Read `.github/instructions/benchmark-experiments.instructions.md` and any relevant data-handling instructions.
+Goal:
 
-2. **Use the existing rebuild path**
-   - Prefer `uv run python scripts/reduced_canonical.py`.
-   - Do not invent a one-off canonical-preparation script unless the existing script is broken.
+- rebuild the reduced canonical dataset with the standard repository path and report whether it is ready for the next benchmark run
 
-3. **Verify the rebuild inputs and outputs**
-   - Report the source canonical path.
-   - Report the output folder.
-   - Report the filtered row count if available.
+Success means:
 
-4. **Check readiness for benchmarking**
-   - Confirm whether the rebuilt folder is the path used by `benchmarking/settings.py` or by the current benchmark workflow.
-   - Flag any mismatch explicitly.
+- `.github/instructions/benchmark-experiments.instructions.md` is used first
+- the standard rebuild path is used unless it is broken
+- the source path, output path, and filtered row count are reported when available
+- readiness for the next benchmark run is stated clearly
 
-5. **Close with next-step readiness**
-   - State whether the reduced canonical is ready for the next benchmark run.
+Stop rules:
+
+- do not invent a bespoke canonical-preparation script unless the standard rebuild path is broken
+- do not treat the rebuild as successful until the output path and benchmark-readiness check are both reported
 
 Constraints:
 - Use `uv`.

--- a/.github/prompts/record-level-audit.prompt.md
+++ b/.github/prompts/record-level-audit.prompt.md
@@ -1,54 +1,22 @@
 ---
 mode: ask
-description: "Generate a human-readable record-level audit for a persisted benchmark run using MatchResult, _splink_predictions(), and an elegant markdown plus JSON companion in the run directory."
+description: "Use the benchmark-experiment skill for persisted record-level benchmark audits and loser-viewer workflows."
 ---
 
-Create a record-level audit for a benchmark run in `uk_address_matcher` using this workflow:
+Use the `benchmark-experiment` skill for persisted benchmark audits.
 
-1. **Read context first**
-   - Read `.github/instructions/benchmark-experiments.instructions.md`.
-   - Confirm the dataset, current run ID, baseline run ID, and whether the user wants newly-correct rows, newly-wrong rows, or both.
+Goal:
 
-2. **Start from persisted artefacts**
-   - Read the existing `manifest.json`, `accuracy_table.json`, and `stage_diagnostics.json` for the referenced runs.
-   - Confirm aggregate numbers before doing any rerun work.
+- explain row-level benchmark differences from persisted evidence before rerunning anything
 
-3. **Reconstruct the right variants**
-   - If needed, reconstruct the baseline variant using the current reduced canonical plus the prior model settings.
-   - Use separate DuckDB connections per variant.
-   - Enable `retain_intermediate_calculation_columns=True` when rerunning Splink.
+Success means:
 
-4. **Extract row-level evidence**
-   - Use `MatchResult.matches(all_columns=True)` and `MatchResult._splink_predictions()`.
-   - Extract per-candidate weight provenance from `bf_*` columns.
-   - Verify left/right orientation before drawing conclusions.
+- `.github/instructions/benchmark-experiments.instructions.md` is read first
+- the persisted run directory is inspected before any replay or regeneration step
+- replay-audit and loser-viewer commands come from the benchmark skill assets
+- any new audit output stays human-readable and writes the JSON companion when required
 
-5. **Produce two artefacts in the run directory**
-   - a human-readable markdown audit,
-   - a machine-readable JSON companion.
+Stop rules:
 
-6. **Format the markdown for manual review**
-   - Start each reviewed example with the original source address in the heading.
-   - Show `Messy input`, `Expected canonical`, and `Current predicted canonical` side by side.
-   - Put the quick-review table for all newly-wrong rows near the top.
-   - Keep weight summaries short and legible.
-   - Deduplicate candidate rows.
-   - Avoid raw JSON dumps in the main reading flow unless they add clear value.
-
-7. **When auditing wrong matches**
-   - Add an opinion label per row:
-     - `Likely genuinely wrong`,
-     - `Likely source mislabel`,
-     - `Possibly source mislabel`,
-     - `Unclear`.
-   - Explain the opinion briefly using the messy row, expected row, predicted row, and weight evidence.
-
-8. **Close out clearly**
-   - Report the markdown path and JSON path.
-   - Summarise the main movement in terms of feature effect versus threshold effect.
-   - If a comparison overlay chart exists, reference it and explain how its precision-gap view aligns with the row-level findings.
-
-Constraints:
-- Prefer elegant markdown over exhaustive raw dumps.
-- Keep the JSON companion as the source of full structured detail.
-- If historical baseline artefacts are incompatible with the current code path, reconstruct rather than forcing stale data.
+- do not rerun a replay audit if the persisted artefacts already answer the question
+- do not force this workflow when the task is not really a persisted benchmark audit

--- a/.github/prompts/refactor-safe.prompt.md
+++ b/.github/prompts/refactor-safe.prompt.md
@@ -1,21 +1,29 @@
 ---
 mode: ask
+description: "Perform a behaviour-preserving refactor with explicit boundaries and targeted validation."
 ---
 
-Perform a safe refactor in `uk_address_matcher`:
+Perform the refactor without behavioural drift.
 
-1. **Set boundaries**
-   - Define what will and will not change (no behavioural drift).
-2. **Baseline**
-   - Identify existing tests that protect current behaviour.
-3. **Refactor plan**
-   - Break into small, reviewable edits with low risk.
-4. **Execute**
-   - Preserve public interfaces unless explicitly requested otherwise.
-5. **Verify**
-   - Run targeted tests after each logical chunk where practical.
-6. **Final check**
-   - Run broader relevant tests and summarise equivalence evidence.
+Success means:
+
+- the refactor boundary is explicit before edits begin
+- existing behaviour is anchored with nearby tests or other concrete checks
+- public interfaces stay stable unless the user asked otherwise
+- targeted validation is run after each meaningful slice where practical
+
+Working rules:
+
+- break the work into small, reviewable edits
+- prefer local simplification over repo-wide cleanup
+- preserve DuckDB/Splink pipeline behaviour and placeholders
+
+Report:
+
+- refactor boundary
+- preserved behaviour evidence
+- main internal simplification
+- validation evidence
 
 Constraints:
 - No opportunistic rewrites.

--- a/.github/prompts/sql-stage.prompt.md
+++ b/.github/prompts/sql-stage.prompt.md
@@ -1,25 +1,29 @@
 ---
 mode: ask
+description: "Add or change a SQL pipeline stage with explicit stage contracts and targeted stage validation."
 ---
 
-Add or modify a SQL pipeline stage in `uk_address_matcher`:
+Add or modify the SQL pipeline stage without breaking downstream contracts.
 
-1. **Context read**
-   - Review relevant `.github/instructions/*.instructions.md` files, existing stage patterns, and dependent downstream stages.
-2. **Design**
-   - Define stage intent, inputs, outputs, and dependency placeholders.
-3. **Implement**
-   - Use `@pipeline_stage` and return `CTEStep` entries.
-   - Use explicit DuckDB-compatible CTE SQL.
-   - Reference prior outputs via placeholders (e.g. `{annotated_exact_matches}`).
-4. **Enum safety**
-   - If match reasons change, ensure `MatchReason` enum registration is handled.
-5. **Tests**
-   - Add/update stage tests, including edge cases and downstream compatibility checks.
-6. **Run tests**
-   - Execute targeted `uv run pytest` commands; expand if needed.
-7. **Report**
-   - Summarise SQL changes, affected stages, and test evidence.
+Success means:
+
+- the stage intent, inputs, outputs, and dependencies are explicit
+- the implementation stays inside the pipeline framework with DuckDB-compatible SQL
+- downstream-required columns and enum registrations remain correct
+- targeted stage tests pass before any broader checks
+
+Working rules:
+
+- review the relevant `.github/instructions/*.instructions.md` files and the owning stage chain first
+- use `@pipeline_stage`, `CTEStep`, and dependency placeholders such as `{annotated_exact_matches}`
+- treat missing columns, enum updates, and downstream compatibility as first-class constraints
+
+Report:
+
+- stage intent
+- affected stages
+- SQL or contract changes
+- validation evidence
 
 Constraints:
 - Minimal diff, no unrelated refactors.

--- a/.github/skills/benchmark-experiment/SKILL.md
+++ b/.github/skills/benchmark-experiment/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: benchmark-experiment
+description: "Use when: running benchmark experiments, rebuilding reduced canonical data, comparing persisted benchmark runs, generating replay audits, inspecting overlay charts, or regenerating structural TF loser viewers. Provides exact commands, env vars, artefact paths, and workflow selection for uk_address_matcher experiments."
+---
+
+# Benchmark Experiment Skill
+
+Use this skill for recurring benchmark workflows in `uk_address_matcher`.
+
+## Goal
+
+- Resolve benchmark experiments, persisted comparisons, and record-level audits without rediscovering commands, env vars, or artefact paths across the repo.
+
+## Success Criteria
+
+- The correct benchmark workflow is chosen.
+- Persisted artefacts are used before reruns where they already answer the question.
+- Rebuilds and reruns only happen when there is a concrete evidence gap.
+- Reports include run IDs, output paths, changed settings, and validation evidence.
+
+## Start Here
+
+- Read `.github/instructions/benchmark-experiments.instructions.md` first.
+- Then use the bundled assets in this skill instead of rediscovering commands across `benchmarking/`, `.github/prompts/`, and `docs/findings/`.
+
+## What This Skill Covers
+
+- Standard persisted benchmark runs via `benchmarking/run_benchmarking.py`
+- Reduced canonical rebuilds via `scripts/reduced_canonical.py`
+- Structural TF variant builds via `benchmarking/build_structural_tf_variant.py`
+- Replay audits and row-level loser analysis
+- Persisted artefact lookup under `benchmarking/results/<dataset>/<date>/<run_id>/`
+- Static loser-viewer regeneration for findings work
+
+## Bundled Assets
+
+- `commands.md` for exact command templates
+- `env-vars.md` for `UKAM_*` and dataset data-path variables
+- `artefacts.md` for persisted-run directory contents and which files to read first
+
+## Workflow Selection
+
+- Use `benchmarking/run_benchmarking.py` for normal persisted experiments.
+- Use `scripts/reduced_canonical.py` when upstream cleaned features or canonical-side fields changed and the standard reduced canonical needs rebuilding.
+- Use `benchmarking/build_structural_tf_variant.py` when the task is a structural TF ablation or variant comparison.
+- Use `benchmarking/structural_tf_recall_audit.py` when the user wants replayed threshold analysis or row-level lost-record exports.
+- Use `benchmarking/structural_tf_loser_viewer.py` when the user wants a portable HTML review surface from lost-record JSON.
+
+Start from persisted run artefacts whenever the request can be answered from existing outputs.
+
+## Working Rules
+
+- Prefer `uv run python -m ...` for benchmark entrypoints that rely on package imports.
+- Prefer persisted artefacts over console summaries.
+- Report run IDs, output directories, exact changed settings, and overlay chart paths.
+- If a workflow question is already answered in this skill, do not reopen broad repo exploration.
+
+## Stop Rules
+
+- Do not rebuild reduced canonical data unless upstream cleaned features or canonical-side fields changed.
+- Do not rerun a benchmark or replay audit just to restate numbers already available in persisted artefacts.
+- When enough persisted evidence exists to answer correctly, answer and stop.

--- a/.github/skills/benchmark-experiment/artefacts.md
+++ b/.github/skills/benchmark-experiment/artefacts.md
@@ -1,0 +1,45 @@
+# Benchmark Experiment Artefacts
+
+Persisted benchmark runs live under:
+
+```text
+benchmarking/results/<dataset>/<yyyy-mm-dd>/<run_id>/
+```
+
+## Files To Read First
+
+- `manifest.json`
+  - Run metadata, stage definition, summary, timings, and chart paths.
+
+- `accuracy_table.json`
+  - Precision, recall, F1, and stage outcome counts.
+
+- `stage_diagnostics.json`
+  - Rows entering each stage, matched counts, and timing detail.
+
+- `comparison_summary_<baseline>_vs_<current>.json`
+  - Machine-readable deltas for comparison runs.
+
+- `comparison_report_<baseline>_vs_<current>.md`
+  - Human-readable comparison summary.
+
+- `charts/precision_recall_overlay_<baseline>_vs_<current>.html`
+  - Primary comparison chart.
+
+- `charts/precision_recall_overlay_<baseline>_vs_<current>.vl.json`
+  - Vega-Lite spec for the same overlay chart.
+
+## When To Read Which Artefact
+
+- Start with `manifest.json` if you need run IDs, stage settings, summary counts, or output paths.
+- Read `comparison_report_*.md` first when the user wants a human-readable summary.
+- Read `comparison_summary_*.json` first when you need exact deltas or want to quote numbers programmatically.
+- Read the overlay chart or spec when the user asks whether the change is broadly better or worse across thresholds.
+- Read `stage_diagnostics.json` when the question is about runtime or stage-level movement.
+
+## Run Comparison Rules
+
+- `run_id` is the user-facing identifier.
+- Comparisons are dataset-specific.
+- `COMPARISON_BASELINE_RUN_ID = "latest"` is the default comparison mode in normal reruns.
+- Persisted artefacts are preferred over notebook output or raw terminal logs.

--- a/.github/skills/benchmark-experiment/commands.md
+++ b/.github/skills/benchmark-experiment/commands.md
@@ -1,0 +1,68 @@
+# Benchmark Experiment Commands
+
+These are the default command templates for recurring experiment work.
+
+## Run A Persisted Benchmark
+
+```bash
+export UKAM_OS_CANONICAL_PREPARED=/path/to/prepared/canonical
+uv run python -m benchmarking.run_benchmarking
+```
+
+Notes:
+
+- Run as a module so imports resolve correctly.
+- Keep `benchmarking/run_benchmarking.py` edits surgical: dataset selection, stages, and comparison baseline only.
+
+## Rebuild The Reduced Canonical
+
+```bash
+uv run python scripts/reduced_canonical.py
+```
+
+Use this when upstream cleaned features or canonical-side fields used by matching changed.
+
+## Build A Structural TF Variant
+
+```bash
+uv run python -m benchmarking.build_structural_tf_variant \
+  --filter-mode unit_only \
+  --output-dir /path/to/tmp/variant
+```
+
+Common modes:
+
+- `none`
+- `broad`
+- `unit_only`
+
+## Run A Structural TF Replay Audit
+
+```bash
+uv run python benchmarking/structural_tf_recall_audit.py \
+  --dataset-key hackney \
+  --baseline-run-id <baseline_run_id> \
+  --variant-run-id <variant_run_id> \
+  --baseline-canonical-path /path/to/baseline/canonical \
+  --variant-canonical-path /path/to/variant/canonical \
+  --baseline-filter-mode none \
+  --variant-filter-mode unit_only \
+  --output-dir benchmarking/results/hackney/<yyyy-mm-dd>/<variant_run_id>
+```
+
+This writes replayed overlay charts, markdown and JSON audits, and lost-record JSON.
+
+## Generate The Static Loser Viewer
+
+```bash
+uv run python benchmarking/structural_tf_loser_viewer.py \
+  --lost-records-json benchmarking/results/hackney/<yyyy-mm-dd>/<run_id>/structural_tf_lost_records_<baseline>_vs_<variant>.json \
+  --canonical-path /path/to/variant/canonical \
+  --output-html docs/findings/hackney_structural_tf_unit_only_loser_viewer.html
+```
+
+## Manual Run Comparison
+
+Use `COMPARISON_BASELINE_RUN_ID = "latest"` in `benchmarking/run_benchmarking.py` for the normal case.
+
+If you need a manual comparison helper, inspect `benchmarking/compare_runs.py` and the persisted run directories first.

--- a/.github/skills/benchmark-experiment/env-vars.md
+++ b/.github/skills/benchmark-experiment/env-vars.md
@@ -1,0 +1,43 @@
+# Benchmark Experiment Environment Variables
+
+## Core Experiment Variables
+
+- `UKAM_OS_CANONICAL_PREPARED`
+  - Path to the prepared canonical folder used by benchmarking.
+  - This folder normally contains `ukam_canonical_addresses.parquet`, `ukam_term_frequencies.parquet`, `ukam_inverted_index.parquet`, and `ukam_manifest.json`.
+
+- `UKAM_EXCLUDE_STRUCTURAL_TF_TOKENS`
+  - Structural TF filter enable/disable flag.
+  - Typical values: `1`, `0`, `true`, `false`.
+
+- `UKAM_STRUCTURAL_TF_TOKEN_FILTER_MODE`
+  - Structural TF filter mode.
+  - Supported modes in current code: `none`, `broad`, `unit_only`.
+
+## Dataset Source Variables
+
+These are defined in `benchmarking/config/datasets.py`.
+
+- `UKAM_ABERDEENSHIRE_DATA_PATH`
+- `UKAM_HACKNEY_DATA_PATH`
+- `UKAM_LAMBETH_DATA_PATH`
+- `UKAM_MID_SUSSEX_DATA_PATH`
+- `UKAM_RHONDDA_DATA_PATH`
+
+The configured value may point either to:
+
+- a directory or prefix, in which case the default dataset filename is appended
+- a specific `.csv`, `.parquet`, or `.xlsx` file
+
+## Resolution Rules
+
+- Benchmark settings are loaded through `benchmarking/settings.py`.
+- Dataset paths are resolved through `benchmarking/config/sources.py`.
+- Local dataset paths must exist.
+- S3 paths must start with `s3://`.
+
+## Practical Guidance
+
+- Treat `UKAM_OS_CANONICAL_PREPARED` as the main experiment switch for canonical variants.
+- When debugging a benchmark, report the exact canonical folder and dataset env var values that were in effect.
+- If a task only needs a persisted comparison readout, do not change env vars unnecessarily.


### PR DESCRIPTION
Added copilot notes and instructions to reduce total token consumption.

Now, the agent can work out where to go more rapidly or how to run an experiment without needing to be re-prompted multiple times.