### PR TITLE
feat(logging): add progress bar for cleaning

### DIFF
--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -189,29 +189,69 @@ def test_cleaning_num_chunks_is_propagated_to_cleaning_steps(
         cleaning_num_chunks=2,
     )
 
-    with caplog.at_level(logging.INFO, logger="uk_address_matcher"):
+    with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
         matcher._resolve_canonical_data()
         matcher._resolve_messy_data()
 
     info_messages = [
         record.getMessage() for record in caplog.records if record.levelno == logging.INFO
     ]
-
-    cleaned_logs = [
-        message
-        for message in info_messages
-        if message.startswith("Cleaned and preprocessed:")
-    ]
-    tf_logs = [
-        message
-        for message in info_messages
-        if message.startswith("Applied term frequencies:")
+    debug_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
     ]
 
-    assert any("chunk 1/2" in message for message in cleaned_logs)
-    assert any("chunk 2/2" in message for message in cleaned_logs)
-    assert any("chunk 1/2" in message for message in tf_logs)
-    assert any("chunk 2/2" in message for message in tf_logs)
+    cleaned_info_logs = [
+        message
+        for message in info_messages
+        if message.startswith("Cleaning and preprocessing")
+    ]
+    tf_info_logs = [
+        message
+        for message in info_messages
+        if message.startswith("Applying term frequencies")
+    ]
+    cleaned_debug_logs = [
+        message
+        for message in debug_messages
+        if message.startswith("Cleaning and preprocessing:")
+    ]
+    tf_debug_logs = [
+        message
+        for message in debug_messages
+        if message.startswith("Applying term frequencies:")
+    ]
+
+    assert any(
+        "Cleaning and preprocessing: 20,500 records across 2 chunks" == message
+        for message in cleaned_info_logs
+    )
+    assert any(
+        message.startswith("Cleaning and preprocessing completed:")
+        for message in cleaned_info_logs
+    )
+    assert any(
+        "Applying term frequencies: 20,500 records across 2 chunks" == message
+        for message in tf_info_logs
+    )
+    assert any(
+        message.startswith("Applying term frequencies completed:")
+        for message in tf_info_logs
+    )
+    assert any("chunk 1/2" in message for message in cleaned_debug_logs)
+    assert any("chunk 2/2" in message for message in cleaned_debug_logs)
+    assert any("chunk 1/2" in message for message in tf_debug_logs)
+    assert any("chunk 2/2" in message for message in tf_debug_logs)
+    progress_glyphs = ("█", "░", "▕", "▏", "▮", "▯")
+    assert all(
+        all(glyph not in message for glyph in progress_glyphs)
+        for message in info_messages
+    )
+    assert all(
+        all(glyph not in message for glyph in progress_glyphs)
+        for message in debug_messages
+    )
 
 
 def test_match_with_custom_splink_stage(con, canonical_data, messy_data):

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -1,4 +1,6 @@
+import io
 import json
+import logging
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -8,8 +10,12 @@ import pyarrow
 import pytest
 
 from uk_address_matcher import prepare_canonical_folder
+from uk_address_matcher.cleaning import chunking_strategies
+from uk_address_matcher.helpers import progress as progress_helpers
+from uk_address_matcher.helpers.progress import _ProgressBar
 from uk_address_matcher.prepare_canonical import (
     MAX_CHUNK_COUNT,
+    _coerce_prepare_input_to_relation,
     _PreparedCanonical,
     load_prepared_canonical_data,
 )
@@ -31,6 +37,42 @@ CANONICAL_RECORDS = [
         "postcode": "B1 1AA",
     },
 ]
+
+
+class _FakeStream(io.StringIO):
+    def __init__(self, *, isatty_value: bool) -> None:
+        super().__init__()
+        self._isatty_value = isatty_value
+
+    def isatty(self) -> bool:
+        return self._isatty_value
+
+
+class _AsciiStream(_FakeStream):
+    @property
+    def encoding(self) -> str:
+        return "ascii"
+
+
+class _BrokenWriteStream(_FakeStream):
+    def write(self, s: str) -> int:
+        raise UnicodeEncodeError("ascii", s, 0, 1, "cannot encode")
+
+
+def _write_raw_canonical_csv(path: Path, records: list[dict[str, str]]) -> None:
+    rows = ["unique_id,address_concat,postcode"]
+    for record in records:
+        rows.append(
+            f"{record['unique_id']},{record['address_concat']},{record['postcode']}"
+        )
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def _fake_relation(*, columns: list[str], row_count: int) -> MagicMock:
+    relation = MagicMock()
+    relation.columns = columns
+    relation.count.return_value.fetchone.return_value = (row_count,)
+    return relation
 
 
 @pytest.fixture
@@ -59,6 +101,157 @@ def test_prepare_creates_expected_files(prepared_folder):
     assert (prepared_folder / "ukam_manifest.json").exists()
 
 
