### PR TITLE
fix: update docstring for ExactMatch stage

### DIFF
--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -504,7 +504,7 @@ def test_stage_repr_is_concise_and_informative():
     assert exact_repr.startswith("ExactMatchStage()")
     assert "\n  Purpose:" in exact_repr
     assert (
-        "Deterministic exact matching on ``clean_full_address`` and ``postcode``."
+        "Deterministic exact matching on `clean_full_address` and `postcode`."
         in exact_repr
     )  # noqa: E501
     assert "\n  Import:  from uk_address_matcher import ExactMatchStage" in exact_repr

--- a/uk_address_matcher/linking_model/matching/stages/exact_match.py
+++ b/uk_address_matcher/linking_model/matching/stages/exact_match.py
@@ -62,7 +62,7 @@ def _flat_retraction_unit_evidence_sql(alias: str) -> str:
 
 @dataclass(frozen=True, repr=False)
 class ExactMatchStage(MatchingStage):
-    """Deterministic exact matching on ``clean_full_address`` and ``postcode``.
+    """Deterministic exact matching on `clean_full_address` and `postcode`.
 
     This is usually the first stage in a pipeline. It accepts the easy,
     unambiguous cases before any probabilistic matching is attempted.


### PR DESCRIPTION
`Deterministic exact matching on ``clean_full_address`` and ``postcode``.` -> `Deterministic exact matching on `clean_full_address` and `postcode`.`.

Fix added so when the available stages are printed to the user, it doesn't look strange. This is not being rendered by docs currently, so shouldn't cause any issues.