### PR TITLE
Feature/improve overlay chart

### DIFF
--- a/tests/test_overlay_precision_recall_charts.py
+++ b/tests/test_overlay_precision_recall_charts.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from uk_address_matcher.analysis.overlay_precision_recall_charts import (
+    _LABEL_MIN_VERTICAL_GAP,
+    _OVERLAY_COLOUR_RANGE,
+    _apply_label_offsets,
+    _build_overlay_chart_definition,
+)
+
+
+def test_apply_label_offsets_separates_close_endpoint_labels() -> None:
+    adjusted = _apply_label_offsets(
+        [
+            {
+                "series_label": "Hackney 320bdce991462589",
+                "recall": 0.962,
+                "precision": 0.976,
+                "is_baseline": True,
+            },
+            {
+                "series_label": "Hackney 366b7bec7391f5df",
+                "recall": 0.958,
+                "precision": 0.974,
+                "is_baseline": False,
+            },
+            {
+                "series_label": "Hackney 739f3335b49a58f0",
+                "recall": 0.812,
+                "precision": 0.913,
+                "is_baseline": False,
+            },
+        ]
+    )
+
+    adjusted_by_label = {record["series_label"]: record for record in adjusted}
+    left = adjusted_by_label["Hackney 320bdce991462589"]
+    right = adjusted_by_label["Hackney 366b7bec7391f5df"]
+
+    assert (
+        abs(float(left["label_precision"]) - float(right["label_precision"]))
+        >= _LABEL_MIN_VERTICAL_GAP
+    )
+    assert left["label_has_connector"] or right["label_has_connector"]
+
+
+def test_overlay_chart_definition_includes_hover_guides_and_solid_labels() -> None:
+    chart_definition = _build_overlay_chart_definition(
+        curve_records=[
+            {
+                "series_id": "baseline",
+                "series_label": "Baseline",
+                "is_baseline": True,
+                "recall": 0.91,
+                "precision": 0.96,
+            },
+            {
+                "series_id": "comparison_1",
+                "series_label": "Comparison",
+                "is_baseline": False,
+                "recall": 0.89,
+                "precision": 0.955,
+            },
+        ],
+        diff_records=[],
+        label_records=[
+            {
+                "series_label": "Baseline",
+                "is_baseline": True,
+                "recall": 0.91,
+                "precision": 0.96,
+            },
+            {
+                "series_label": "Comparison",
+                "is_baseline": False,
+                "recall": 0.89,
+                "precision": 0.955,
+            },
+        ],
+    )
+
+    top_panel = chart_definition["vconcat"][0]
+    assert "params" not in chart_definition
+    assert "params" not in top_panel
+
+    hover_source_layer = next(
+        layer for layer in top_panel["layer"] if layer.get("params")
+    )
+    assert hover_source_layer["params"][0]["name"] == "curve_hover"
+
+    hover_rule_layers = [
+        layer
+        for layer in top_panel["layer"]
+        if layer.get("mark", {}).get("type") == "rule"
+        and layer.get("transform")
+        == [{"filter": {"param": "curve_hover", "empty": False}}]
+    ]
+    assert len(hover_rule_layers) == 2
+
+    label_layer = next(
+        layer
+        for layer in top_panel["layer"]
+        if layer.get("mark", {}).get("type") == "text"
+    )
+    assert "stroke" not in label_layer["mark"]
+    assert label_layer["encoding"]["y"]["field"] == "label_precision"
+
+    connector_layer = next(
+        layer
+        for layer in top_panel["layer"]
+        if layer.get("mark", {}).get("type") == "rule"
+        and layer.get("encoding", {}).get("y2", {}).get("field") == "label_precision"
+    )
+    assert connector_layer["transform"] == [{"filter": "datum.label_has_connector"}]
+
+    top_colour_scale = top_panel["layer"][0]["encoding"]["color"]["scale"]
+    assert top_colour_scale["domain"] == ["Baseline", "Comparison"]
+    assert top_colour_scale["range"] == _OVERLAY_COLOUR_RANGE[:2]
+
+    bottom_colour_scale = chart_definition["vconcat"][1]["layer"][1]["encoding"]["color"][
+        "scale"
+    ]
+    assert bottom_colour_scale["domain"] == ["Comparison"]
+    assert bottom_colour_scale["range"] == [_OVERLAY_COLOUR_RANGE[1]]