+def test_progress_bar_disabled_writes_nothing():
+    stream = _FakeStream(isatty_value=True)
+    progress = _ProgressBar(label="Testing", total=10, enabled=False, stream=stream)
+
+    progress.update(5)
+    progress.close()
+
+    assert stream.getvalue() == ""
+
+
+def test_progress_bar_enabled_writes_carriage_return_and_newline():
+    stream = _FakeStream(isatty_value=True)
+    progress = _ProgressBar(
+        label="Testing",
+        total=10,
+        total_units=4,
+        enabled=True,
+        stream=stream,
+    )
+
+    progress.update(5, completed_units=2)
+    progress.close()
+
+    output = stream.getvalue()
+    assert "\rTesting:  50% ▕" in output
+    assert "▮" * 12 in output
+    assert "▯" * 12 in output
+    assert "5/10 records" in output
+    assert output.endswith("\n")
+
+
+def test_progress_bar_caps_progress_at_total():
+    stream = _FakeStream(isatty_value=True)
+    progress = _ProgressBar(
+        label="Testing",
+        total=10,
+        total_units=4,
+        enabled=True,
+        stream=stream,
+    )
+
+    progress.update(25, completed_units=8)
+
+    assert "10/10 records" in stream.getvalue()
+    assert f"▕{'▮' * 24}▏" in stream.getvalue()
+
+
+def test_progress_bar_defaults_to_enabled():
+    stream = _FakeStream(isatty_value=False)
+    progress = _ProgressBar(label="Testing", total=10, stream=stream)
+
+    progress.update(5)
+
+    assert stream.getvalue()
+
+
+def test_progress_bar_disables_itself_when_stream_cannot_render():
+    stream = _BrokenWriteStream(isatty_value=True)
+    progress = _ProgressBar(
+        label="Testing",
+        total=10,
+        total_units=4,
+        enabled=True,
+        stream=stream,
+    )
+
+    progress.update(5, completed_units=2)
+    progress.close()
+
+    assert progress.enabled is False
+
+
+def test_progress_bar_ascii_fallback_uses_plain_glyphs():
+    stream = _AsciiStream(isatty_value=True)
+    progress = _ProgressBar(
+        label="Testing",
+        total=10,
+        total_units=4,
+        enabled=True,
+        stream=stream,
+    )
+
+    progress.update(5, completed_units=2)
+    progress.close()
+
+    output = stream.getvalue()
+    assert "[" in output and "]" in output
+    assert "#" in output and "-" in output
+    assert "▕" not in output and "▮" not in output
+
+
+def test_progress_bar_close_without_render_writes_nothing():
+    stream = _FakeStream(isatty_value=True)
+    progress = _ProgressBar(label="Testing", total=10, enabled=True, stream=stream)
+
+    progress.close()
+
+    assert stream.getvalue() == ""
+
+
+def test_progress_bar_clears_leftover_characters_on_shorter_render():
+    stream = _FakeStream(isatty_value=True)
+    progress = _ProgressBar(
+        label="Testing",
+        total=10,
+        total_units=4,
+        enabled=True,
+        stream=stream,
+    )
+
+    progress.update(10, completed_units=4)
+    progress.update(1, completed_units=1)
+
+    output = stream.getvalue()
+    assert "\rTesting: 100%" in output
+    assert "\rTesting:  10%" in output
+    assert output.endswith(" " * 2) or "  " in output.split("\r")[-1]
+
+
+def test_prepare_accepts_local_csv_path_input(con, tmp_path):
+    input_csv = tmp_path / "canonical.csv"
+    _write_raw_canonical_csv(input_csv, CANONICAL_RECORDS)
+
+    prepare_canonical_folder(input_csv, output_folder=tmp_path / "prepared", con=con)
+
+    assert (tmp_path / "prepared" / "ukam_canonical_addresses.parquet").exists()
+    assert (tmp_path / "prepared" / "ukam_term_frequencies.parquet").exists()
+    assert (tmp_path / "prepared" / "ukam_inverted_index.parquet").exists()
+    assert (tmp_path / "prepared" / "ukam_manifest.json").exists()
+
+
+def test_prepare_accepts_list_of_local_csv_paths(con, tmp_path):
+    first_csv = tmp_path / "canonical_part_1.csv"
+    second_csv = tmp_path / "canonical_part_2.csv"
+    _write_raw_canonical_csv(first_csv, CANONICAL_RECORDS[:2])
+    _write_raw_canonical_csv(second_csv, CANONICAL_RECORDS[2:])
+
+    prepare_canonical_folder(
+        [first_csv, second_csv],
+        output_folder=tmp_path / "prepared",
+        con=con,
+        output_chunk_count=2,
+    )
+
+    chunk_files = sorted(
+        (tmp_path / "prepared" / "ukam_canonical_addresses_chunks").glob("*.parquet")
+    )
+    assert len(chunk_files) == 2
+    assert (tmp_path / "prepared" / "ukam_manifest.json").exists()
+
+
 def test_prepare_can_create_chunked_canonical_output(con, canonical_data, tmp_path):
     prepare_canonical_folder(
         canonical_data,
@@ -77,6 +270,221 @@ def test_prepare_can_create_chunked_canonical_output(con, canonical_data, tmp_pa
     assert chunk_files[1].name == "canonical_addresses_chunk_00002_of_00003.parquet"
     assert chunk_files[2].name == "canonical_addresses_chunk_00003_of_00003.parquet"
     assert not (tmp_path / "ukam_canonical_addresses.parquet").exists()
+
+
+def test_prepare_show_progress_false_suppresses_live_output(
+    con, canonical_data, tmp_path, monkeypatch
+):
+    stream = _FakeStream(isatty_value=True)
+    monkeypatch.setattr(progress_helpers.sys, "stderr", stream)
+
+    prepare_canonical_folder(
+        canonical_data,
+        output_folder=tmp_path / "prepared",
+        con=con,
+        overwrite=True,
+        show_progress=False,
+    )
+
+    assert stream.getvalue() == ""
+
+
+def test_prepare_default_show_progress_enables_live_output(
+    con, canonical_data, tmp_path, monkeypatch
+):
+    enabled_values: list[bool] = []
+
+    class _RecordingProgressBar:
+        def __init__(
+            self,
+            *,
+            label: str,
+            total: int,
+            total_units: int | None = None,
+            enabled: bool = True,
+            stream: object | None = None,
+        ) -> None:
+            del label, total, total_units, stream
+            enabled_values.append(enabled)
+
+        def update(
+            self,
+            current: int,
+            *,
+            completed_units: int | None = None,
+        ) -> None:
+            del current, completed_units
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(chunking_strategies, "_ProgressBar", _RecordingProgressBar)
+
+    prepare_canonical_folder(
+        canonical_data,
+        output_folder=tmp_path / "prepared",
+        con=con,
+        overwrite=True,
+    )
+
+    assert enabled_values
+    assert all(value is True for value in enabled_values)
+
+
+def test_prepare_show_progress_true_emits_live_output(
+    con, canonical_data, tmp_path, monkeypatch
+):
+    enabled_values: list[bool] = []
+
+    class _RecordingProgressBar:
+        def __init__(
+            self,
+            *,
+            label: str,
+            total: int,
+            total_units: int | None = None,
+            enabled: bool = True,
+            stream: object | None = None,
+        ) -> None:
+            del label, total, total_units, stream
+            enabled_values.append(enabled)
+
+        def update(
+            self,
+            current: int,
+            *,
+            completed_units: int | None = None,
+        ) -> None:
+            del current, completed_units
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(chunking_strategies, "_ProgressBar", _RecordingProgressBar)
+
+    prepare_canonical_folder(
+        canonical_data,
+        output_folder=tmp_path / "prepared",
+        con=con,
+        overwrite=True,
+        show_progress=True,
+    )
+
+    assert enabled_values
+    assert all(value is True for value in enabled_values)
+
+
+def test_prepare_logs_sparse_info_and_debug_progress(
+    con, canonical_data, tmp_path, caplog
+):
+    with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
+        prepare_canonical_folder(
+            canonical_data,
+            output_folder=tmp_path / "prepared",
+            con=con,
+            overwrite=True,
+            show_progress=False,
+        )
+
+    info_messages = [
+        record.getMessage() for record in caplog.records if record.levelno == logging.INFO
+    ]
+    debug_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ]
+
+    assert any(
+        message.startswith("Cleaning for TF derivation:") and "records across" in message
+        for message in info_messages
+    )
+    assert any(
+        message.startswith("Cleaning for TF derivation completed:")
+        for message in info_messages
+    )
+    assert any(
+        message.startswith("Applying term frequencies:") and "records across" in message
+        for message in info_messages
+    )
+    assert any(
+        message.startswith("Applying term frequencies completed:")
+        for message in info_messages
+    )
+    assert any(
+        message.startswith("Cleaning for TF derivation:") and "chunk 1/1" in message
+        for message in debug_messages
+    )
+    progress_glyphs = ("█", "░", "▕", "▏", "▮", "▯")
+    assert all(
+        all(glyph not in message for glyph in progress_glyphs)
+        for message in info_messages
+    )
+    assert all(
+        all(glyph not in message for glyph in progress_glyphs)
+        for message in debug_messages
+    )
+
+
+@pytest.mark.parametrize(
+    ("input_value", "reader_name", "expected_argument"),
+    [
+        (
+            "s3://bucket/input/os_fake.csv",
+            "read_csv",
+            "s3://bucket/input/os_fake.csv",
+        ),
+        (
+            "gs://bucket/input/data.parquet?version=1",
+            "read_parquet",
+            "gs://bucket/input/data.parquet?version=1",
+        ),
+        (
+            [
+                "abfs://container/input/part-1.csv",
+                "abfs://container/input/part-2.csv",
+            ],
+            "read_csv",
+            [
+                "abfs://container/input/part-1.csv",
+                "abfs://container/input/part-2.csv",
+            ],
+        ),
+    ],
+)
+def test_coerce_prepare_input_reads_cloud_paths_with_duckdb(
+    input_value, reader_name, expected_argument
+):
+    con = MagicMock()
+    relation = _fake_relation(
+        columns=["unique_id", "address_concat", "postcode"],
+        row_count=3,
+    )
+    getattr(con, reader_name).return_value = relation
+
+    result = _coerce_prepare_input_to_relation(input_value, con=con)
+
+    assert result is relation
+    getattr(con, reader_name).assert_called_once_with(expected_argument)
+
+
+def test_coerce_prepare_input_projects_original_address_concat():
+    con = MagicMock()
+    original_relation = MagicMock()
+    projected_relation = _fake_relation(
+        columns=["unique_id", "original_address_concat", "address_concat"],
+        row_count=3,
+    )
+    original_relation.columns = ["unique_id", "original_address_concat"]
+    original_relation.project.return_value = projected_relation
+    con.read_csv.return_value = original_relation
+
+    result = _coerce_prepare_input_to_relation("s3://bucket/input/raw.csv", con=con)
+
+    assert result is projected_relation
+    original_relation.project.assert_called_once_with(
+        "*, original_address_concat AS address_concat"
+    )
 
 
 @pytest.mark.parametrize("invalid_chunk_count", [0, -1, -10])
@@ -153,6 +561,128 @@ def test_prepare_overwrite_true_succeeds(con, canonical_data):
         prepare_canonical_folder(
             canonical_data, output_folder=tmp, con=con, overwrite=True
         )
+
+
+def test_prepare_remote_csv_input_writes_remote_output(monkeypatch):
+    from uk_address_matcher.cleaning import chunking_strategies
+
+    con = MagicMock()
+    raw_relation = _fake_relation(
+        columns=["unique_id", "address_concat", "postcode"],
+        row_count=3,
+    )
+    con.read_csv.return_value = raw_relation
+    con.read_parquet.side_effect = FileNotFoundError("missing")
+
+    tf_relation = _fake_relation(columns=["token", "count"], row_count=4)
+    inverted_relation = _fake_relation(columns=["token", "address_id"], row_count=5)
+    clean_relation = _fake_relation(
+        columns=["unique_id", "address_concat", "postcode"],
+        row_count=3,
+    )
+
+    monkeypatch.setattr(
+        chunking_strategies,
+        "derive_term_frequencies_table",
+        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
+    )
+    monkeypatch.setattr(
+        chunking_strategies,
+        "prepare_data_for_matching",
+        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
+            clean_relation
+        ),
+    )
+    monkeypatch.setattr(
+        chunking_strategies,
+        "derive_inverted_index",
+        lambda df_clean, con, num_of_chunks, show_progress=True: inverted_relation,
+    )
+
+    prepare_canonical_folder(
+        "s3://bucket/input/canonical.csv",
+        "s3://bucket/output/prepared",
+        con=con,
+    )
+
+    con.read_csv.assert_called_once_with("s3://bucket/input/canonical.csv")
+    tf_relation.write_parquet.assert_called_once_with(
+        "s3://bucket/output/prepared/ukam_term_frequencies.parquet"
+    )
+    inverted_relation.write_parquet.assert_called_once_with(
+        "s3://bucket/output/prepared/ukam_inverted_index.parquet"
+    )
+    clean_relation.write_parquet.assert_called_once_with(
+        "s3://bucket/output/prepared/ukam_canonical_addresses.parquet"
+    )
+    assert any(
+        "ukam_manifest.json" in call.args[0]
+        for call in con.execute.call_args_list
+        if call.args
+    )
+
+
+def test_prepare_remote_output_writes_chunked_paths(monkeypatch):
+    from uk_address_matcher.cleaning import chunking_strategies
+
+    con = MagicMock()
+    raw_relation = _fake_relation(
+        columns=["unique_id", "address_concat", "postcode"],
+        row_count=3,
+    )
+    con.read_csv.return_value = raw_relation
+    con.read_parquet.side_effect = FileNotFoundError("missing")
+
+    tf_relation = _fake_relation(columns=["token", "count"], row_count=4)
+    inverted_relation = _fake_relation(columns=["token", "address_id"], row_count=5)
+    clean_relation = _fake_relation(
+        columns=["unique_id", "address_concat", "postcode"],
+        row_count=3,
+    )
+
+    chunk_queries = []
+    for row_count in (2, 1):
+        chunk_query = _fake_relation(
+            columns=["unique_id", "address_concat", "postcode"],
+            row_count=row_count,
+        )
+        chunk_queries.append(chunk_query)
+    con.sql.side_effect = chunk_queries
+
+    monkeypatch.setattr(
+        chunking_strategies,
+        "derive_term_frequencies_table",
+        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
+    )
+    monkeypatch.setattr(
+        chunking_strategies,
+        "prepare_data_for_matching",
+        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
+            clean_relation
+        ),
+    )
+    monkeypatch.setattr(
+        chunking_strategies,
+        "derive_inverted_index",
+        lambda df_clean, con, num_of_chunks, show_progress=True: inverted_relation,
+    )
+
+    prepare_canonical_folder(
+        "s3://bucket/input/canonical.csv",
+        "s3://bucket/output/prepared",
+        con=con,
+        output_chunk_count=2,
+    )
+
+    clean_relation.create.assert_called_once()
+    chunk_queries[0].write_parquet.assert_called_once_with(
+        "s3://bucket/output/prepared/ukam_canonical_addresses_chunks/"
+        "canonical_addresses_chunk_00001_of_00002.parquet"
+    )
+    chunk_queries[1].write_parquet.assert_called_once_with(
+        "s3://bucket/output/prepared/ukam_canonical_addresses_chunks/"
+        "canonical_addresses_chunk_00002_of_00002.parquet"
+    )
 
 
 def test_overwrite_clears_stale_files(con, canonical_data):

