### PR TITLE
fix: resolve issue with duckdb 1.3.2

### DIFF
--- a/tests/sql_pipeline/test_helpers.py
+++ b/tests/sql_pipeline/test_helpers.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import duckdb
+
+from uk_address_matcher.sql_pipeline.helpers import _register_input_relation_once
+
+
+class _FakeRelation:
+    def __init__(self, sql: str) -> None:
+        self._sql = sql
+        self.alias = None
+
+    def sql_query(self) -> str:
+        return self._sql
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.register_calls: list[tuple[str, _FakeRelation]] = []
+        self.sql_calls: list[str] = []
+        self.table_calls: list[str] = []
+
+    def execute(self, _query: str) -> SimpleNamespace:
+        return SimpleNamespace(fetchone=lambda: (0,))
+
+    def register(self, alias: str, relation: _FakeRelation) -> None:
+        self.register_calls.append((alias, relation))
+
+    def table(self, alias: str) -> _FakeRelation:
+        self.table_calls.append(alias)
+        return _FakeRelation("SELECT * FROM ColumnDataCollection - broken")
+
+    def sql(self, query: str) -> _FakeRelation:
+        self.sql_calls.append(query)
+        return _FakeRelation(query)
+
+
+def test_register_input_relation_once_uses_sql_for_registered_aliases():
+    con = _FakeConnection()
+    relation = _FakeRelation("SELECT 1 AS a")
+
+    result = _register_input_relation_once(relation, con=con, role="probe")
+
+    assert len(con.register_calls) == 1
+    alias, registered_relation = con.register_calls[0]
+    assert registered_relation is relation
+    assert con.table_calls == []
+    assert con.sql_calls == [f'SELECT * FROM "{alias}"']
+    assert result.sql_query() == f'SELECT * FROM "{alias}"'
+
+
+def test_register_input_relation_once_returns_nested_sql_for_cross_connection_relation():
+    source_con = duckdb.connect(database=":memory:")
+    target_con = duckdb.connect(database=":memory:")
+
+    try:
+        relation = source_con.sql(
+            """
+            SELECT *
+            FROM (
+                VALUES
+                    (1, 'alpha'),
+                    (2, 'beta')
+            ) AS t(a, b)
+            """
+        )
+
+        registered = _register_input_relation_once(
+            relation,
+            con=target_con,
+            role="cross_connection",
+        )
+
+        target_con.execute(
+            "CREATE TABLE registered_copy AS "
+            f"SELECT * FROM ({registered.sql_query()}) AS src"
+        )
+        rows = target_con.table("registered_copy").order("a").fetchall()
+
+        assert rows == [(1, "alpha"), (2, "beta")]
+    finally:
+        source_con.close()
+        target_con.close()

--- a/uk_address_matcher/sql_pipeline/helpers.py
+++ b/uk_address_matcher/sql_pipeline/helpers.py
@@ -161,6 +161,24 @@ def _duckdb_table_exists(con: duckdb.DuckDBPyConnection, table_name: str) -> boo
     return result[0] > 0
 
 
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _relation_from_registered_alias(
+    con: duckdb.DuckDBPyConnection,
+    alias: str,
+) -> duckdb.DuckDBPyRelation:
+    """Read a registered alias via SQL rather than ``con.table(alias)``.
+
+    DuckDB 1.3.2 returns a debug-style ``sql_query()`` string for relations
+    created with ``con.table(alias)`` after ``con.register(...)``. Building the
+    relation via ``SELECT * FROM <alias>`` keeps ``sql_query()`` valid across
+    DuckDB versions, which matters because downstream code nests that SQL.
+    """
+    return con.sql(f"SELECT * FROM {_quote_identifier(alias)}")
+
+
 def _drop_table_and_registered_aliases(
     con: duckdb.DuckDBPyConnection,
     table_name: str,
@@ -197,7 +215,7 @@ def _register_input_relation_once(
     relation_sql = relation.sql_query()
     cached_alias = registration_cache.get(relation_sql)
     if cached_alias and _duckdb_table_exists(con, cached_alias):
-        return con.table(cached_alias)
+        return _relation_from_registered_alias(con, cached_alias)
 
     relation_alias = getattr(relation, "alias", None)
     if (
@@ -206,7 +224,7 @@ def _register_input_relation_once(
         and _duckdb_table_exists(con, str(relation_alias))
     ):
         registration_cache[relation_sql] = str(relation_alias)
-        return con.table(str(relation_alias))
+        return _relation_from_registered_alias(con, str(relation_alias))
 
     alias = f"__ukam__tmp_input_{role}_{_uid()}"
     while _duckdb_table_exists(con, alias):
@@ -220,7 +238,7 @@ def _register_input_relation_once(
         con.register(alias, relation.to_arrow_table())
 
     registration_cache[relation_sql] = alias
-    return con.table(alias)
+    return _relation_from_registered_alias(con, alias)
 
 
 def _explain_debug(con: duckdb.DuckDBPyConnection, sql: str) -> None:


### PR DESCRIPTION
Users have been reporting errors with some of the older duckdb versions, due to the way we have been pulling out specific info.

This typically manifests as:
`ParserException: Parser Error: syntax error at or near "-"`