--- a/uk_address_matcher/analysis/chart_defs/precision_recall.json
+++ b/uk_address_matcher/analysis/chart_defs/precision_recall.json
@@ -28,9 +28,9 @@
   "mark": {
     "type": "area",
     "fillOpacity": 0.12,
-    "color": "#4C78A8",
+    "color": "#12436D",
     "line": {
-      "color": "#4C78A8"
+      "color": "#12436D"
     },
     "point": {
       "filled": true

--- a/uk_address_matcher/analysis/chart_defs/precision_recall_diff.json
+++ b/uk_address_matcher/analysis/chart_defs/precision_recall_diff.json
@@ -10,7 +10,7 @@
     {
       "mark": {
         "type": "rule",
-        "color": "#9AA1A6",
+        "color": "#A0A5B4",
         "strokeDash": [
           4,
           4
@@ -64,13 +64,13 @@
           "title": "Comparison",
           "scale": {
             "range": [
-              "#F58518",
-              "#54A24B",
-              "#E45756",
-              "#72B7B2",
-              "#EECA3B",
-              "#B279A2",
-              "#FF9DA6"
+              "#28A197",
+              "#F46A25",
+              "#801650",
+              "#1D609D",
+              "#30AA51",
+              "#A285D1",
+              "#00B1EB"
             ]
           }
         },

--- a/uk_address_matcher/analysis/overlay_precision_recall_charts.py
+++ b/uk_address_matcher/analysis/overlay_precision_recall_charts.py
@@ -9,15 +9,18 @@ from pathlib import Path
 from typing import Any
 
 _OVERLAY_COLOUR_RANGE = [
-    "#4C78A8",
-    "#F58518",
-    "#54A24B",
-    "#E45756",
-    "#72B7B2",
-    "#EECA3B",
-    "#B279A2",
-    "#FF9DA6",
+    "#12436D",
+    "#28A197",
+    "#F46A25",
+    "#801650",
+    "#1D609D",
+    "#30AA51",
+    "#A285D1",
+    "#00B1EB",
 ]
+
+_HOVER_GUIDE_COLOUR = "#A0A5B4"
+_LABEL_MIN_VERTICAL_GAP = 0.012
 
 _ALTAIR_SPEC_ASSIGNMENT_RE = re.compile(r"\b(?:var|const|let)\s+spec\s*=\s*")
 
@@ -203,6 +206,60 @@ def _choose_label_record(records: list[dict[str, Any]]) -> dict[str, Any]:
     return max(records, key=lambda row: (row["recall"], row["precision"]))
 
 
+def _apply_label_offsets(label_records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not label_records:
+        return []
+
+    adjusted_records = [
+        {
+            **record,
+            "_label_order": index,
+            "label_precision": float(record["precision"]),
+            "label_has_connector": False,
+        }
+        for index, record in enumerate(label_records)
+    ]
+    adjusted_records.sort(
+        key=lambda record: (float(record["precision"]), float(record["recall"]))
+    )
+
+    for index in range(1, len(adjusted_records)):
+        previous_label_precision = float(adjusted_records[index - 1]["label_precision"])
+        current_label_precision = float(adjusted_records[index]["label_precision"])
+        minimum_label_precision = previous_label_precision + _LABEL_MIN_VERTICAL_GAP
+        if current_label_precision < minimum_label_precision:
+            adjusted_records[index]["label_precision"] = minimum_label_precision
+
+    overflow = float(adjusted_records[-1]["label_precision"]) - 1.0
+    if overflow > 0:
+        for record in adjusted_records:
+            record["label_precision"] = max(
+                0.0,
+                float(record["label_precision"]) - overflow,
+            )
+
+        for index in range(len(adjusted_records) - 2, -1, -1):
+            next_label_precision = float(adjusted_records[index + 1]["label_precision"])
+            current_label_precision = float(adjusted_records[index]["label_precision"])
+            maximum_label_precision = next_label_precision - _LABEL_MIN_VERTICAL_GAP
+            if current_label_precision > maximum_label_precision:
+                adjusted_records[index]["label_precision"] = max(
+                    0.0,
+                    maximum_label_precision,
+                )
+
+    for record in adjusted_records:
+        record["label_has_connector"] = (
+            abs(float(record["label_precision"]) - float(record["precision"])) > 1e-9
+        )
+
+    adjusted_records.sort(key=lambda record: int(record["_label_order"]))
+    return [
+        {key: value for key, value in record.items() if key != "_label_order"}
+        for record in adjusted_records
+    ]
+
+
 def _interpolate_precision_for_recall(
     records: list[dict[str, Any]],
     *,
@@ -319,7 +376,14 @@ def _build_overlay_chart_definition(
     diff_records: list[dict[str, Any]],
     label_records: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    ordered_series_labels = [record["series_label"] for record in label_records]
+    adjusted_label_records = _apply_label_offsets(label_records)
+    ordered_series_labels = [record["series_label"] for record in adjusted_label_records]
+    comparison_labels = [
+        record["series_label"]
+        for record in adjusted_label_records
+        if not bool(record["is_baseline"])
+    ]
+    comparison_colour_range = _OVERLAY_COLOUR_RANGE[1 : len(comparison_labels) + 1]
 
     top_panel = _prepare_nested_chart_definition(
         _load_chart_definition("precision_recall.json")
@@ -364,7 +428,71 @@ def _build_overlay_chart_definition(
             "encoding": top_encoding,
         },
         {
-            "data": {"values": label_records},
+            "mark": {
+                "type": "point",
+                "opacity": 0,
+                "size": 90,
+            },
+            "encoding": {
+                "x": {
+                    "field": "recall",
+                    "type": "quantitative",
+                },
+                "y": {
+                    "field": "precision",
+                    "type": "quantitative",
+                },
+                "detail": {
+                    "field": "series_id",
+                    "type": "nominal",
+                },
+                "tooltip": top_encoding["tooltip"],
+            },
+            "params": [
+                {
+                    "name": "curve_hover",
+                    "select": {
+                        "type": "point",
+                        "on": "mouseover",
+                        "clear": "mouseout",
+                        "nearest": True,
+                        "fields": ["series_id", "recall", "precision"],
+                    },
+                }
+            ],
+        },
+        {
+            "data": {"values": adjusted_label_records},
+            "transform": [{"filter": "datum.label_has_connector"}],
+            "mark": {
+                "type": "rule",
+                "strokeWidth": 1,
+            },
+            "encoding": {
+                "x": {
+                    "field": "recall",
+                    "type": "quantitative",
+                },
+                "y": {
+                    "field": "precision",
+                    "type": "quantitative",
+                },
+                "y2": {
+                    "field": "label_precision",
+                },
+                "color": {
+                    "field": "series_label",
+                    "type": "nominal",
+                    "legend": None,
+                    "scale": {
+                        "domain": ordered_series_labels,
+                        "range": _OVERLAY_COLOUR_RANGE[: len(ordered_series_labels)],
+                    },
+                },
+            },
+        },
+        {
+            "data": {"values": adjusted_label_records},
             "mark": {
                 "type": "text",
                 "align": "left",
@@ -379,7 +507,7 @@ def _build_overlay_chart_definition(
                     "type": "quantitative",
                 },
                 "y": {
-                    "field": "precision",
+                    "field": "label_precision",
                     "type": "quantitative",
                 },
                 "text": {
@@ -397,12 +525,46 @@ def _build_overlay_chart_definition(
                 },
             },
         },
+        {
+            "data": {"values": curve_records},
+            "mark": {
+                "type": "rule",
+                "color": _HOVER_GUIDE_COLOUR,
+                "strokeWidth": 1,
+            },
+            "encoding": {
+                "x": {
+                    "field": "recall",
+                    "type": "quantitative",
+                },
+            },
+            "transform": [{"filter": {"param": "curve_hover", "empty": False}}],
+        },
+        {
+            "data": {"values": curve_records},
+            "mark": {
+                "type": "rule",
+                "color": _HOVER_GUIDE_COLOUR,
+                "strokeWidth": 1,
+            },
+            "encoding": {
+                "y": {
+                    "field": "precision",
+                    "type": "quantitative",
+                },
+            },
+            "transform": [{"filter": {"param": "curve_hover", "empty": False}}],
+        },
     ]
 
     bottom_panel = _prepare_nested_chart_definition(
         _load_chart_definition("precision_recall_diff.json")
     )
     bottom_panel["data"]["values"] = diff_records
+    bottom_panel["layer"][1]["encoding"]["color"]["scale"] = {
+        "domain": comparison_labels,
+        "range": comparison_colour_range,
+    }
 
     return {
         "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
@@ -473,10 +635,4 @@ def _overlay_precision_recall_charts(
         diff_records,
         label_records,
     )
-
-    try:
-        import altair as alt
-    except ImportError:
-        return chart_definition
-
-    return alt.VConcatChart.from_dict(chart_definition)
+    return chart_definition


### PR DESCRIPTION
Fixes three primary things:
1. Resolves issue with line titles overlapping
2. Improves colour scheme to allow for better differentiation between curves
3. Adds better hover-over support for charts

Old chart:
<img width="1205" height="765" alt="Screenshot 2026-06-05 at 11 03 51" src="https://github.com/user-attachments/assets/c96e2d10-6930-4160-a365-87731e864c46" />

New chart:
<img width="967" height="695" alt="Screenshot 2026-06-05 at 11 05 10" src="https://github.com/user-attachments/assets/91260918-3972-4e95-8720-557beadc42b1" />

[hackney_three_way_overlay.html](https://github.com/user-attachments/files/28633762/hackney_three_way_overlay.html)