--- a/uk_address_matcher/_typing.py
+++ b/uk_address_matcher/_typing.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TypeAlias, TypedDict
+
+import duckdb
 
 
 class StageDiagnosticRow(TypedDict):
@@ -14,3 +17,5 @@ class StageDiagnosticRow(TypedDict):
 
 
 StageDiagnostics: TypeAlias = list[StageDiagnosticRow]
+
+PrepareCanonicalInput: TypeAlias = duckdb.DuckDBPyRelation | str | Path | list[str | Path]

--- a/uk_address_matcher/address_matcher.py
+++ b/uk_address_matcher/address_matcher.py
@@ -9,6 +9,9 @@ from uk_address_matcher.cleaning.chunking_strategies import (
     derive_term_frequencies_table,
     prepare_data_for_matching,
 )
+from uk_address_matcher.helpers.canonical_inputs import (
+    normalise_and_validate_raw_canonical,
+)
 from uk_address_matcher.linking_model.address_record import AddressRecord
 from uk_address_matcher.linking_model.matching.runner import _run_matching
 from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
@@ -35,24 +38,6 @@ def _default_stages() -> list[MatchingStage]:
     from uk_address_matcher.linking_model.matching.stages.splink import SplinkStage
 
     return [ExactMatchStage(), SplinkStage()]
-
-
-def _normalise_and_validate_raw_canonical(
-    rel: duckdb.DuckDBPyRelation,
-) -> duckdb.DuckDBPyRelation:
-    """Normalise and validate required columns for raw canonical input."""
-    if "address_concat" not in rel.columns and "original_address_concat" in rel.columns:
-        rel = rel.project("*, original_address_concat AS address_concat")
-
-    required = {"unique_id", "address_concat"}
-    missing = sorted(required.difference(rel.columns))
-    if missing:
-        raise ValueError(
-            "canonical_addresses relation is missing required columns: "
-            f"{missing}. Expected at least ['address_concat', 'unique_id']."
-        )
-
-    return rel
 
 
 class AddressMatcher:
@@ -234,7 +219,7 @@ class AddressMatcher:
             self._register_inverted_index(prepared.inverted_index)
 
         else:
