### PR TITLE
fix: update JavaScript library paths in mkdocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,9 +73,9 @@ extra_css:
   - stylesheets/extra.css
 
 extra_javascript:
-  - https://cdn.jsdelivr.net/npm/vega@5
-  - https://cdn.jsdelivr.net/npm/vega-lite@5
-  - https://cdn.jsdelivr.net/npm/vega-embed@6
+  - https://cdn.jsdelivr.net/npm/vega@5/build/vega.min.js
+  - https://cdn.jsdelivr.net/npm/vega-lite@5/build/vega-lite.min.js
+  - https://cdn.jsdelivr.net/npm/vega-embed@6/build/vega-embed.min.js
 
 exclude_docs: |
   adr/


### PR DESCRIPTION
Was getting 

mkdocs-charts-plugin.js 200 script performance/:1147 3.0 kB 13 ms vega@5 (failed)net::ERR_BLOCKED_BY_ORB

on some browsers