-            canonical_for_preparation = _normalise_and_validate_raw_canonical(
+            canonical_for_preparation = normalise_and_validate_raw_canonical(
                 self._raw_canonical
             )
             # Data is either raw or only pre-cleaned.  In both cases we need

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -22,6 +22,7 @@ from uk_address_matcher.cleaning.steps.inverted_index import (
     _build_inverted_index_from_keys,
     _derive_keys_for_strategy,
 )
+from uk_address_matcher.helpers.progress import _ProgressBar
 from uk_address_matcher.sql_pipeline.helpers import (
     _drop_table_and_registered_aliases,
     _uid,
@@ -81,39 +82,61 @@ def _format_elapsed(elapsed_seconds: float) -> str:
     return f"{minutes}m {seconds:02d}s"
 
 
-def _format_progress_bar(progress_fraction: float, *, width: int = 24) -> str:
-    clamped_progress = min(max(progress_fraction, 0.0), 1.0)
-    filled_width = int(round(clamped_progress * width))
-    filled = "▮" * filled_width
-    empty = "▯" * (width - filled_width)
-    return f"▕{filled}{empty}▏"
+def _format_elapsed_brief(elapsed_seconds: float) -> str:
+    total_seconds = int(round(max(0.0, elapsed_seconds)))
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+    return _format_elapsed(elapsed_seconds)
+
+
+def _log_stage_start(stage_label: str, total_records: int, total_chunks: int) -> None:
+    logger.info(
+        "%s: %s records across %s chunk%s",
+        stage_label,
+        f"{total_records:,}",
+        total_chunks,
+        "" if total_chunks == 1 else "s",
+    )
+
+
+def _log_stage_complete(
+    stage_label: str,
+    total_records: int,
+    elapsed_seconds: float,
+) -> None:
+    logger.info(
+        "%s completed: %s records in %s",
+        stage_label,
+        f"{total_records:,}",
+        _format_elapsed_brief(elapsed_seconds),
+    )
 
 
 def _log_progress(
     total_records: int,
     processed_records: int,
-    stage_type: str,
+    stage_label: str,
     *,
     chunk_index: int | None = None,
     total_chunks: int | None = None,
     chunk_elapsed_seconds: float | None = None,
 ) -> None:
-    percentage_complete = processed_records / total_records if total_records > 0 else 1.0
-    percent_label = f"{percentage_complete:.0%}"
-    progress_bar = _format_progress_bar(percentage_complete)
-    chunk_label = ""
+    chunk_position = "?/?"
     if chunk_index is not None and total_chunks is not None:
-        chunk_label = f"chunk {chunk_index + 1}/{total_chunks} "
+        chunk_position = f"{chunk_index + 1}/{total_chunks}"
 
-    message = (
-        f"{stage_type}"
-        f"{chunk_label}{percent_label} {progress_bar} "
-        f"({processed_records:,.0f}/{total_records:,.0f} records)"
-    )
+    elapsed_suffix = ""
     if chunk_elapsed_seconds is not None:
-        message += f" ({_format_elapsed(chunk_elapsed_seconds)} elapsed)"
+        elapsed_suffix = f", elapsed={_format_elapsed_brief(chunk_elapsed_seconds)}"
 
-    logger.info(message)
+    logger.debug(
+        "%s: chunk %s, %s/%s records%s",
+        stage_label,
+        chunk_position,
+        f"{processed_records:,}",
+        f"{total_records:,}",
+        elapsed_suffix,
+    )
 
 
 def _calculate_chunk_size(total_records: int, num_of_chunks: int) -> int:
@@ -135,6 +158,7 @@ def clean_data_pre_term_frequencies(
     num_of_chunks: int = 10,
     *,
     debug_options: Optional[DebugOptions] = None,
+    show_progress: bool = True,
 ) -> DuckDBPyRelation:
     """Clean address data with foundational steps only (no term frequencies).
 
@@ -164,51 +188,70 @@ def clean_data_pre_term_frequencies(
     total_chunks = (total_rows + chunk_size - 1) // chunk_size
     next_ukam_address_id_offset = 0
     processed_records = 0
+    stage_label = "Cleaning and preprocessing"
+    progress = _ProgressBar(
+        label=stage_label,
+        total=total_rows,
+        total_units=total_chunks,
+        enabled=show_progress,
+    )
 
     con.execute(f"DROP TABLE IF EXISTS __ukam_chunked_addresses_{uid}")
 
-    for chunk_index in range(total_chunks):
-        chunk_started_at = time.perf_counter()
-        chunk_query = con.sql(f"""
-        SELECT *
-            FROM {input_name}
-            WHERE (abs(hash(address_concat)) % {total_chunks}) = {chunk_index}
-        """)
-        chunk_table = f"__ukam_chunk_input_{uid}_{chunk_index}"
-        chunk = _materialise_relation_with_ukam_address_id(
-            con,
-            chunk_query,
-            chunk_table,
-            id_offset=next_ukam_address_id_offset,
-        )
-        chunk_row_count = chunk.count("*").fetchone()[0]
+    stage_started_at = time.perf_counter()
+    _log_stage_start(stage_label, total_rows, total_chunks)
 
-        # Process the chunk without address ID,
-        # applying debug options only on first iteration.
-        processed_chunk = _clean_data_pre_term_frequencies(
-            chunk,
-            con,
-            debug_options=debug_options if chunk_index == 0 else None,
-        )
+    try:
+        for chunk_index in range(total_chunks):
+            chunk_started_at = time.perf_counter()
+            chunk_query = con.sql(f"""
+            SELECT *
+                FROM {input_name}
+                WHERE (abs(hash(address_concat)) % {total_chunks}) = {chunk_index}
+            """)
+            chunk_table = f"__ukam_chunk_input_{uid}_{chunk_index}"
+            chunk = _materialise_relation_with_ukam_address_id(
+                con,
+                chunk_query,
+                chunk_table,
+                id_offset=next_ukam_address_id_offset,
+            )
+            chunk_row_count = chunk.count("*").fetchone()[0]
 
-        if chunk_index == 0:
-            processed_chunk.create(f"__ukam_chunked_addresses_{uid}")
-        else:
-            processed_chunk.insert_into(f"__ukam_chunked_addresses_{uid}")
+            # Process the chunk without address ID,
+            # applying debug options only on first iteration.
+            processed_chunk = _clean_data_pre_term_frequencies(
+                chunk,
+                con,
+                debug_options=debug_options if chunk_index == 0 else None,
+            )
 
-        processed_records += chunk_row_count
-        next_ukam_address_id_offset += chunk_row_count
+            if chunk_index == 0:
+                processed_chunk.create(f"__ukam_chunked_addresses_{uid}")
+            else:
+                processed_chunk.insert_into(f"__ukam_chunked_addresses_{uid}")
 
-        _log_progress(
-            total_rows,
-            processed_records,
-            stage_type="Cleaned and preprocessed: ",
-            chunk_index=chunk_index,
-            total_chunks=total_chunks,
-            chunk_elapsed_seconds=time.perf_counter() - chunk_started_at,
-        )
+            processed_records += chunk_row_count
+            next_ukam_address_id_offset += chunk_row_count
+            progress.update(
+                processed_records,
+                completed_units=chunk_index + 1,
+            )
 
-        _drop_table_and_registered_aliases(con, chunk_table)
+            _log_progress(
+                total_rows,
+                processed_records,
+                stage_label=stage_label,
+                chunk_index=chunk_index,
+                total_chunks=total_chunks,
+                chunk_elapsed_seconds=time.perf_counter() - chunk_started_at,
+            )
+
+            _drop_table_and_registered_aliases(con, chunk_table)
+    finally:
+        progress.close()
+
+    _log_stage_complete(stage_label, total_rows, time.perf_counter() - stage_started_at)
 
     _drop_table_and_registered_aliases(con, input_name)
     _drop_tables_with_prefix(con, f"__ukam_chunk_input_{uid}_")
@@ -222,6 +265,7 @@ def derive_term_frequencies_table(
     num_of_chunks: int = 10,
     *,
     debug_options: Optional["DebugOptions"] = None,
+    show_progress: bool = True,
 ) -> DuckDBPyRelation:
     """Derive a term frequency lookup table from address data.
 
@@ -267,54 +311,75 @@ def derive_term_frequencies_table(
     total_chunks = (total_rows + chunk_size - 1) // chunk_size
     next_ukam_address_id_offset = 0
     processed_records = 0
+    stage_label = "Cleaning for TF derivation"
+    progress = _ProgressBar(
+        label=stage_label,
+        total=total_rows,
+        total_units=total_chunks,
+        enabled=show_progress,
+    )
 
     cleaned_table = f"__ukam_tf_derive_cleaned_{uid}"
     con.execute(f"DROP TABLE IF EXISTS {cleaned_table}")
 
     # Process in chunks using minimal pipeline (clean + tokenise only)
-    for chunk_index in range(total_chunks):
-        chunk_started_at = time.perf_counter()
-        chunk_query = con.sql(f"""
-            SELECT *
-            FROM {input_name}
-            WHERE (abs(hash(address_concat)) % {total_chunks}) = {chunk_index}
-        """)
-        chunk_table = f"__ukam_tf_chunk_input_{uid}_{chunk_index}"
-        chunk = _materialise_relation_with_ukam_address_id(
-            con,
-            chunk_query,
-            chunk_table,
-            id_offset=next_ukam_address_id_offset,
-        )
-        chunk_row_count = chunk.count("*").fetchone()[0]
+    stage_started_at = time.perf_counter()
+    _log_stage_start(stage_label, total_rows, total_chunks)
 
-        pipeline = create_sql_pipeline(
-            con,
-            input_rel=chunk,
-            stage_specs=QUEUE_FOR_TF_DERIVATION,
-            pipeline_name="Clean for TF derivation",
-            pipeline_description=("Clean and tokenise for term frequency computation"),
-        )
-        processed_chunk = pipeline.run(debug_options if chunk_index == 0 else None)
+    try:
+        for chunk_index in range(total_chunks):
+            chunk_started_at = time.perf_counter()
+            chunk_query = con.sql(f"""
+                SELECT *
+                FROM {input_name}
+                WHERE (abs(hash(address_concat)) % {total_chunks}) = {chunk_index}
+            """)
+            chunk_table = f"__ukam_tf_chunk_input_{uid}_{chunk_index}"
+            chunk = _materialise_relation_with_ukam_address_id(
+                con,
+                chunk_query,
+                chunk_table,
+                id_offset=next_ukam_address_id_offset,
+            )
+            chunk_row_count = chunk.count("*").fetchone()[0]
 
-        if chunk_index == 0:
-            processed_chunk.create(cleaned_table)
-        else:
-            processed_chunk.insert_into(cleaned_table)
+            pipeline = create_sql_pipeline(
+                con,
+                input_rel=chunk,
+                stage_specs=QUEUE_FOR_TF_DERIVATION,
+                pipeline_name="Clean for TF derivation",
+                pipeline_description=(
+                    "Clean and tokenise for term frequency computation"
+                ),
+            )
+            processed_chunk = pipeline.run(debug_options if chunk_index == 0 else None)
 
-        processed_records += chunk_row_count
-        next_ukam_address_id_offset += chunk_row_count
+            if chunk_index == 0:
+                processed_chunk.create(cleaned_table)
+            else:
+                processed_chunk.insert_into(cleaned_table)
 
-        _log_progress(
-            total_rows,
-            processed_records,
-            stage_type="Cleaned for TF derivation: ",
-            chunk_index=chunk_index,
-            total_chunks=total_chunks,
-            chunk_elapsed_seconds=time.perf_counter() - chunk_started_at,
-        )
+            processed_records += chunk_row_count
+            next_ukam_address_id_offset += chunk_row_count
+            progress.update(
+                processed_records,
+                completed_units=chunk_index + 1,
+            )
 
-        _drop_table_and_registered_aliases(con, chunk_table)
+            _log_progress(
+                total_rows,
+                processed_records,
+                stage_label=stage_label,
+                chunk_index=chunk_index,
+                total_chunks=total_chunks,
+                chunk_elapsed_seconds=time.perf_counter() - chunk_started_at,
+            )
+
+            _drop_table_and_registered_aliases(con, chunk_table)
+    finally:
+        progress.close()
+
+    _log_stage_complete(stage_label, total_rows, time.perf_counter() - stage_started_at)
 
     # Compute token frequencies from clean_full_address tokens
     tf_sql = f"""
@@ -350,6 +415,7 @@ def derive_inverted_index(
     strategies: list[IndexingStrategy] | None = None,
     *,
     debug_options: Optional["DebugOptions"] = None,
+    show_progress: bool = True,
 ) -> DuckDBPyRelation:
     """Derive an inverted index from already-cleaned canonical data.
 
@@ -404,7 +470,10 @@ def derive_inverted_index(
     total_rows = cleaned_address_table.count("*").fetchone()[0]
 
     for strategy in strategies:
+        stage_label = f"Building inverted index ({strategy.name})"
         if num_of_chunks == 1:
+            stage_started_at = time.perf_counter()
+            _log_stage_start(stage_label, total_rows, 1)
             # Single-pass for this strategy
             pipeline = create_sql_pipeline(
                 con,
@@ -425,48 +494,86 @@ def derive_inverted_index(
                 first_insert = False
             else:
                 chunk_result.insert_into(result_table)
+            _log_progress(
+                total_rows,
+                total_rows,
+                stage_label=stage_label,
+                chunk_index=0,
+                total_chunks=1,
+                chunk_elapsed_seconds=time.perf_counter() - stage_started_at,
+            )
+            _log_stage_complete(
+                stage_label,
+                total_rows,
+                time.perf_counter() - stage_started_at,
+            )
         else:
             # Chunked path for this strategy
-            for chunk_index in range(num_of_chunks):
-                chunk_started_at = time.perf_counter()
+            stage_started_at = time.perf_counter()
+            progress = _ProgressBar(
+                label=stage_label,
+                total=total_rows,
+                total_units=num_of_chunks,
+                enabled=show_progress,
+            )
+            _log_stage_start(stage_label, total_rows, num_of_chunks)
+            try:
+                for chunk_index in range(num_of_chunks):
+                    chunk_started_at = time.perf_counter()
 
-                pipeline = create_sql_pipeline(
-                    con,
-                    input_rel=cleaned_address_table,
-                    stage_specs=[
-                        _derive_keys_for_strategy(
-                            strategy,
-                            num_of_chunks=num_of_chunks,
-                            chunk_index=chunk_index,
+                    pipeline = create_sql_pipeline(
+                        con,
+                        input_rel=cleaned_address_table,
+                        stage_specs=[
+                            _derive_keys_for_strategy(
+                                strategy,
+                                num_of_chunks=num_of_chunks,
+                                chunk_index=chunk_index,
+                            ),
+                            _build_inverted_index_from_keys(
+                                strategy,
+                                max_unique_ids_per_key,
+                            ),
+                        ],
+                        pipeline_name=f"Build inverted index ({strategy.name})",
+                        pipeline_description=(
+                            f"Derive {strategy.name} keys and aggregate into inverted "
+                            f"index (chunk {chunk_index + 1}/{num_of_chunks})"
                         ),
-                        _build_inverted_index_from_keys(strategy, max_unique_ids_per_key),
-                    ],
-                    pipeline_name=f"Build inverted index ({strategy.name})",
-                    pipeline_description=(
-                        f"Derive {strategy.name} keys and aggregate into inverted "
-                        f"index (chunk {chunk_index + 1}/{num_of_chunks})"
-                    ),
-                )
-                chunk_result = pipeline.run(debug_options if first_insert else None)
+                    )
+                    chunk_result = pipeline.run(debug_options if first_insert else None)
 
-                if first_insert:
-                    chunk_result.create(result_table)
-                    first_insert = False
-                else:
-                    chunk_result.insert_into(result_table)
+                    if first_insert:
+                        chunk_result.create(result_table)
+                        first_insert = False
+                    else:
+                        chunk_result.insert_into(result_table)
 
-                _log_progress(
-                    total_rows,
-                    min(
+                    processed_records = min(
                         (chunk_index + 1)
                         * ((total_rows + num_of_chunks - 1) // num_of_chunks),
                         total_rows,
-                    ),
-                    stage_type=(f"Built inverted index ({strategy.name}): "),
-                    chunk_index=chunk_index,
-                    total_chunks=num_of_chunks,
-                    chunk_elapsed_seconds=(time.perf_counter() - chunk_started_at),
-                )
+                    )
+                    progress.update(
+                        processed_records,
+                        completed_units=chunk_index + 1,
+                    )
+                    _log_progress(
+                        total_rows,
+                        processed_records,
+                        stage_label=stage_label,
+                        chunk_index=chunk_index,
+                        total_chunks=num_of_chunks,
+                        chunk_elapsed_seconds=(time.perf_counter() - chunk_started_at),
+                    )
+            finally:
+                progress.close()
+
+            _log_stage_complete(
+                stage_label,
+                total_rows,
+                time.perf_counter() - stage_started_at,
+            )
 
     return con.table(result_table)
 
@@ -486,6 +593,7 @@ def prepare_data_for_matching(
     *,
     dataset_role: Literal["messy", "canonical"] | None = None,
     debug_options: Optional[DebugOptions] = None,
+    show_progress: bool = True,
 ) -> DuckDBPyRelation:
     """Prepare address data for matching.
 
@@ -545,7 +653,11 @@ def prepare_data_for_matching(
 
     # Clean data in chunks (without term frequencies)
     cleaned_address_table = clean_data_pre_term_frequencies(
-        address_table, con, num_of_chunks=num_of_chunks, debug_options=debug_options
+        address_table,
+        con,
+        num_of_chunks=num_of_chunks,
+        debug_options=debug_options,
+        show_progress=show_progress,
     )
 
     total_rows = cleaned_address_table.count("*").fetchone()[0]
@@ -563,6 +675,13 @@ def prepare_data_for_matching(
 
     chunk_size = _calculate_chunk_size(total_rows, num_of_chunks)
     total_chunks = (total_rows + chunk_size - 1) // chunk_size
+    stage_label = "Applying term frequencies"
+    progress = _ProgressBar(
+        label=stage_label,
+        total=total_rows,
+        total_units=total_chunks,
+        enabled=show_progress,
+    )
 
     # Get the underlying table name for direct access
     cleaned_table_name = cleaned_address_table.alias
@@ -577,50 +696,66 @@ def prepare_data_for_matching(
         raise ValueError("dataset_role must be one of: 'messy', 'canonical', or None.")
 
     # Apply term frequencies and trigram blocking to cleaned chunks
-    for chunk_index in range(total_chunks):
-        chunk_started_at = time.perf_counter()
-        chunk_query = con.sql(f"""
-        SELECT *
-            FROM {cleaned_table_name}
-            WHERE (abs(hash(original_address_concat)) % {total_chunks}) = {chunk_index}
-        """)
-        chunk_table = f"__ukam_post_tf_chunk_input_{uid}_{chunk_index}"
-        chunk = _materialise_relation(con, chunk_query, chunk_table)
+    stage_started_at = time.perf_counter()
+    _log_stage_start(stage_label, total_rows, total_chunks)
+    try:
+        for chunk_index in range(total_chunks):
+            chunk_started_at = time.perf_counter()
+            chunk_query = con.sql(f"""
+            SELECT *
+                FROM {cleaned_table_name}
+                WHERE
+                    (abs(hash(original_address_concat)) % {total_chunks})
+                    = {chunk_index}
+            """)
+            chunk_table = f"__ukam_post_tf_chunk_input_{uid}_{chunk_index}"
+            chunk = _materialise_relation(con, chunk_query, chunk_table)
 
-        # Process chunk: apply term frequencies + inverted index blocking in one pass
-        processed_chunk = _clean_data_using_precomputed_rel_tok_freq(
-            chunk,
-            con=con,
-            pre_cleaned_addresses=True,
-            derive_distinguishing_wrt_adjacent_records=(
-                derive_distinguishing_wrt_adjacent_records
-            ),
-            additional_stages=inverted_index_stages,
-            debug_options=debug_options if chunk_index == 0 else None,
-        )
+            # Process chunk: apply term frequencies + inverted index blocking in one pass
+            processed_chunk = _clean_data_using_precomputed_rel_tok_freq(
+                chunk,
+                con=con,
+                pre_cleaned_addresses=True,
+                derive_distinguishing_wrt_adjacent_records=(
+                    derive_distinguishing_wrt_adjacent_records
+                ),
+                additional_stages=inverted_index_stages,
+                debug_options=debug_options if chunk_index == 0 else None,
+            )
 
-        if chunk_index == 0:
-            con.execute(f"DROP TABLE IF EXISTS {processed_table}")
-            processed_chunk.create(processed_table)
-        else:
-            processed_chunk.insert_into(processed_table)
+            if chunk_index == 0:
+                con.execute(f"DROP TABLE IF EXISTS {processed_table}")
+                processed_chunk.create(processed_table)
+            else:
+                processed_chunk.insert_into(processed_table)
 
-        # Delete processed rows from the intermediate cleaned table to free memory
-        con.execute(f"""
-            DELETE FROM {cleaned_table_name}
-            WHERE (abs(hash(original_address_concat)) % {total_chunks}) = {chunk_index}
-        """)
+            # Delete processed rows from the intermediate cleaned table to free memory
+            con.execute(f"""
+                DELETE FROM {cleaned_table_name}
+                WHERE
+                    (abs(hash(original_address_concat)) % {total_chunks})
+                    = {chunk_index}
+            """)
 
-        _log_progress(
-            total_rows,
-            min((chunk_index + 1) * chunk_size, total_rows),
-            stage_type="Applied term frequencies: ",
-            chunk_index=chunk_index,
-            total_chunks=total_chunks,
-            chunk_elapsed_seconds=time.perf_counter() - chunk_started_at,
-        )
+            processed_records = min((chunk_index + 1) * chunk_size, total_rows)
+            progress.update(
+                processed_records,
+                completed_units=chunk_index + 1,
+            )
+            _log_progress(
+                total_rows,
+                processed_records,
+                stage_label=stage_label,
+                chunk_index=chunk_index,
+                total_chunks=total_chunks,
+                chunk_elapsed_seconds=time.perf_counter() - chunk_started_at,
+            )
 
-        _drop_table_and_registered_aliases(con, chunk_table)
+            _drop_table_and_registered_aliases(con, chunk_table)
+    finally:
+        progress.close()
+
+    _log_stage_complete(stage_label, total_rows, time.perf_counter() - stage_started_at)
 
     # Verify the intermediate table is now empty (all chunks processed)
     remaining_rows = con.sql(f"SELECT COUNT(*) FROM {cleaned_table_name}").fetchone()[0]

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -81,6 +81,14 @@ def _format_elapsed(elapsed_seconds: float) -> str:
     return f"{minutes}m {seconds:02d}s"
 
 
+def _format_progress_bar(progress_fraction: float, *, width: int = 24) -> str:
+    clamped_progress = min(max(progress_fraction, 0.0), 1.0)
+    filled_width = int(round(clamped_progress * width))
+    filled = "▮" * filled_width
+    empty = "▯" * (width - filled_width)
+    return f"▕{filled}{empty}▏"
+
+
 def _log_progress(
     total_records: int,
     processed_records: int,
@@ -91,16 +99,19 @@ def _log_progress(
     chunk_elapsed_seconds: float | None = None,
 ) -> None:
     percentage_complete = processed_records / total_records if total_records > 0 else 1.0
+    percent_label = f"{percentage_complete:.0%}"
+    progress_bar = _format_progress_bar(percentage_complete)
+    chunk_label = ""
+    if chunk_index is not None and total_chunks is not None:
+        chunk_label = f"chunk {chunk_index + 1}/{total_chunks} "
 
     message = (
         f"{stage_type}"
-        f"{processed_records:,.0f} records ({percentage_complete:.0%} complete)"
+        f"{chunk_label}{percent_label} {progress_bar} "
+        f"({processed_records:,.0f}/{total_records:,.0f} records)"
     )
     if chunk_elapsed_seconds is not None:
-        chunk_suffix = ""
-        if chunk_index is not None and total_chunks is not None:
-            chunk_suffix = f"chunk {chunk_index + 1}/{total_chunks} "
-        message += f" - {chunk_suffix}took {_format_elapsed(chunk_elapsed_seconds)}"
+        message += f" ({_format_elapsed(chunk_elapsed_seconds)} elapsed)"
 
     logger.info(message)
 

--- a/uk_address_matcher/helpers/__init__.py
+++ b/uk_address_matcher/helpers/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/uk_address_matcher/helpers/canonical_inputs.py
+++ b/uk_address_matcher/helpers/canonical_inputs.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import duckdb
+
+
+def normalise_and_validate_raw_canonical(
+    rel: duckdb.DuckDBPyRelation,
+) -> duckdb.DuckDBPyRelation:
+    """Normalise and validate required columns for raw canonical input."""
+    if "address_concat" not in rel.columns and "original_address_concat" in rel.columns:
+        rel = rel.project("*, original_address_concat AS address_concat")
+
+    required = {"unique_id", "address_concat"}
+    missing = sorted(required.difference(rel.columns))
+    if missing:
+        raise ValueError(
+            "Canonical input is missing required columns: "
+            f"{missing}. Expected at least ['address_concat', 'unique_id']."
+        )
+
+    return rel

--- a/uk_address_matcher/helpers/path_parsing.py
+++ b/uk_address_matcher/helpers/path_parsing.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import duckdb
+
+
+def is_uri_reference(path: str | Path) -> bool:
+    """Return True when a path-like value is a URI string."""
+    return isinstance(path, str) and bool(urlsplit(path).scheme)
+
+
+def is_remote_folder_reference(folder: str | Path) -> bool:
+    """Return True when a folder reference points to a remote URI."""
+    return is_uri_reference(folder)
+
+
+def is_path_like_input(value: object) -> bool:
+    """Return True for a single supported path-like input."""
+    return isinstance(value, (str, Path))
+
+
+def is_sequence_of_path_like_inputs(value: object) -> bool:
+    """Return True for a non-empty list of supported path-like inputs."""
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, (str, Path)) for item in value)
+    )
+
+
+def join_remote_path(base: str, name: str) -> str:
+    """Join a remote base URI and relative artefact name."""
+    return f"{base.rstrip('/')}/{name}"
+
+
+def strip_uri_query_or_fragment(path: str) -> str:
+    """Strip URI query parameters and fragments for suffix detection."""
+    parsed = urlsplit(path)
+    return parsed.path if parsed.scheme else path.split("?", 1)[0].split("#", 1)[0]
+
+
+def infer_tabular_input_format(path: str | Path) -> str | None:
+    """Infer the supported tabular format for a local path or URI."""
+    stripped_path = strip_uri_query_or_fragment(str(path)).lower()
+    if stripped_path.endswith(".parquet") or "*.parquet" in stripped_path:
+        return "parquet"
+    if stripped_path.endswith(".csv") or "*.csv" in stripped_path:
+        return "csv"
+    return None
+
+
+def relative_remote_path(base: str, path: str) -> str:
+    """Return the artefact path relative to a remote base URI."""
+    prefix = f"{base.rstrip('/')}/"
+    if path.startswith(prefix):
+        return path[len(prefix) :]
+    return path
+
+
+def read_duckdb_relation_from_path(
+    path_or_paths: str | Path | list[str | Path],
+    *,
+    con: duckdb.DuckDBPyConnection,
+) -> duckdb.DuckDBPyRelation:
+    """Read CSV or Parquet path input(s) through DuckDB."""
+    paths = [path_or_paths] if is_path_like_input(path_or_paths) else path_or_paths
+    path_strings = [str(path) for path in paths]
+    formats = {infer_tabular_input_format(path) for path in path_strings}
+
+    if None in formats:
+        raise ValueError(
+            "Unsupported canonical input file type. Expected CSV or Parquet path(s)."
+        )
+    if len(formats) != 1:
+        raise ValueError(
+            "Canonical input path list must use a single file type. "
+            "Mixing CSV and Parquet inputs is not supported."
+        )
+
+    read_input: str | list[str] = (
+        path_strings[0] if len(path_strings) == 1 else path_strings
+    )
+    input_format = next(iter(formats))
+    if input_format == "parquet":
+        return con.read_parquet(read_input)
+    return con.read_csv(read_input)

--- a/uk_address_matcher/helpers/progress.py
+++ b/uk_address_matcher/helpers/progress.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sys
+import time
+
+
+class _ProgressBar:
+    def __init__(
+        self,
+        *,
+        label: str,
+        total: int,
+        total_units: int | None = None,
+        enabled: bool = True,
+        stream: object | None = None,
+        width: int = 24,
+    ) -> None:
+        self.label = label
+        self.total = max(0, total)
+        self.total_units = max(1, total_units or 24)
+        self.completed_units = 0
+        self.current = 0
+        self.stream = sys.stderr if stream is None else stream
+        self.width = max(8, width)
+        self.start_time = time.monotonic()
+        self._rendered = False
+        self._last_render_length = 0
+        self._left_edge = "▕"
+        self._right_edge = "▏"
+        self._filled_glyph = "▮"
+        self._empty_glyph = "▯"
+
+        self.enabled = enabled
+        self._configure_glyphs()
+
+    def _configure_glyphs(self) -> None:
+        encoding = getattr(self.stream, "encoding", None) or "utf-8"
+        try:
+            "▕▏▮▯".encode(encoding)
+        except (LookupError, UnicodeEncodeError):
+            self._left_edge = "["
+            self._right_edge = "]"
+            self._filled_glyph = "#"
+            self._empty_glyph = "-"
+
+    def _disable(self) -> None:
+        self.enabled = False
+
+    def update(self, current: int, *, completed_units: int | None = None) -> None:
+        if not self.enabled:
+            return
+
+        self.current = min(max(0, current), self.total)
+        if completed_units is not None:
+            self.completed_units = min(max(0, completed_units), self.total_units)
+
+        fraction = self.current / self.total if self.total else 1.0
+        percent = int(fraction * 100)
+        elapsed = time.monotonic() - self.start_time
+        unit_fraction = (
+            self.completed_units / self.total_units if self.total_units else 1.0
+        )
+        filled_units = int(round(self.width * unit_fraction))
+        filled_units = min(max(0, filled_units), self.width)
+        empty_units = self.width - filled_units
+        bar = self._filled_glyph * filled_units + self._empty_glyph * empty_units
+
+        try:
+            line = (
+                f"{self.label}: {percent:3d}% "
+                f"{self._left_edge}{bar}{self._right_edge} "
+                f"({self.current:,}/{self.total:,} records, "
+                f"{elapsed:05.2f}s elapsed)"
+            )
+            padding = " " * max(0, self._last_render_length - len(line))
+            self.stream.write(f"\r{line}{padding}")
+            self.stream.flush()
+            self._rendered = True
+            self._last_render_length = len(line)
+        except (OSError, UnicodeEncodeError, ValueError):
+            self._disable()
+
+    def close(self) -> None:
+        if self.enabled and self._rendered:
+            try:
+                self.stream.write("\n")
+                self.stream.flush()
+            except (OSError, UnicodeEncodeError, ValueError):
+                self._disable()

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import re
 import shutil
 import time
 import warnings
@@ -13,6 +12,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from uk_address_matcher._typing import PrepareCanonicalInput
+from uk_address_matcher.helpers.canonical_inputs import (
+    normalise_and_validate_raw_canonical,
+)
+from uk_address_matcher.helpers.path_parsing import (
+    is_path_like_input,
+    is_remote_folder_reference,
+    is_sequence_of_path_like_inputs,
+    join_remote_path,
+    read_duckdb_relation_from_path,
+    relative_remote_path,
+)
 from uk_address_matcher.sql_pipeline.helpers import _register_input_relation_once
 
 if TYPE_CHECKING:
@@ -66,17 +77,69 @@ class _PreparedFolderLayout:
     canonical_paths: list[Path]
 
 
-_URI_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+def _escape_sql_string(value: str) -> str:
+    """Escape a Python string for embedding in a DuckDB SQL string literal."""
+    return value.replace("'", "''")
 
 
-def _is_remote_folder_reference(folder: str | Path) -> bool:
-    """Return True if the provided folder points to a remote URI."""
-    return isinstance(folder, str) and bool(_URI_SCHEME_RE.match(folder))
+def _describe_prepare_input(data: PrepareCanonicalInput) -> str:
+    """Return a concise description of the canonical input source."""
+    if is_path_like_input(data):
+        return str(data)
+    if is_sequence_of_path_like_inputs(data):
+        return f"{len(data)} path(s): {', '.join(str(item) for item in data)}"
+    return "DuckDB relation"
 
 
-def _join_remote_path(base: str, name: str) -> str:
-    """Join a remote base URI and relative artefact name."""
-    return f"{base.rstrip('/')}/{name}"
+def _coerce_prepare_input_to_relation(
+    data: PrepareCanonicalInput,
+    *,
+    con: duckdb.DuckDBPyConnection,
+) -> duckdb.DuckDBPyRelation:
+    """Coerce supported canonical input types into a DuckDB relation."""
+    import duckdb as _duckdb
+
+    if isinstance(data, _duckdb.DuckDBPyRelation):
+        rel = _register_input_relation_once(data, con=con, role="prepare_canonical")
+        return normalise_and_validate_raw_canonical(rel)
+
+    if is_path_like_input(data) or is_sequence_of_path_like_inputs(data):
+        rel = read_duckdb_relation_from_path(data, con=con)
+        return normalise_and_validate_raw_canonical(rel)
+
+    raise TypeError(
+        "prepare_canonical_folder expected a DuckDB relation, a CSV/Parquet path, "
+        "or a non-empty list of CSV/Parquet paths."
+    )
+
+
+def _remote_output_exists(
+    folder_uri: str,
+    *,
+    con: duckdb.DuckDBPyConnection,
+) -> bool:
+    """Best-effort check for existing remote prepared artefacts."""
+    candidate_paths = [
+        join_remote_path(folder_uri, PREPARED_TERM_FREQUENCIES_FILENAME),
+        join_remote_path(folder_uri, PREPARED_INVERTED_INDEX_FILENAME),
+        join_remote_path(folder_uri, PREPARED_ADDRESSES_FILENAME),
+        join_remote_path(folder_uri, f"{PREPARED_ADDRESSES_CHUNK_DIRNAME}/*.parquet"),
+    ]
+
+    for candidate_path in candidate_paths:
+        try:
+            con.read_parquet(candidate_path).limit(1).fetchone()
+            return True
+        except Exception as exc:
+            _rollback_if_needed(con)
+            if _is_permission_error(exc):
+                raise PermissionError(
+                    f"Cannot inspect remote output folder '{folder_uri}'. "
+                    "Check object-store credentials and permissions. "
+                    f"Underlying error: {exc}"
+                ) from exc
+
+    return False
 
 
 def _is_permission_error(exc: Exception) -> bool:
@@ -117,14 +180,14 @@ def _load_prepared_canonical_data_remote(
     # transaction state. Clear it before attempting fallback reads.
     _rollback_if_needed(con)
 
-    tf_uri = _join_remote_path(folder_uri, PREPARED_TERM_FREQUENCIES_FILENAME)
-    idx_uri = _join_remote_path(folder_uri, PREPARED_INVERTED_INDEX_FILENAME)
-    single_canonical_uri = _join_remote_path(folder_uri, PREPARED_ADDRESSES_FILENAME)
-    chunk_glob_uri = _join_remote_path(
+    tf_uri = join_remote_path(folder_uri, PREPARED_TERM_FREQUENCIES_FILENAME)
+    idx_uri = join_remote_path(folder_uri, PREPARED_INVERTED_INDEX_FILENAME)
+    single_canonical_uri = join_remote_path(folder_uri, PREPARED_ADDRESSES_FILENAME)
+    chunk_glob_uri = join_remote_path(
         folder_uri,
         f"{PREPARED_ADDRESSES_CHUNK_DIRNAME}/*.parquet",
     )
-    single_dataset_glob_uri = _join_remote_path(
+    single_dataset_glob_uri = join_remote_path(
         folder_uri,
         f"{PREPARED_ADDRESSES_FILENAME}/*.parquet",
     )
@@ -275,8 +338,26 @@ def _resolve_canonical_parquet_paths(folder: Path) -> list[Path]:
     return []
 
 
+def _build_manifest(
+    *,
+    created_with_duckdb_version: str,
+    files_meta: dict[str, dict[str, object]],
+    row_counts: dict[str, int],
+) -> dict[str, object]:
+    """Build the manifest payload shared by local and remote writers."""
+    from uk_address_matcher import __version__
+
+    return {
+        "ukam_version": __version__,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_with_duckdb_version": created_with_duckdb_version,
+        "row_counts": row_counts,
+        "files": files_meta,
+    }
+
+
 def prepare_canonical_folder(
-    data: duckdb.DuckDBPyRelation,
+    data: PrepareCanonicalInput,
     output_folder: str | Path,
     *,
     con: duckdb.DuckDBPyConnection,
@@ -300,7 +381,8 @@ def prepare_canonical_folder(
     - `ukam_manifest.json` — provenance metadata (version, row counts, hashes)
 
     Args:
-        data: Raw canonical address data as a DuckDB relation.
+        data: Raw canonical address data as a DuckDB relation, a CSV/Parquet
+            path, or a non-empty list of CSV/Parquet paths.
         output_folder: Folder to write prepared artefacts to.
         con: DuckDB connection.
         num_of_chunks: Number of chunks to split the data into for cleaning
@@ -323,26 +405,40 @@ def prepare_canonical_folder(
         prepare_data_for_matching,
     )
 
-    output_folder = Path(output_folder)
-    data = _register_input_relation_once(data, con=con, role="prepare_canonical")
+    output_is_remote = is_remote_folder_reference(output_folder)
+    output_folder_uri = str(output_folder) if output_is_remote else None
+    output_folder_path = None if output_is_remote else Path(output_folder)
+    data = _coerce_prepare_input_to_relation(data, con=con)
+
+    logger.debug("Preparing canonical data from '%s'", _describe_prepare_input(data))
+    logger.debug("Writing prepared canonical artefacts to '%s'", output_folder)
 
     _validate_chunk_count(num_of_chunks, name="num_of_chunks")
     _validate_chunk_count(output_chunk_count, name="output_chunk_count")
 
-    if output_folder.exists() and not overwrite:
-        existing = [f for f in REQUIRED_FILES if (output_folder / f).exists()]
-        if _resolve_canonical_parquet_paths(output_folder):
-            existing.append("canonical_addresses")
-        if existing:
+    if output_is_remote:
+        assert output_folder_uri is not None
+        if not overwrite and _remote_output_exists(output_folder_uri, con=con):
             raise FileExistsError(
-                f"Output folder '{output_folder}' already contains prepared files: "
-                f"{existing}. Set overwrite=True to replace them."
+                f"Output folder '{output_folder_uri}' already contains prepared "
+                "files. Set overwrite=True to replace the managed artefacts."
             )
+    else:
+        assert output_folder_path is not None
+        if output_folder_path.exists() and not overwrite:
+            existing = [f for f in REQUIRED_FILES if (output_folder_path / f).exists()]
+            if _resolve_canonical_parquet_paths(output_folder_path):
+                existing.append("canonical_addresses")
+            if existing:
+                raise FileExistsError(
+                    f"Output folder '{output_folder_path}' already contains prepared "
+                    f"files: {existing}. Set overwrite=True to replace them."
+                )
 
-    output_folder.mkdir(parents=True, exist_ok=True)
+        output_folder_path.mkdir(parents=True, exist_ok=True)
 
-    if overwrite:
-        _clear_stale_artefacts(output_folder)
+        if overwrite:
+            _clear_stale_artefacts(output_folder_path)
 
     # Derive artefacts / cleaned canonical data for export
     logger.debug("Deriving term frequencies from canonical data")
@@ -360,20 +456,39 @@ def prepare_canonical_folder(
     inverted_index = derive_inverted_index(df_clean, con=con, num_of_chunks=num_of_chunks)
 
     # Write parquet files
-    tf_path = output_folder / PREPARED_TERM_FREQUENCIES_FILENAME
-    idx_path = output_folder / PREPARED_INVERTED_INDEX_FILENAME
+    tf_path = (
+        join_remote_path(output_folder_uri, PREPARED_TERM_FREQUENCIES_FILENAME)
+        if output_is_remote
+        else output_folder_path / PREPARED_TERM_FREQUENCIES_FILENAME
+    )
+    idx_path = (
+        join_remote_path(output_folder_uri, PREPARED_INVERTED_INDEX_FILENAME)
+        if output_is_remote
+        else output_folder_path / PREPARED_INVERTED_INDEX_FILENAME
+    )
 
     tf_table.write_parquet(str(tf_path))
     inverted_index.write_parquet(str(idx_path))
 
-    canonical_paths: list[Path]
+    canonical_paths: list[str | Path]
+    chunk_output_location: str | Path | None = None
     if output_chunk_count == 1:
-        addr_path = output_folder / PREPARED_ADDRESSES_FILENAME
+        addr_path = (
+            join_remote_path(output_folder_uri, PREPARED_ADDRESSES_FILENAME)
+            if output_is_remote
+            else output_folder_path / PREPARED_ADDRESSES_FILENAME
+        )
         df_clean.write_parquet(str(addr_path))
         canonical_paths = [addr_path]
     else:
-        chunk_dir = output_folder / PREPARED_ADDRESSES_CHUNK_DIRNAME
-        chunk_dir.mkdir(parents=True, exist_ok=True)
+        chunk_dir = (
+            join_remote_path(output_folder_uri, PREPARED_ADDRESSES_CHUNK_DIRNAME)
+            if output_is_remote
+            else output_folder_path / PREPARED_ADDRESSES_CHUNK_DIRNAME
+        )
+        chunk_output_location = chunk_dir
+        if not output_is_remote:
+            Path(chunk_dir).mkdir(parents=True, exist_ok=True)
 
         uid = uuid4().hex
         input_table = f"__ukam_prepare_canonical_clean_{uid}"
@@ -382,28 +497,37 @@ def prepare_canonical_folder(
         con.execute(f"DROP TABLE IF EXISTS {input_table}")
         df_clean.create(input_table)
 
-        canonical_paths = []
-        for chunk_index in range(output_chunk_count):
-            started_at = time.perf_counter()
-            chunk_query = con.sql(f"""
-                SELECT *
-                FROM {input_table}
-                WHERE (abs(hash({hash_key})) % {output_chunk_count}) = {chunk_index}
-            """)
-            chunk_path = chunk_dir / _chunk_file_name(chunk_index, output_chunk_count)
-            chunk_query.write_parquet(str(chunk_path))
-            chunk_count = chunk_query.count("*").fetchone()[0]
-            canonical_paths.append(chunk_path)
-            logger.info(
-                "Wrote canonical output chunk %d/%d to '%s' (%d rows) - took %s",
-                chunk_index + 1,
-                output_chunk_count,
-                chunk_path,
-                chunk_count,
-                _format_elapsed(time.perf_counter() - started_at),
-            )
-
-        con.execute(f"DROP TABLE IF EXISTS {input_table}")
+        try:
+            canonical_paths = []
+            for chunk_index in range(output_chunk_count):
+                started_at = time.perf_counter()
+                chunk_query = con.sql(f"""
+                    SELECT *
+                    FROM {input_table}
+                    WHERE (abs(hash({hash_key})) % {output_chunk_count}) = {chunk_index}
+                """)
+                chunk_path = (
+                    join_remote_path(
+                        str(chunk_dir),
+                        _chunk_file_name(chunk_index, output_chunk_count),
+                    )
+                    if output_is_remote
+                    else Path(chunk_dir)
+                    / _chunk_file_name(chunk_index, output_chunk_count)
+                )
+                chunk_query.write_parquet(str(chunk_path))
+                chunk_count = chunk_query.count("*").fetchone()[0]
+                canonical_paths.append(chunk_path)
+                logger.info(
+                    "Wrote canonical output chunk %d/%d to '%s' (%d rows) - took %s",
+                    chunk_index + 1,
+                    output_chunk_count,
+                    chunk_path,
+                    chunk_count,
+                    _format_elapsed(time.perf_counter() - started_at),
+                )
+        finally:
+            con.execute(f"DROP TABLE IF EXISTS {input_table}")
 
     # Compute row counts once (avoids repeated full scans)
     addr_count = df_clean.count("*").fetchone()[0]
@@ -422,7 +546,7 @@ def prepare_canonical_folder(
         logger.info(
             "Wrote %d canonical output chunks to '%s'",
             output_chunk_count,
-            output_folder / PREPARED_ADDRESSES_CHUNK_DIRNAME,
+            chunk_output_location,
         )
 
     artefact_columns: dict[str, list[str]] = {
@@ -430,24 +554,39 @@ def prepare_canonical_folder(
         PREPARED_INVERTED_INDEX_FILENAME: inverted_index.columns,
     }
     for canonical_path in canonical_paths:
-        relative_name = str(canonical_path.relative_to(output_folder))
+        relative_name = (
+            relative_remote_path(output_folder_uri, str(canonical_path))
+            if output_is_remote
+            else str(Path(canonical_path).relative_to(output_folder_path))
+        )
         artefact_columns[relative_name] = df_clean.columns
 
-    _write_manifest(
-        output_folder,
-        con=con,
-        artefact_paths=[*canonical_paths, tf_path, idx_path],
-        artefact_columns=artefact_columns,
-        row_counts={
-            "canonical_addresses": addr_count,
-            "term_frequencies": tf_count,
-            "inverted_index": idx_count,
-            "canonical_output_chunks": output_chunk_count,
-        },
-    )
+    manifest_row_counts = {
+        "canonical_addresses": addr_count,
+        "term_frequencies": tf_count,
+        "inverted_index": idx_count,
+        "canonical_output_chunks": output_chunk_count,
+    }
+
+    if output_is_remote:
+        _write_manifest_remote(
+            output_folder_uri,
+            con=con,
+            artefact_paths=[str(path) for path in [*canonical_paths, tf_path, idx_path]],
+            artefact_columns=artefact_columns,
+            row_counts=manifest_row_counts,
+        )
+    else:
+        _write_manifest_local(
+            output_folder_path,
+            con=con,
+            artefact_paths=[Path(path) for path in [*canonical_paths, tf_path, idx_path]],
+            artefact_columns=artefact_columns,
+            row_counts=manifest_row_counts,
+        )
 
 
-def _write_manifest(
+def _write_manifest_local(
     folder: Path,
     *,
     con: duckdb.DuckDBPyConnection,
@@ -462,8 +601,6 @@ def _write_manifest(
     """
     import duckdb as _duckdb
 
-    from uk_address_matcher import __version__
-
     files_meta = {}
     for p in artefact_paths:
         name = str(p.relative_to(folder))
@@ -474,13 +611,11 @@ def _write_manifest(
             "columns": artefact_columns.get(name, []),
         }
 
-    manifest = {
-        "ukam_version": __version__,
-        "created_at": datetime.now(timezone.utc).isoformat(),
-        "created_with_duckdb_version": _duckdb.__version__,
-        "row_counts": row_counts,
-        "files": files_meta,
-    }
+    manifest = _build_manifest(
+        created_with_duckdb_version=_duckdb.__version__,
+        files_meta=files_meta,
+        row_counts=row_counts,
+    )
 
     # Atomic write: write to a temp file then replace
     tmp = folder / f"{MANIFEST_FILENAME}.tmp"
@@ -488,6 +623,61 @@ def _write_manifest(
     tmp.replace(folder / MANIFEST_FILENAME)
 
     logger.debug("Manifest written to '%s'", folder / MANIFEST_FILENAME)
+
+
+def _write_manifest_remote(
+    folder_uri: str,
+    *,
+    con: duckdb.DuckDBPyConnection,
+    artefact_paths: list[str],
+    artefact_columns: dict[str, list[str]],
+    row_counts: dict[str, int],
+) -> None:
+    """Write a JSON manifest to a remote folder via DuckDB COPY."""
+    import duckdb as _duckdb
+
+    files_meta = {}
+    for path in artefact_paths:
+        name = relative_remote_path(folder_uri, path)
+        files_meta[name] = {
+            "size_bytes": None,
+            "sha256": None,
+            "columns": artefact_columns.get(name, []),
+        }
+
+    manifest = _build_manifest(
+        created_with_duckdb_version=_duckdb.__version__,
+        files_meta=files_meta,
+        row_counts=row_counts,
+    )
+
+    manifest_table = f"__ukam_manifest_{uuid4().hex}"
+    manifest_uri = join_remote_path(folder_uri, MANIFEST_FILENAME)
+    escaped_manifest_uri = _escape_sql_string(manifest_uri)
+    con.execute(
+        (
+            f"CREATE TEMP TABLE {manifest_table} AS "
+            "SELECT ? AS ukam_version, ? AS created_at, "
+            "? AS created_with_duckdb_version, "
+            "?::JSON AS row_counts, ?::JSON AS files"
+        ),
+        [
+            manifest["ukam_version"],
+            manifest["created_at"],
+            manifest["created_with_duckdb_version"],
+            json.dumps(manifest["row_counts"]),
+            json.dumps(manifest["files"]),
+        ],
+    )
+    try:
+        con.execute(
+            f"COPY {manifest_table} TO '{escaped_manifest_uri}' "
+            "(FORMAT JSON, ARRAY false)"
+        )
+    finally:
+        con.execute(f"DROP TABLE IF EXISTS {manifest_table}")
+
+    logger.debug("Manifest written to '%s'", manifest_uri)
 
 
 def _check_manifest(folder: Path) -> None:
@@ -612,7 +802,7 @@ def load_prepared_canonical_data(
         A `_PreparedCanonical` containing `addresses`, `term_frequencies`,
         and `inverted_index` relations.
     """
-    if _is_remote_folder_reference(folder):
+    if is_remote_folder_reference(folder):
         return _load_prepared_canonical_data_remote(
             folder,
             con=con,

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -364,6 +364,7 @@ def prepare_canonical_folder(
     num_of_chunks: int = 10,
     output_chunk_count: int = 1,
     overwrite: bool = False,
+    show_progress: bool = True,
 ) -> None:
     """Prepare canonical data and persist to a folder for later use.
 
@@ -394,6 +395,8 @@ def prepare_canonical_folder(
         overwrite: Whether to overwrite existing files in the folder. When
             `True`, all known artefacts are removed before writing to ensure
             the folder ends up in a consistent state.
+        show_progress: Whether to show live interactive progress bars for
+            chunked cleaning stages.
 
     Raises:
         FileExistsError: If the output folder already contains prepared files
@@ -410,8 +413,8 @@ def prepare_canonical_folder(
     output_folder_path = None if output_is_remote else Path(output_folder)
     data = _coerce_prepare_input_to_relation(data, con=con)
 
-    logger.debug("Preparing canonical data from '%s'", _describe_prepare_input(data))
-    logger.debug("Writing prepared canonical artefacts to '%s'", output_folder)
+    logger.info("Preparing canonical data from '%s'", _describe_prepare_input(data))
+    logger.info("Writing prepared canonical artefacts to '%s'", output_folder)
 
     _validate_chunk_count(num_of_chunks, name="num_of_chunks")
     _validate_chunk_count(output_chunk_count, name="output_chunk_count")
@@ -442,7 +445,12 @@ def prepare_canonical_folder(
 
     # Derive artefacts / cleaned canonical data for export
     logger.debug("Deriving term frequencies from canonical data")
-    tf_table = derive_term_frequencies_table(data, con=con, num_of_chunks=num_of_chunks)
+    tf_table = derive_term_frequencies_table(
+        data,
+        con=con,
+        num_of_chunks=num_of_chunks,
+        show_progress=show_progress,
+    )
 
     logger.debug("Cleaning canonical addresses")
     df_clean = prepare_data_for_matching(
@@ -450,10 +458,16 @@ def prepare_canonical_folder(
         con=con,
         num_of_chunks=num_of_chunks,
         term_frequency_lookup=tf_table,
+        show_progress=show_progress,
     )
 
     logger.debug("Building inverted index")
-    inverted_index = derive_inverted_index(df_clean, con=con, num_of_chunks=num_of_chunks)
+    inverted_index = derive_inverted_index(
+        df_clean,
+        con=con,
+        num_of_chunks=num_of_chunks,
+        show_progress=show_progress,
+    )
 
     # Write parquet files
     tf_path = (
@@ -518,7 +532,7 @@ def prepare_canonical_folder(
                 chunk_query.write_parquet(str(chunk_path))
                 chunk_count = chunk_query.count("*").fetchone()[0]
                 canonical_paths.append(chunk_path)
-                logger.info(
+                logger.debug(
                     "Wrote canonical output chunk %d/%d to '%s' (%d rows) - took %s",
                     chunk_index + 1,
                     output_chunk_count,
@@ -543,7 +557,7 @@ def prepare_canonical_folder(
     )
 
     if output_chunk_count > 1:
-        logger.info(
+        logger.debug(
             "Wrote %d canonical output chunks to '%s'",
             output_chunk_count,
             chunk_output_location,
@@ -584,6 +598,8 @@ def prepare_canonical_folder(
             artefact_columns=artefact_columns,
             row_counts=manifest_row_counts,
         )
+
+    logger.info("Prepared canonical artefacts written to '%s'", output_folder)
 
 
 def _write_manifest_local(


### PR DESCRIPTION
## PR Summary

This PR delivers two main improvements to the canonical pre-cleaning workflow:

1. Replaces noisy per-chunk progress logging with live progress bars and cleaner stage-level logging.
2. Extends canonical preparation so it can read raw inputs directly from cloud object storage and write prepared artefacts back to cloud storage without requiring a local staging step.

Together, these changes make large pre-cleaning jobs easier to run operationally and much easier to follow while they are running.

## Change 1: Progress bar logging

### What changed

Pre-cleaning previously emitted a large number of chunk-level log lines during cleaning, term-frequency derivation, and inverted-index generation. This PR changes that behavior so that.

This now looks like so:
```txt
Cleaning for TF derivation: 100% ▕▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▏ (3,575,293/3,575,293 records, 127.03s elapsed)
INFO Cleaning for TF derivation completed: 3,575,293 records in 2m 07s
INFO Cleaning and preprocessing: 3,575,293 records across 10 chunks
Cleaning and preprocessing: 100% ▕▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▏ (3,575,293/3,575,293 records, 47.23s elapsed)
INFO Cleaning and preprocessing completed: 3,575,293 records in 47s
INFO Applying term frequencies: 3,575,293 records across 10 chunks
Applying term frequencies: 100% ▕▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▏ (3,575,293/3,575,293 records, 13.09s elapsed)
INFO Applying term frequencies completed: 3,575,293 records in 13s
INFO Building inverted index (trigram): 3,575,293 records across 10 chunks
Building inverted index (trigram): 100% ▕▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▏ (3,575,293/3,575,293 records, 06.15s elapsed)
INFO Building inverted index (trigram) completed: 3,575,293 records in 6s
INFO Building inverted index (bigram): 3,575,293 records across 10 chunks
Building inverted index (bigram): 100% ▕▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▮▏ (3,575,293/3,575,293 records, 04.58s elapsed)
```

This makes long-running jobs substantially easier to monitor:
- logs are less noisy in normal operation
- active work is easier to read at a glance
- chunking logic is cleaner because progress rendering is separated from processing code
- callers no longer need a tri-state progress setting

The existing logs are now output as debug calls, to reduce the amount of noise from the system.

## Change 2: Direct cloud read/write for pre-cleaning

### What changed

The canonical preparation entrypoint now accepts raw canonical input from more than just an in-memory DuckDB relation. It can now consume:

- a DuckDB relation
- a local CSV or Parquet path
- a list of local or remote CSV/Parquet paths
- cloud object-store paths supported by DuckDB object-store access, such as S3-style URIs

Prepared output can also now be written directly to either:

- a local output folder
- a remote output prefix in object storage

The prepared-folder loader also supports loading prepared artefacts directly from a remote location.

This removes an unnecessary local staging step from batch workflows. It is now possible to:

- prepare canonical data directly from an object store source
- persist the cleaned canonical dataset, term frequencies, inverted index, and manifest straight back to the object store
- use the same preparation API for both local and cloud-based workflows

This is especially useful for production or benchmark runs where the raw canonical source already lives remotely.

### Example usage

#### Read raw canonical data from S3 and write prepared output back to S3

```python
import duckdb

from uk_address_matcher import prepare_canonical_folder

con = duckdb.connect()

prepare_canonical_folder(
    "s3://my-bucket/raw/canonical_addresses.parquet",
    output_folder="s3://my-bucket/prepared/ukam_canonical/",
    con=con,
    overwrite=True,
)
```