### PR TITLE
feat(clean): sort inverted index to take advantage of RLE

### DIFF
--- a/.github/skills/benchmark-experiment/SKILL.md
+++ b/.github/skills/benchmark-experiment/SKILL.md
@@ -16,7 +16,7 @@ Use this skill for recurring benchmark workflows in `uk_address_matcher`.
 - The correct benchmark workflow is chosen.
 - Persisted artefacts are used before reruns where they already answer the question.
 - Rebuilds and reruns only happen when there is a concrete evidence gap.
-- Reports include run IDs, output paths, changed settings, and validation evidence.
+- Reports include run IDs, output paths, changed settings, PR-AUC / area-under-the-curve evidence, and validation evidence.
 
 ## Start Here
 
@@ -52,7 +52,9 @@ Start from persisted run artefacts whenever the request can be answered from exi
 
 - Prefer `uv run python -m ...` for benchmark entrypoints that rely on package imports.
 - Prefer persisted artefacts over console summaries.
-- Report run IDs, output directories, exact changed settings, and overlay chart paths.
+- Use PR-AUC / area under the precision-recall curve as a primary threshold-independent decision aid, not just fixed-threshold precision/recall.
+- Treat the overlay precision-recall chart plus PR-AUC as the minimum pair for deciding whether a variant is broadly better.
+- Report run IDs, output directories, exact changed settings, PR-AUC findings, and overlay chart paths.
 - If a workflow question is already answered in this skill, do not reopen broad repo exploration.
 
 ## Stop Rules

--- a/.github/skills/benchmark-experiment/artefacts.md
+++ b/.github/skills/benchmark-experiment/artefacts.md
@@ -12,7 +12,7 @@ benchmarking/results/<dataset>/<yyyy-mm-dd>/<run_id>/
   - Run metadata, stage definition, summary, timings, and chart paths.
 
 - `accuracy_table.json`
-  - Precision, recall, F1, and stage outcome counts.
+  - Precision, recall, F1, PR-AUC, operating-point recall/thresholds, default-threshold error rates, and stage outcome counts.
 
 - `stage_diagnostics.json`
   - Rows entering each stage, matched counts, and timing detail.
@@ -32,10 +32,18 @@ benchmarking/results/<dataset>/<yyyy-mm-dd>/<run_id>/
 ## When To Read Which Artefact
 
 - Start with `manifest.json` if you need run IDs, stage settings, summary counts, or output paths.
+- Read `accuracy_table.json` early when you need threshold-independent ranking evidence such as PR-AUC / area under the precision-recall curve and operating-point recall.
 - Read `comparison_report_*.md` first when the user wants a human-readable summary.
 - Read `comparison_summary_*.json` first when you need exact deltas or want to quote numbers programmatically.
 - Read the overlay chart or spec when the user asks whether the change is broadly better or worse across thresholds.
 - Read `stage_diagnostics.json` when the question is about runtime or stage-level movement.
+
+## AUC-Driven Decision Rules
+
+- Do not decide from one threshold alone when PR-AUC and the overlay chart disagree.
+- Use PR-AUC as the first check for whether ranking quality improved overall.
+- Then use operating-point recall from `accuracy_table.json` to answer practical questions like recall at `>=99%` precision.
+- Use fixed-threshold precision/recall/F1 only after the AUC-level picture is clear.
 
 ## Run Comparison Rules
 

--- a/docs/experiments/signature_evidence_overview.md
+++ b/docs/experiments/signature_evidence_overview.md
@@ -1,0 +1,352 @@
+# Signature Evidence (Inverted Index): Final Overview
+
+This document is the single consolidated record of the inverted-index
+"signature evidence" work. It replaces the earlier pair of notes
+(`signature_evidence_findings.md` and
+`signature_evidence_inverted_index_summary.md`) and is the place to return to if
+we pick this work back up.
+
+It covers:
+
+- what the feature is and how it works end to end,
+- the key design decision (why we did **not** materialise extra index columns),
+- what we tested and what the results were,
+- which existing model fields overlap with this signal,
+- the approach we are currently pursuing and the open questions.
+
+---
+
+## 1. What the feature is
+
+We reuse the existing bigram/trigram inverted index to produce a per-candidate
+overlap score for each messy → canonical pair, then expose that score to Splink
+as a new comparison called `signature_evidence`.
+
+Critically, we did **not** switch the persisted index to a richer multi-column
+scoring table. The on-disk index is still fundamentally a
+`key -> candidate unique_ids` structure. What changed lives in the runtime
+lookup and the model layer:
+
+1. the lookup stage derives an additional runtime score map from the same index,
+2. Splink reads that score map as a new comparison (`signature_evidence`),
+3. no new persisted scoring columns are required.
+
+---
+
+## 2. How it works end to end
+
+### 2.1 The persisted inverted index
+
+After the rebuild, the on-disk file
+[ukam_inverted_index.parquet](/Users/thomas.hepworth/data/address_matcher/secret_data/os/ukam_prepared_canonical/ukam_inverted_index.parquet)
+has three columns:
+
+- `key` — one bigram or trigram derived from `clean_full_address`
+- `unique_ids` — the list of canonical `unique_id` values containing that key
+- `index_strategy` — lightweight provenance / grouping metadata
+
+Build rules:
+
+- bigram and trigram keys only,
+- a key is kept only if it maps to at most `20` canonical ids (more common keys
+  are dropped as too common to be useful for blocking).
+
+There is deliberately **no** stored column for key frequency, IDF, capped
+score, within-address occurrence count, or any extra n-gram payload.
+
+`index_strategy` is not required by the scoring logic. We kept it because it
+compresses well when the parquet is written ordered by `index_strategy, key`,
+which actually makes the file smaller (see Section 6).
+
+### 2.2 The runtime scoring step
+
+During messy-side cleaning, in
+[inverted_index.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/cleaning/steps/inverted_index.py),
+we derive a `signature_score_map` column. For each messy record:
+
+1. generate its bigram/trigram keys,
+2. deduplicate the keys per record (a repeated n-gram counts once),
+3. join the keys to the inverted index,
+4. compute a per-key inverse-document-frequency weight:
+
+$$
+\mathrm{key\_idf} = \log_2\!\left(\frac{N}{\text{posting\_list\_size}}\right)
+$$
+
+where `N` is the canonical row count and
+`posting_list_size = len(unique_ids)` for that key,
+
+5. unnest the matched candidate ids and add the key's IDF to every candidate it
+   points to,
+6. emit `signature_score_map : MAP<canonical_id VARCHAR -> summed IDF DOUBLE>`.
+
+`N` is provided at match time via a small `__ukam_index_meta` table registered
+in
+[pipelines.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/cleaning/pipelines.py),
+and the canonical row count is threaded through
+[address_matcher.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/address_matcher.py).
+
+The resulting map is keyed by canonical `unique_id` and holds the summed IDF
+evidence for that messy row against each candidate, e.g.:
+
+```text
+{
+  "123456789": 42.7,
+  "987654321": 18.4,
+  "555555555": 7.9
+}
+```
+
+### 2.3 The Splink comparison
+
+In
+[splink_model.json](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/data/splink_model.json)
+the `signature_evidence` comparison reads the score for the specific candidate
+pair:
+
+```sql
+list_extract(map_extract(signature_score_map_r, CAST(unique_id_l AS VARCHAR)), 1)
+```
+
+Because Splink evaluates one pair at a time with the canonical row on the left
+(`_l`) and the messy row on the right (`_r`), this expression:
+
+1. takes the current canonical candidate id (`unique_id_l`),
+2. casts it to `VARCHAR` (the map keys are strings),
+3. looks it up in the messy row's `signature_score_map_r`,
+4. returns the summed IDF score for that exact pair.
+
+So the map is not a global table — it is a per-messy-row lookup answering "if
+Splink is currently evaluating candidate X against me, here is the overlap
+score for X".
+
+Current production buckets (Bayes factors):
+
+| Level | Condition | m |
+| --- | --- | --- |
+| very strong | summed IDF `>= 40` | 8 |
+| strong | summed IDF `>= 20` | 3 |
+| weak | summed IDF `>= 8` | 1.5 |
+| none / else | otherwise | neutral |
+
+The new "level" therefore lives in the model layer, not in the parquet schema.
+
+### 2.4 Two jobs from one index
+
+| Use | Question it answers |
+| --- | --- |
+| candidate generation (`exploding_unique_ids`) | which canonical ids share at least one bigram/trigram with this messy row? |
+| candidate scoring (`signature_score_map`) | for each of those ids, how much rare shared n-gram evidence is there? |
+
+The index was already powering `exploding_unique_ids` before this change. The
+new work added the scoring layer on top of the same structure.
+
+### 2.5 Worked example
+
+Messy address:
+
+```text
+flat 2 10 high street aberdeen
+```
+
+Generated keys include `flat 2`, `2 10`, `10 high`, `high street`,
+`flat 2 10`, `2 10 high`, `10 high street`. If:
+
+- candidate A shares `flat 2 10`, `10 high street`, `high street`
+- candidate B shares only `high street`
+- candidate C shares `10 high`
+
+then with rarer keys carrying higher IDF the map might be:
+
+```text
+{ "A": 41.6, "B": 4.3, "C": 9.8 }
+```
+
+Splink buckets these as A → very strong (`>= 40`), C → weak (`>= 8`), B →
+neutral. The feature says A is much stronger because it shares rarer, more
+distinctive fragments.
+
+---
+
+## 3. Why we did NOT precompute extra index fields
+
+A reasonable expectation was that we would expand the index to store per-key
+counts, capped scores, or precomputed weights. We deliberately did not, for
+these reasons:
+
+- **The score is pair-specific, not key-specific.** The useful number is "how
+  much shared rare-ngram evidence does *this messy row* have for *this
+  candidate*". That is a function of the messy row's key set and the candidate
+  id, summed across keys — not a property of any single key, so per-key scalars
+  would not save the join-and-sum we still do at match time.
+- **The expensive part is already cheap.** The IDF is just
+  `log2(N / len(unique_ids))`. `len(unique_ids)` is already in the index and `N`
+  is a single number, so precomputing IDF would only avoid one cheap `log2` per
+  key while enlarging the index and coupling it to `N`.
+- **We want the index small and reusable.** Adding per-key payloads grows disk
+  and match-time memory. Keeping it as `key -> unique_ids` keeps the same
+  structure powering both blocking and scoring.
+- **Repeated-ngram counts were intentionally dropped.** Keys are deduplicated
+  per record, so this is set-based overlap evidence, not repeated-occurrence
+  frequency. This avoids inflating scores for long or repetitive addresses,
+  which would hurt precision.
+- **The cap is structural, not a stored score.** The only cap is the build-time
+  posting-list cap (`<= 20` ids per key). The Splink thresholds (40/20/8) do the
+  bucketing at match time, where it is easy to tune.
+
+---
+
+## 4. What we tested and what worked
+
+### 4.1 Adding the scoring path (worked)
+
+Adding `signature_score_map` plus the `signature_evidence` comparison improved
+recall with negligible precision impact across all three benchmark datasets.
+
+Per-dataset deltas (signature ON vs OFF, current weights):
+
+| Dataset | Precision Δ | Recall Δ | F1 Δ |
+| --- | --- | --- | --- |
+| hackney | −0.023 pp | +0.354 pp | +0.171 pp |
+| rhondda | +0.012 pp | +0.161 pp | +0.088 pp |
+| aberdeenshire | −0.002 pp | +0.205 pp | +0.106 pp |
+
+Headline result: more correct matches, roughly flat precision.
+
+### 4.2 Schema-alignment fix for older prepared canonicals (worked)
+
+Live messy cleaning always emits `signature_score_map`, but a canonical
+prepared before this change does not. The linker concatenates the column set
+from both sides, which caused a binder error. Fix: in
+[splink_model.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/linking_model/splink_model.py)
+we add an empty, type-compatible map to whichever side lacks the column, so we
+can run without rebuilding the full index.
+
+### 4.3 Experiment toggles during development (since removed)
+
+While developing the feature we used environment toggles to switch the
+signature path on/off and to sweep m-weights without editing JSON. Those
+experiment modes have since been **removed**: the production code now always
+runs the single summed-IDF path, and the corresponding tests assert the
+production behaviour. The findings below were gathered while those toggles
+still existed.
+
+### 4.4 m-weight tuning (mixed)
+
+We swept several weightings. On hackney, concentrating weight on the strongest
+bucket (`10/1/1`) was best, but it did not generalise to the other datasets.
+
+| Variant | hackney F1 | rhondda F1 | aberdeenshire F1 |
+| --- | --- | --- | --- |
+| baseline (off) | 0.97951 | 0.97622 | 0.96468 |
+| prod 8/3/1.5 | 0.98122 | 0.97708 | 0.96574 |
+| strong_only 10/1/1 | 0.98227 | 0.97706 | 0.96529 |
+
+Conclusion: we kept `8/3/1.5` in production. This is the clearest evidence of
+the competing-signal problem (Section 5): the medium/weak buckets add little
+once other token-overlap comparisons already fire.
+
+### 4.5 What is not working / not yet done
+
+- The runtime "memory cost" win is small; this feature is recall-oriented, not
+  a performance optimisation.
+- Early wall-clock "faster" numbers were confounded by OS file-cache warmth, so
+  timing comparisons should be treated cautiously.
+- We have not yet jointly retuned `signature_evidence` together with the
+  overlapping token comparison (Section 5), which is the principled next step.
+
+---
+
+## 5. Overlap with existing model fields
+
+Splink's Fellegi-Sunter scoring assumes comparisons are conditionally
+independent. Signature evidence (shared rare bigrams/trigrams) is **not**
+independent of several comparisons that also reward shared tokens. When two
+correlated comparisons both fire, their Bayes factors multiply and we
+double-count evidence — the "competing signals" effect.
+
+Ranked by overlap with signature evidence:
+
+- **`token_rel_freq_arr_hist` — highest overlap.** The dominant token-overlap
+  comparison (Bayes factors up to ~78,000:1), scoring shared tokens weighted by
+  rarity. Signature evidence rewards the same rare-token sharing at
+  bigram/trigram granularity. This is the strongest competitor and the main
+  reason the medium/weak signature buckets add little.
+- **`clean_full_address` (exact match) — high overlap at the top end.** When the
+  whole cleaned address matches exactly, signature overlap is also maximal;
+  the two are almost perfectly redundant for exact-match pairs.
+- **`address_without_numbers` (incl. Jaccard levels) — high overlap.** Jaccard
+  over tokens is conceptually close to bigram/trigram overlap, especially
+  mid-band.
+- **`common_end_tokens` — moderate overlap.** Shared trailing tokens, though the
+  posting-list cap removes the most common ones.
+- **Low overlap (mostly independent):** `flat_identity`,
+  `sub_premise_location`, `numeric_token_1/2/3`, `postcode`.
+
+**Should we remove any fields?** Not yet. Each currently earns its place, and
+signature evidence is a net positive on top of them. The right fix for the
+correlation is coordinated tuning, not deletion: treat
+`token_rel_freq_arr_hist` and `signature_evidence` as a correlated pair, and
+either down-weight signature evidence where it co-fires with strong
+token-histogram evidence, or fold the bigram/trigram signal into a single
+combined token comparison. Any removal should be driven by a benchmark showing
+no recall loss at fixed precision.
+
+---
+
+## 6. Persisted file state
+
+The rebuilt prepared inverted index file has:
+
+- schema: `key`, `unique_ids`, `index_strategy`
+- size: `696,133,480` bytes
+
+Compared with an earlier rebuilt file that omitted `index_strategy`
+(`955,366,890` bytes), the ordered write with `index_strategy` retained is
+smaller by:
+
+- `259,233,410` bytes (≈ `247.22 MiB`, ≈ `27.13%`).
+
+This is why we kept `index_strategy`: ordering by `index_strategy, key`
+compresses better than dropping the column.
+
+---
+
+## 7. Current approach and open questions
+
+The approach we are initially pursuing:
+
+- keep the persisted index structurally simple (`key -> unique_ids`, plus
+  `index_strategy` for compression),
+- derive a pair-specific summed-IDF overlap score at lookup time,
+- let Splink bucket that derived score into the `signature_evidence` comparison
+  with production weights `8/3/1.5`,
+- run a single, always-on production path (no experiment toggles).
+
+Open questions to revisit later:
+
+1. Joint tuning of `signature_evidence` with `token_rel_freq_arr_hist` (and
+   possibly `address_without_numbers` Jaccard) to remove double-counting,
+   rather than tuning signature evidence in isolation.
+2. Whether `signature_evidence` and `address_without_numbers` Jaccard levels do
+   meaningfully different work; if not, one could be trimmed.
+3. Whether a more explicit rarity feature for numeric/structured tokens would
+   let the inverted index carry more of the scoring load (related to the
+   separate question of whether inverted-index evidence could reduce reliance
+   on numeric TF adjustment — see the Splink stage notes).
+
+---
+
+## 8. What is true now
+
+- The inverted index still stores only key-to-candidate-list mappings (plus
+  `index_strategy` metadata).
+- We derive a candidate-specific summed-IDF overlap score at lookup time.
+- Splink consumes that derived score as the `signature_evidence` comparison.
+- We did **not** add persisted per-key score columns, n-gram count columns, or a
+  stored capped score.
+- The feature is a consistent recall/F1 win across all three datasets at
+  roughly flat precision.
+- The main open problem is correlation with existing token-overlap comparisons
+  (`token_rel_freq_arr_hist` most of all), which is why aggressive signature
+  weights do not generalise.

--- a/docs/experiments/signature_evidence_overview.md
+++ b/docs/experiments/signature_evidence_overview.md
@@ -38,8 +38,7 @@ lookup and the model layer:
 ### 2.1 The persisted inverted index
 
 After the rebuild, the on-disk file
-[ukam_inverted_index.parquet](/Users/thomas.hepworth/data/address_matcher/secret_data/os/ukam_prepared_canonical/ukam_inverted_index.parquet)
-has three columns:
+`ukam_inverted_index.parquet` has three columns:
 
 - `key` — one bigram or trigram derived from `clean_full_address`
 - `unique_ids` — the list of canonical `unique_id` values containing that key
@@ -61,7 +60,7 @@ which actually makes the file smaller (see Section 6).
 ### 2.2 The runtime scoring step
 
 During messy-side cleaning, in
-[inverted_index.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/cleaning/steps/inverted_index.py),
+inverted_index.py](./uk_address_matcher/cleaning/steps/inverted_index.py),
 we derive a `signature_score_map` column. For each messy record:
 
 1. generate its bigram/trigram keys,
@@ -82,9 +81,9 @@ where `N` is the canonical row count and
 
 `N` is provided at match time via a small `__ukam_index_meta` table registered
 in
-[pipelines.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/cleaning/pipelines.py),
+[pipelines.py](./uk_address_matcher/cleaning/pipelines.py),
 and the canonical row count is threaded through
-[address_matcher.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/address_matcher.py).
+[address_matcher.py](./uk_address_matcher/address_matcher.py).
 
 The resulting map is keyed by canonical `unique_id` and holds the summed IDF
 evidence for that messy row against each candidate, e.g.:
@@ -100,7 +99,7 @@ evidence for that messy row against each candidate, e.g.:
 ### 2.3 The Splink comparison
 
 In
-[splink_model.json](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/data/splink_model.json)
+[splink_model.json](./uk_address_matcher/data/splink_model.json)
 the `signature_evidence` comparison reads the score for the specific candidate
 pair:
 
@@ -218,7 +217,7 @@ Headline result: more correct matches, roughly flat precision.
 Live messy cleaning always emits `signature_score_map`, but a canonical
 prepared before this change does not. The linker concatenates the column set
 from both sides, which caused a binder error. Fix: in
-[splink_model.py](/Users/thomas.hepworth/work_projects/address_matching/inverted_index_matching/uk_address_matcher/linking_model/splink_model.py)
+[splink_model.py](./uk_address_matcher/linking_model/splink_model.py)
 we add an empty, type-compatible map to whichever side lacks the column, so we
 can run without rebuilding the full index.
 

--- a/uk_address_matcher/address_matcher.py
+++ b/uk_address_matcher/address_matcher.py
@@ -255,6 +255,9 @@ class AddressMatcher:
         """Cleans messy data, reusing the canonical term frequencies and index."""
 
         logger.debug("Cleaning messy data")
+        inverted_index_n: int | None = None
+        if self._canonical_clean is not None:
+            inverted_index_n = self._canonical_clean.count("*").fetchone()[0]
         self._messy_clean = prepare_data_for_matching(
             self._raw_messy,
             con=self.con,
@@ -262,6 +265,7 @@ class AddressMatcher:
             # If nothing was loaded from disk, these will be None — but that's fine,
             term_frequency_lookup=self._tf_table,
             inverted_index=self._inverted_index,
+            inverted_index_n=inverted_index_n,
             dataset_role="messy",
             debug_options=self.debug_options,
         )

--- a/uk_address_matcher/analysis/accuracy_sql.py
+++ b/uk_address_matcher/analysis/accuracy_sql.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
+
 
 def ratio_sql(
     numerator_sql: str,
@@ -99,3 +101,93 @@ def average_rank_within_k_sql(*, rank_sql: str, k: int) -> str:
         f"WHEN {rank_sql} IS NOT NULL AND {rank_sql} <= {k} "
         f"THEN {rank_sql}::DOUBLE ELSE NULL END)"
     )
+
+
+def build_threshold_metrics_sql(rounding_expr: str) -> str:
+    """Return threshold-sweep SQL parameterised by the score-rounding expression."""
+    splink_value = MatchReason.SPLINK.value.replace("'", "''")
+    enum_values = str(MatchReason.enum_values())
+    splink_reason_sql = f"'{splink_value}'::ENUM {enum_values}"
+
+    return f"""
+    WITH canonical_ids AS (
+        SELECT DISTINCT unique_id FROM __ukam_threshold_canonical__
+    ),
+    labelled AS (
+        SELECT
+            m.unique_id,
+            CASE WHEN c.unique_id IS NOT NULL THEN 1 ELSE 0 END AS clerical_positive,
+            CASE
+                WHEN c.unique_id IS NOT NULL
+                 AND m.resolved_canonical_id = m.ukam_label
+                THEN 1
+                ELSE 0
+            END AS true_positive_row,
+            CASE
+                WHEN m.match_reason IS NULL THEN CAST(-999 AS DOUBLE)
+                WHEN m.match_reason = {splink_reason_sql} THEN {rounding_expr}
+                ELSE CAST(999 AS DOUBLE)
+            END AS match_weight_adj
+        FROM __ukam_threshold_matches__ m
+        LEFT JOIN canonical_ids c ON m.ukam_label = c.unique_id
+    ),
+    grouped AS (
+        SELECT
+            match_weight_adj                                           AS truth_threshold,
+            SUM(true_positive_row)                                     AS tp_row,
+            SUM(1 - true_positive_row)                                 AS not_tp_row,
+            SUM(CASE WHEN true_positive_row = 0 AND clerical_positive = 0
+                     THEN 1 ELSE 0 END)                                AS fp_neg_at,
+            SUM(clerical_positive)                                     AS cp,
+            SUM(1 - clerical_positive)                                 AS cn
+        FROM labelled
+        GROUP BY match_weight_adj
+    ),
+    stats AS (
+        SELECT
+            truth_threshold,
+            SUM(tp_row)    OVER (ORDER BY truth_threshold DESC)         AS tp,
+            SUM(not_tp_row) OVER (ORDER BY truth_threshold DESC)        AS fp,
+            SUM(fp_neg_at) OVER (ORDER BY truth_threshold DESC)         AS fp_neg,
+            SUM(cp) OVER ()                                             AS p,
+            SUM(cn) OVER ()                                             AS n
+        FROM grouped
+    ),
+    truth_space AS (
+        SELECT
+            truth_threshold,
+            p                                                          AS p,
+            n                                                          AS n,
+            CAST(tp              AS DOUBLE)                            AS tp,
+            CAST(fp              AS DOUBLE)                            AS fp,
+            CAST(fp_neg          AS DOUBLE)                            AS fp_neg,
+            CAST(p - tp          AS DOUBLE)                            AS fn,
+            CAST(GREATEST(n - fp_neg, 0) AS DOUBLE)                    AS tn
+        FROM stats
+    )
+    SELECT
+        truth_threshold,
+        CASE
+            WHEN truth_threshold >=  999 THEN 1.0
+            WHEN truth_threshold <= -999 THEN 0.0
+            ELSE power(2, truth_threshold)
+                / (1.0 + power(2, truth_threshold))
+        END AS match_probability,
+        tp                                                              AS tp,
+        tn                                                              AS tn,
+        fp                                                              AS fp,
+        fp_neg                                                          AS fp_neg,
+        fn                                                              AS fn,
+        tp / NULLIF(p, 0)                                               AS tp_rate,
+        tn / NULLIF(CAST(n AS DOUBLE), 0)                               AS tn_rate,
+        fp_neg / NULLIF(CAST(n AS DOUBLE), 0)                           AS fp_rate,
+        fn / NULLIF(p, 0)                                               AS fn_rate,
+        CASE WHEN tp + fp = 0 THEN 1.0 ELSE tp / (tp + fp) END         AS precision,
+        tp / NULLIF(p, 0)                                               AS recall,
+        CASE
+            WHEN 2.0 * tp + fp + fn = 0 THEN 0.0
+            ELSE 2.0 * tp / (2.0 * tp + fp + fn)
+        END                                                             AS f1
+    FROM truth_space
+    ORDER BY truth_threshold ASC
+    """

--- a/uk_address_matcher/analysis/accuracy_table.py
+++ b/uk_address_matcher/analysis/accuracy_table.py
@@ -257,15 +257,33 @@ def _build_threshold_summary(
 
         summary.update(
             {
-                "default_precision": float(threshold_row[0]) if threshold_row[0] is not None else None,
-                "default_recall": float(threshold_row[1]) if threshold_row[1] is not None else None,
-                "default_false_match_rate": float(threshold_row[2]) if threshold_row[2] is not None else None,
-                "default_missed_match_rate": float(threshold_row[3]) if threshold_row[3] is not None else None,
-                "default_true_no_match_rejection_rate": float(threshold_row[4]) if threshold_row[4] is not None else None,
-                "default_predicted_no_match_npv": float(threshold_row[5]) if threshold_row[5] is not None else None,
-                "wrong_canonical_id_count": int(threshold_row[6]) if threshold_row[6] is not None else None,
-                "true_match_predicted_no_match_count": int(threshold_row[7]) if threshold_row[7] is not None else None,
-                "true_no_match_forced_to_canonical_id_count": int(threshold_row[8]) if threshold_row[8] is not None else None,
+                "default_precision": float(threshold_row[0])
+                if threshold_row[0] is not None
+                else None,
+                "default_recall": float(threshold_row[1])
+                if threshold_row[1] is not None
+                else None,
+                "default_false_match_rate": float(threshold_row[2])
+                if threshold_row[2] is not None
+                else None,
+                "default_missed_match_rate": float(threshold_row[3])
+                if threshold_row[3] is not None
+                else None,
+                "default_true_no_match_rejection_rate": float(threshold_row[4])
+                if threshold_row[4] is not None
+                else None,
+                "default_predicted_no_match_npv": float(threshold_row[5])
+                if threshold_row[5] is not None
+                else None,
+                "wrong_canonical_id_count": int(threshold_row[6])
+                if threshold_row[6] is not None
+                else None,
+                "true_match_predicted_no_match_count": int(threshold_row[7])
+                if threshold_row[7] is not None
+                else None,
+                "true_no_match_forced_to_canonical_id_count": int(threshold_row[8])
+                if threshold_row[8] is not None
+                else None,
             }
         )
         return summary
@@ -327,38 +345,38 @@ def build_accuracy_table(
     )
     threshold_summary_sql = f"""
         SELECT
-            {_sql_double_literal(threshold_summary['pr_auc'])} AS pr_auc,
-            {_sql_double_literal(threshold_summary['threshold_at_precision_99_5'])}
+            {_sql_double_literal(threshold_summary["pr_auc"])} AS pr_auc,
+            {_sql_double_literal(threshold_summary["threshold_at_precision_99_5"])}
                 AS threshold_at_precision_99_5,
-            {_sql_double_literal(threshold_summary['recall_at_precision_99_5'])}
+            {_sql_double_literal(threshold_summary["recall_at_precision_99_5"])}
                 AS recall_at_precision_99_5,
-            {_sql_double_literal(threshold_summary['threshold_at_precision_99_0'])}
+            {_sql_double_literal(threshold_summary["threshold_at_precision_99_0"])}
                 AS threshold_at_precision_99_0,
-            {_sql_double_literal(threshold_summary['recall_at_precision_99_0'])}
+            {_sql_double_literal(threshold_summary["recall_at_precision_99_0"])}
                 AS recall_at_precision_99_0,
-            {_sql_double_literal(threshold_summary['threshold_at_precision_98_0'])}
+            {_sql_double_literal(threshold_summary["threshold_at_precision_98_0"])}
                 AS threshold_at_precision_98_0,
-            {_sql_double_literal(threshold_summary['recall_at_precision_98_0'])}
+            {_sql_double_literal(threshold_summary["recall_at_precision_98_0"])}
                 AS recall_at_precision_98_0,
-            {_sql_double_literal(threshold_summary['default_threshold'])}
+            {_sql_double_literal(threshold_summary["default_threshold"])}
                 AS default_threshold,
-            {_sql_double_literal(threshold_summary['default_precision'])}
+            {_sql_double_literal(threshold_summary["default_precision"])}
                 AS default_threshold_precision,
-            {_sql_double_literal(threshold_summary['default_recall'])}
+            {_sql_double_literal(threshold_summary["default_recall"])}
                 AS default_threshold_recall,
-            {_sql_double_literal(threshold_summary['default_false_match_rate'])}
+            {_sql_double_literal(threshold_summary["default_false_match_rate"])}
                 AS default_threshold_false_match_rate,
-            {_sql_double_literal(threshold_summary['default_missed_match_rate'])}
+            {_sql_double_literal(threshold_summary["default_missed_match_rate"])}
                 AS default_threshold_missed_match_rate,
-            {_sql_double_literal(threshold_summary['default_true_no_match_rejection_rate'])}
+            {_sql_double_literal(threshold_summary["default_true_no_match_rejection_rate"])}
                 AS default_threshold_true_no_match_rejection_rate,
-            {_sql_double_literal(threshold_summary['default_predicted_no_match_npv'])}
+            {_sql_double_literal(threshold_summary["default_predicted_no_match_npv"])}
                 AS default_threshold_predicted_no_match_npv,
-            {_sql_bigint_literal(threshold_summary['wrong_canonical_id_count'])}
+            {_sql_bigint_literal(threshold_summary["wrong_canonical_id_count"])}
                 AS wrong_canonical_id_count,
-            {_sql_bigint_literal(threshold_summary['true_match_predicted_no_match_count'])}
+            {_sql_bigint_literal(threshold_summary["true_match_predicted_no_match_count"])}
                 AS true_match_predicted_no_match_count,
-            {_sql_bigint_literal(threshold_summary['true_no_match_forced_to_canonical_id_count'])}
+            {_sql_bigint_literal(threshold_summary["true_no_match_forced_to_canonical_id_count"])}
                 AS true_no_match_forced_to_canonical_id_count
     """
 

--- a/uk_address_matcher/analysis/accuracy_table.py
+++ b/uk_address_matcher/analysis/accuracy_table.py
@@ -222,9 +222,19 @@ def _build_threshold_summary(
                         AS tp,
                     SUM(CASE WHEN is_accepted AND is_true_positive = 0 THEN 1 ELSE 0 END)
                         AS fp,
-                    SUM(CASE WHEN NOT is_accepted AND clerical_positive = 1 THEN 1 ELSE 0 END)
+                    SUM(
+                        CASE
+                            WHEN NOT is_accepted AND clerical_positive = 1 THEN 1
+                            ELSE 0
+                        END
+                    )
                         AS fn,
-                    SUM(CASE WHEN NOT is_accepted AND clerical_positive = 0 THEN 1 ELSE 0 END)
+                    SUM(
+                        CASE
+                            WHEN NOT is_accepted AND clerical_positive = 0 THEN 1
+                            ELSE 0
+                        END
+                    )
                         AS tn,
                     SUM(CASE
                         WHEN is_accepted
@@ -233,7 +243,12 @@ def _build_threshold_summary(
                         THEN 1
                         ELSE 0
                     END) AS wrong_canonical_id_count,
-                    SUM(CASE WHEN NOT is_accepted AND clerical_positive = 1 THEN 1 ELSE 0 END)
+                    SUM(
+                        CASE
+                            WHEN NOT is_accepted AND clerical_positive = 1 THEN 1
+                            ELSE 0
+                        END
+                    )
                         AS true_match_predicted_no_match_count,
                     SUM(CASE WHEN is_accepted AND clerical_positive = 0 THEN 1 ELSE 0 END)
                         AS true_no_match_forced_to_canonical_id_count,
@@ -242,7 +257,10 @@ def _build_threshold_summary(
                 FROM scored
             )
             SELECT
-                CASE WHEN tp + fp = 0 THEN 1.0 ELSE tp::DOUBLE / (tp + fp) END AS precision,
+                CASE
+                    WHEN tp + fp = 0 THEN 1.0
+                    ELSE tp::DOUBLE / (tp + fp)
+                END AS precision,
                 tp::DOUBLE / NULLIF(p::DOUBLE, 0.0) AS recall,
                 fp::DOUBLE / NULLIF((tp + fp)::DOUBLE, 0.0) AS false_match_rate,
                 fn::DOUBLE / NULLIF(p::DOUBLE, 0.0) AS missed_match_rate,
@@ -500,19 +518,23 @@ def build_accuracy_table(
                 ELSE NULL
             END AS default_threshold_recall,
             CASE
-                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_false_match_rate, 6)
+                WHEN a.stage = 'overall'
+                    THEN ROUND(ts.default_threshold_false_match_rate, 6)
                 ELSE NULL
             END AS default_threshold_false_match_rate,
             CASE
-                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_missed_match_rate, 6)
+                WHEN a.stage = 'overall'
+                    THEN ROUND(ts.default_threshold_missed_match_rate, 6)
                 ELSE NULL
             END AS default_threshold_missed_match_rate,
             CASE
-                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_true_no_match_rejection_rate, 6)
+                WHEN a.stage = 'overall'
+                    THEN ROUND(ts.default_threshold_true_no_match_rejection_rate, 6)
                 ELSE NULL
             END AS default_threshold_true_no_match_rejection_rate,
             CASE
-                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_predicted_no_match_npv, 6)
+                WHEN a.stage = 'overall'
+                    THEN ROUND(ts.default_threshold_predicted_no_match_npv, 6)
                 ELSE NULL
             END AS default_threshold_predicted_no_match_npv,
             CASE
@@ -524,7 +546,8 @@ def build_accuracy_table(
                 ELSE NULL
             END AS true_match_predicted_no_match_count,
             CASE
-                WHEN a.stage = 'overall' THEN ts.true_no_match_forced_to_canonical_id_count
+                WHEN a.stage = 'overall'
+                    THEN ts.true_no_match_forced_to_canonical_id_count
                 ELSE NULL
             END AS true_no_match_forced_to_canonical_id_count
         FROM all_rows AS a

--- a/uk_address_matcher/analysis/accuracy_table.py
+++ b/uk_address_matcher/analysis/accuracy_table.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
+from uk_address_matcher.analysis.accuracy_analysis import (
+    build_match_weight_rounding_expression,
+    compute_precision_recall_auc,
+)
 from uk_address_matcher.analysis.accuracy_sql import (
+    build_threshold_metrics_sql,
     correct_share_of_total_sql,
     f1_from_counts_sql,
     ratio_sql,
@@ -15,6 +20,15 @@ from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
 
 if TYPE_CHECKING:
     import duckdb
+
+
+_OPERATING_POINT_PRECISION_TARGETS: tuple[tuple[str, float], ...] = (
+    ("99_5", 0.995),
+    ("99_0", 0.99),
+    ("98_0", 0.98),
+)
+_DEFAULT_PRECISION_TARGET = 0.99
+_THRESHOLD_ROUNDING = 0.1
 
 
 def resolve_splink_threshold_match_weight(
@@ -41,11 +55,231 @@ def resolve_splink_threshold_match_weight(
     )
 
 
+def _ensure_match_weight_column(
+    con: duckdb.DuckDBPyConnection,
+    relation: duckdb.DuckDBPyRelation,
+) -> duckdb.DuckDBPyRelation:
+    if "match_weight" in relation.columns:
+        return relation
+
+    relation_sql = relation.sql_query()
+    return con.sql(
+        f"""
+        SELECT
+            source_relation.*,
+            NULL::DOUBLE AS match_weight
+        FROM ({relation_sql}) AS source_relation
+        """
+    )
+
+
+def _canonical_relation_for_accuracy(
+    con: duckdb.DuckDBPyConnection,
+    relation: duckdb.DuckDBPyRelation,
+    canonical_relation: duckdb.DuckDBPyRelation | None,
+) -> duckdb.DuckDBPyRelation:
+    if canonical_relation is not None:
+        return canonical_relation
+
+    relation_sql = relation.sql_query()
+    return con.sql(
+        f"""
+        SELECT DISTINCT CAST(ukam_label AS VARCHAR) AS unique_id
+        FROM ({relation_sql}) AS m
+        WHERE ukam_label IS NOT NULL
+        """
+    )
+
+
+def _sql_double_literal(value: float | None) -> str:
+    if value is None:
+        return "NULL::DOUBLE"
+    return f"{float(value)!r}::DOUBLE"
+
+
+def _sql_bigint_literal(value: int | None) -> str:
+    if value is None:
+        return "NULL::BIGINT"
+    return f"{int(value)}::BIGINT"
+
+
+def _find_operating_point(
+    con: duckdb.DuckDBPyConnection,
+    threshold_metrics_sql: str,
+    *,
+    precision_target: float,
+) -> tuple[float | None, float | None]:
+    row = con.sql(
+        f"""
+        SELECT
+            truth_threshold,
+            recall
+        FROM ({threshold_metrics_sql}) AS threshold_metrics
+        WHERE precision >= {precision_target}
+          AND recall IS NOT NULL
+        ORDER BY recall DESC, truth_threshold ASC
+        LIMIT 1
+        """
+    ).fetchone()
+    if row is None:
+        return None, None
+    threshold_value, recall_value = row
+    return float(threshold_value), float(recall_value)
+
+
+def _build_threshold_summary(
+    con: duckdb.DuckDBPyConnection,
+    relation: duckdb.DuckDBPyRelation,
+    canonical_relation: duckdb.DuckDBPyRelation | None,
+    *,
+    threshold_match_weight: float | None,
+) -> dict[str, float | int | None]:
+    threshold_relation = _ensure_match_weight_column(con, relation)
+    resolved_canonical_relation = _canonical_relation_for_accuracy(
+        con,
+        relation,
+        canonical_relation,
+    )
+    rounding_expr = build_match_weight_rounding_expression(_THRESHOLD_ROUNDING)
+    threshold_metrics_sql = build_threshold_metrics_sql(rounding_expr)
+
+    splink_value = sql_literal(MatchReason.SPLINK.value)
+    enum_values = str(MatchReason.enum_values())
+    splink_reason_sql = f"'{splink_value}'::ENUM {enum_values}"
+    accepted_sql = (
+        "TRUE"
+        if threshold_match_weight is None
+        else f"COALESCE(m.match_weight, -1000.0) >= {threshold_match_weight}"
+    )
+
+    con.register("__ukam_threshold_matches__", threshold_relation)
+    con.register("__ukam_threshold_canonical__", resolved_canonical_relation)
+    try:
+        pr_auc = compute_precision_recall_auc(con, threshold_metrics_sql)
+        summary: dict[str, float | int | None] = {"pr_auc": pr_auc}
+
+        operating_points: dict[str, tuple[float | None, float | None]] = {}
+        for suffix, precision_target in _OPERATING_POINT_PRECISION_TARGETS:
+            operating_points[suffix] = _find_operating_point(
+                con,
+                threshold_metrics_sql,
+                precision_target=precision_target,
+            )
+            threshold_value, recall_value = operating_points[suffix]
+            summary[f"threshold_at_precision_{suffix}"] = threshold_value
+            summary[f"recall_at_precision_{suffix}"] = recall_value
+
+        default_threshold = threshold_match_weight
+        if default_threshold is None:
+            default_threshold = operating_points["99_0"][0]
+        summary["default_threshold"] = default_threshold
+
+        if default_threshold is None:
+            summary.update(
+                {
+                    "default_precision": None,
+                    "default_recall": None,
+                    "default_false_match_rate": None,
+                    "default_missed_match_rate": None,
+                    "default_true_no_match_rejection_rate": None,
+                    "default_predicted_no_match_npv": None,
+                    "wrong_canonical_id_count": None,
+                    "true_match_predicted_no_match_count": None,
+                    "true_no_match_forced_to_canonical_id_count": None,
+                }
+            )
+            return summary
+
+        threshold_row = con.sql(
+            f"""
+            WITH canonical_ids AS (
+                SELECT DISTINCT CAST(unique_id AS VARCHAR) AS unique_id
+                FROM __ukam_threshold_canonical__
+            ),
+            scored AS (
+                SELECT
+                    CASE WHEN c.unique_id IS NOT NULL THEN 1 ELSE 0 END
+                        AS clerical_positive,
+                    CASE
+                        WHEN c.unique_id IS NOT NULL
+                         AND CAST(m.resolved_canonical_id AS VARCHAR)
+                            = CAST(m.ukam_label AS VARCHAR)
+                        THEN 1
+                        ELSE 0
+                    END AS is_true_positive,
+                    CASE
+                        WHEN m.match_reason IS NULL THEN FALSE
+                        WHEN m.match_reason = {splink_reason_sql} THEN {accepted_sql}
+                        ELSE TRUE
+                    END AS is_accepted
+                FROM __ukam_threshold_matches__ AS m
+                LEFT JOIN canonical_ids AS c
+                    ON CAST(m.ukam_label AS VARCHAR) = c.unique_id
+            ),
+            counts AS (
+                SELECT
+                    SUM(CASE WHEN is_accepted AND is_true_positive = 1 THEN 1 ELSE 0 END)
+                        AS tp,
+                    SUM(CASE WHEN is_accepted AND is_true_positive = 0 THEN 1 ELSE 0 END)
+                        AS fp,
+                    SUM(CASE WHEN NOT is_accepted AND clerical_positive = 1 THEN 1 ELSE 0 END)
+                        AS fn,
+                    SUM(CASE WHEN NOT is_accepted AND clerical_positive = 0 THEN 1 ELSE 0 END)
+                        AS tn,
+                    SUM(CASE
+                        WHEN is_accepted
+                         AND clerical_positive = 1
+                         AND is_true_positive = 0
+                        THEN 1
+                        ELSE 0
+                    END) AS wrong_canonical_id_count,
+                    SUM(CASE WHEN NOT is_accepted AND clerical_positive = 1 THEN 1 ELSE 0 END)
+                        AS true_match_predicted_no_match_count,
+                    SUM(CASE WHEN is_accepted AND clerical_positive = 0 THEN 1 ELSE 0 END)
+                        AS true_no_match_forced_to_canonical_id_count,
+                    SUM(clerical_positive) AS p,
+                    SUM(1 - clerical_positive) AS n
+                FROM scored
+            )
+            SELECT
+                CASE WHEN tp + fp = 0 THEN 1.0 ELSE tp::DOUBLE / (tp + fp) END AS precision,
+                tp::DOUBLE / NULLIF(p::DOUBLE, 0.0) AS recall,
+                fp::DOUBLE / NULLIF((tp + fp)::DOUBLE, 0.0) AS false_match_rate,
+                fn::DOUBLE / NULLIF(p::DOUBLE, 0.0) AS missed_match_rate,
+                tn::DOUBLE / NULLIF(n::DOUBLE, 0.0) AS true_no_match_rejection_rate,
+                tn::DOUBLE / NULLIF((tn + fn)::DOUBLE, 0.0) AS predicted_no_match_npv,
+                wrong_canonical_id_count,
+                true_match_predicted_no_match_count,
+                true_no_match_forced_to_canonical_id_count
+            FROM counts
+            """
+        ).fetchone()
+
+        summary.update(
+            {
+                "default_precision": float(threshold_row[0]) if threshold_row[0] is not None else None,
+                "default_recall": float(threshold_row[1]) if threshold_row[1] is not None else None,
+                "default_false_match_rate": float(threshold_row[2]) if threshold_row[2] is not None else None,
+                "default_missed_match_rate": float(threshold_row[3]) if threshold_row[3] is not None else None,
+                "default_true_no_match_rejection_rate": float(threshold_row[4]) if threshold_row[4] is not None else None,
+                "default_predicted_no_match_npv": float(threshold_row[5]) if threshold_row[5] is not None else None,
+                "wrong_canonical_id_count": int(threshold_row[6]) if threshold_row[6] is not None else None,
+                "true_match_predicted_no_match_count": int(threshold_row[7]) if threshold_row[7] is not None else None,
+                "true_no_match_forced_to_canonical_id_count": int(threshold_row[8]) if threshold_row[8] is not None else None,
+            }
+        )
+        return summary
+    finally:
+        con.unregister("__ukam_threshold_matches__")
+        con.unregister("__ukam_threshold_canonical__")
+
+
 @requires_ukam_label("relation", function_name="_accuracy_table")
 def build_accuracy_table(
     con: duckdb.DuckDBPyConnection,
     relation: duckdb.DuckDBPyRelation,
     *,
+    canonical_relation: duckdb.DuckDBPyRelation | None = None,
     splink_match_weight_threshold: float | None = None,
     splink_match_probability_threshold: float | None = None,
 ) -> duckdb.DuckDBPyRelation:
@@ -85,6 +319,48 @@ def build_accuracy_table(
         correct_matches_sql="correct_matches",
         total_rows_sql="(SELECT total_input_rows FROM totals)",
     )
+    threshold_summary = _build_threshold_summary(
+        con,
+        relation,
+        canonical_relation,
+        threshold_match_weight=threshold_match_weight,
+    )
+    threshold_summary_sql = f"""
+        SELECT
+            {_sql_double_literal(threshold_summary['pr_auc'])} AS pr_auc,
+            {_sql_double_literal(threshold_summary['threshold_at_precision_99_5'])}
+                AS threshold_at_precision_99_5,
+            {_sql_double_literal(threshold_summary['recall_at_precision_99_5'])}
+                AS recall_at_precision_99_5,
+            {_sql_double_literal(threshold_summary['threshold_at_precision_99_0'])}
+                AS threshold_at_precision_99_0,
+            {_sql_double_literal(threshold_summary['recall_at_precision_99_0'])}
+                AS recall_at_precision_99_0,
+            {_sql_double_literal(threshold_summary['threshold_at_precision_98_0'])}
+                AS threshold_at_precision_98_0,
+            {_sql_double_literal(threshold_summary['recall_at_precision_98_0'])}
+                AS recall_at_precision_98_0,
+            {_sql_double_literal(threshold_summary['default_threshold'])}
+                AS default_threshold,
+            {_sql_double_literal(threshold_summary['default_precision'])}
+                AS default_threshold_precision,
+            {_sql_double_literal(threshold_summary['default_recall'])}
+                AS default_threshold_recall,
+            {_sql_double_literal(threshold_summary['default_false_match_rate'])}
+                AS default_threshold_false_match_rate,
+            {_sql_double_literal(threshold_summary['default_missed_match_rate'])}
+                AS default_threshold_missed_match_rate,
+            {_sql_double_literal(threshold_summary['default_true_no_match_rejection_rate'])}
+                AS default_threshold_true_no_match_rejection_rate,
+            {_sql_double_literal(threshold_summary['default_predicted_no_match_npv'])}
+                AS default_threshold_predicted_no_match_npv,
+            {_sql_bigint_literal(threshold_summary['wrong_canonical_id_count'])}
+                AS wrong_canonical_id_count,
+            {_sql_bigint_literal(threshold_summary['true_match_predicted_no_match_count'])}
+                AS true_match_predicted_no_match_count,
+            {_sql_bigint_literal(threshold_summary['true_no_match_forced_to_canonical_id_count'])}
+                AS true_no_match_forced_to_canonical_id_count
+    """
 
     return con.sql(
         f"""
@@ -124,27 +400,30 @@ def build_accuracy_table(
                 SUM(CASE WHEN is_correct THEN 1 ELSE 0 END) AS correct_matches
             FROM scored
             GROUP BY GROUPING SETS ((stage), ())
+        ),
+        threshold_summary AS (
+            {threshold_summary_sql}
         )
         SELECT
-            stage,
+            a.stage,
             CASE
-                WHEN stage = 'unmatched' THEN total_rows_in_stage
-                ELSE matched_rows_in_stage
+                WHEN a.stage = 'unmatched' THEN a.total_rows_in_stage
+                ELSE a.matched_rows_in_stage
             END AS rows_matched_in_stage,
-            correct_matches,
+            a.correct_matches,
             CASE
-                WHEN stage = 'unmatched' THEN 0
-                ELSE matched_rows_in_stage - correct_matches
+                WHEN a.stage = 'unmatched' THEN 0
+                ELSE a.matched_rows_in_stage - a.correct_matches
             END AS wrong_matches,
             CASE
-                WHEN stage = 'unmatched' THEN NULL
+                WHEN a.stage = 'unmatched' THEN NULL
                 ELSE ROUND(
                     {precision_sql},
                     6
                 )
             END AS precision,
             CASE
-                WHEN stage = 'unmatched' THEN NULL
+                WHEN a.stage = 'unmatched' THEN NULL
                 ELSE ROUND(
                     {wrong_match_rate_expr},
                     2
@@ -161,13 +440,82 @@ def build_accuracy_table(
             ROUND(
                 {f1_sql},
                 6
-            ) AS f1
-        FROM all_rows
+            ) AS f1,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.pr_auc, 6)
+                ELSE NULL
+            END AS pr_auc,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.recall_at_precision_99_5, 6)
+                ELSE NULL
+            END AS recall_at_precision_99_5,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.threshold_at_precision_99_5, 6)
+                ELSE NULL
+            END AS threshold_at_precision_99_5,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.recall_at_precision_99_0, 6)
+                ELSE NULL
+            END AS recall_at_precision_99_0,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.threshold_at_precision_99_0, 6)
+                ELSE NULL
+            END AS threshold_at_precision_99_0,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.recall_at_precision_98_0, 6)
+                ELSE NULL
+            END AS recall_at_precision_98_0,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.threshold_at_precision_98_0, 6)
+                ELSE NULL
+            END AS threshold_at_precision_98_0,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold, 6)
+                ELSE NULL
+            END AS default_threshold,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_precision, 6)
+                ELSE NULL
+            END AS default_threshold_precision,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_recall, 6)
+                ELSE NULL
+            END AS default_threshold_recall,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_false_match_rate, 6)
+                ELSE NULL
+            END AS default_threshold_false_match_rate,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_missed_match_rate, 6)
+                ELSE NULL
+            END AS default_threshold_missed_match_rate,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_true_no_match_rejection_rate, 6)
+                ELSE NULL
+            END AS default_threshold_true_no_match_rejection_rate,
+            CASE
+                WHEN a.stage = 'overall' THEN ROUND(ts.default_threshold_predicted_no_match_npv, 6)
+                ELSE NULL
+            END AS default_threshold_predicted_no_match_npv,
+            CASE
+                WHEN a.stage = 'overall' THEN ts.wrong_canonical_id_count
+                ELSE NULL
+            END AS wrong_canonical_id_count,
+            CASE
+                WHEN a.stage = 'overall' THEN ts.true_match_predicted_no_match_count
+                ELSE NULL
+            END AS true_match_predicted_no_match_count,
+            CASE
+                WHEN a.stage = 'overall' THEN ts.true_no_match_forced_to_canonical_id_count
+                ELSE NULL
+            END AS true_no_match_forced_to_canonical_id_count
+        FROM all_rows AS a
+        CROSS JOIN threshold_summary AS ts
         ORDER BY
             CASE
-                WHEN stage = 'unmatched' THEN total_rows_in_stage
-                ELSE matched_rows_in_stage
+                WHEN a.stage = 'unmatched' THEN a.total_rows_in_stage
+                ELSE a.matched_rows_in_stage
             END DESC,
-            stage
+            a.stage
         """
     )

--- a/uk_address_matcher/analysis/splink_comparison_metrics.py
+++ b/uk_address_matcher/analysis/splink_comparison_metrics.py
@@ -566,7 +566,15 @@ def _build_base_compared_relation(
                 {threshold_value}::DOUBLE AS threshold_match_weight,
                 {total_input_rows}::BIGINT AS total_input_rows,
                 {rows_entering_splink}::BIGINT AS rows_entering_splink,
-                *
+                stage,
+                rows_matched_in_stage,
+                correct_matches,
+                wrong_matches,
+                precision,
+                wrong_match_rate,
+                correct_share_of_total,
+                recall,
+                f1
             FROM ({rel_sql}) AS accuracy
             WHERE stage = 'splink'
             UNION ALL

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -598,6 +598,7 @@ def prepare_data_for_matching(
     num_of_chunks: int = 10,
     term_frequency_lookup: Optional[DuckDBPyRelation] = None,
     inverted_index: Optional[DuckDBPyRelation] = None,
+    inverted_index_n: Optional[int] = None,
     derive_distinguishing_wrt_adjacent_records: bool = False,
     *,
     dataset_role: Literal["messy", "canonical"] | None = None,
@@ -673,7 +674,9 @@ def prepare_data_for_matching(
     _create_term_frequency_tables(con, term_frequency_lookup=term_frequency_lookup)
 
     # Register inverted index table if provided (for use in pipeline stages)
-    inv_idx_table_name = _register_inverted_index_table(con, inverted_index)
+    inv_idx_table_name = _register_inverted_index_table(
+        con, inverted_index, inverted_index_n
+    )
 
     # Determine which inverted index stages to use as additional pipeline stages
     inverted_index_stages = (

--- a/uk_address_matcher/cleaning/pipelines.py
+++ b/uk_address_matcher/cleaning/pipelines.py
@@ -347,6 +347,7 @@ def _create_term_frequency_tables(
 def _register_inverted_index_table(
     con: DuckDBPyConnection,
     inverted_index: Optional[DuckDBPyRelation] = None,
+    inverted_index_n: Optional[int] = None,
 ) -> Optional[str]:
     """Register inverted index table for key lookups.
 
@@ -355,6 +356,9 @@ def _register_inverted_index_table(
         inverted_index: Pre-computed inverted index table with 'key',
             'unique_ids', and 'index_strategy' columns. If None, no
             table is registered.
+        inverted_index_n: Number of canonical addresses the index was built
+            over (``N`` for IDF weighting of signature evidence). When ``None``
+            a fallback is derived from the distinct ids present in the index.
 
     Returns:
         The registered table name, or None if no inverted_index provided.
@@ -368,9 +372,30 @@ def _register_inverted_index_table(
         con.execute(
             f"CREATE TEMP VIEW __ukam_inverted_index AS SELECT * FROM {existing_alias}"
         )
-        return "__ukam_inverted_index"
+    else:
+        # Materialise to avoid lazy evaluation issues
+        con.sql("DROP TABLE IF EXISTS __ukam_inverted_index")
+        inverted_index.create("__ukam_inverted_index")
 
-    # Materialise to avoid lazy evaluation issues
-    con.sql("DROP TABLE IF EXISTS __ukam_inverted_index")
-    inverted_index.create("__ukam_inverted_index")
+    _register_inverted_index_meta(con, inverted_index_n)
     return "__ukam_inverted_index"
+
+
+def _register_inverted_index_meta(
+    con: DuckDBPyConnection,
+    inverted_index_n: Optional[int],
+) -> None:
+    """Register ``__ukam_index_meta`` holding ``N`` for IDF weighting.
+
+    ``N`` is the canonical address count the inverted index was built over.
+    When not supplied (e.g. when ``prepare_data_for_matching`` is called
+    directly in tests) it falls back to the distinct id count in the index.
+    """
+    if inverted_index_n is None:
+        inverted_index_n = con.sql(
+            "SELECT COUNT(DISTINCT u) "
+            "FROM __ukam_inverted_index, unnest(unique_ids) AS t(u)"
+        ).fetchone()[0]
+    n_value = max(int(inverted_index_n or 0), 1)
+    con.execute("DROP TABLE IF EXISTS __ukam_index_meta")
+    con.execute(f"CREATE TABLE __ukam_index_meta AS SELECT {n_value}::BIGINT AS n")

--- a/uk_address_matcher/cleaning/steps/inverted_index.py
+++ b/uk_address_matcher/cleaning/steps/inverted_index.py
@@ -170,8 +170,8 @@ def _build_inverted_index_from_keys(
         )
         SELECT
             key,
-            unique_ids,
-            '{strategy.name}' AS index_strategy
+                        unique_ids,
+                        '{strategy.name}' AS index_strategy
         FROM grouped
         WHERE count_unique_ids >= 1
           AND count_unique_ids <= {max_unique_ids_per_key}
@@ -204,7 +204,7 @@ def _lookup_keys_in_inverted_index(strategies=None):
         name="lookup_keys_in_inverted_index",
         description=(
             "Look up index keys in pre-registered inverted index "
-            "to populate exploding_unique_ids"
+            "to populate exploding_unique_ids and signature_score_map"
         ),
         tags="inverted_index",
     )
@@ -247,13 +247,63 @@ def _lookup_keys_in_inverted_index(strategies=None):
         GROUP BY __messy_uid
         """
 
-        # Join back to base and add exploding_unique_ids column
+        # Signature evidence scoring.
+        # For each messy record, weight every shared index key by its IDF
+        # (log2(N / posting_list_size)) and accumulate the IDF onto each
+        # candidate canonical id that the key points at.  The result is a
+        # MAP<canonical_id (VARCHAR) -> summed IDF> the Splink comparison reads
+        # via list_extract(map_extract(signature_score_map_r, unique_id_l), 1).
+        # Keys are de-duplicated per record first so a repeated bigram/trigram
+        # only contributes its IDF once.
+        distinct_keys_sql = """
+        SELECT DISTINCT __messy_uid, __key
+        FROM {unnested_keys}
+        WHERE __key IS NOT NULL
+        """
+
+        key_scores_sql = """
+        SELECT
+            dk.__messy_uid,
+            ii.unique_ids AS __cand_ids,
+            log2(
+                (SELECT n FROM __ukam_index_meta)::DOUBLE
+                / len(ii.unique_ids)
+            ) AS __key_idf
+        FROM {distinct_keys} AS dk
+        JOIN __ukam_inverted_index AS ii ON dk.__key = ii.key
+        WHERE ii.unique_ids IS NOT NULL
+          AND len(ii.unique_ids) > 0
+        """
+
+        cand_scores_sql = """
+        SELECT
+            __messy_uid,
+            CAST(cid AS VARCHAR) AS __cand_id,
+            SUM(__key_idf) AS __score
+        FROM {key_scores}, unnest(__cand_ids) AS t(cid)
+        GROUP BY __messy_uid, CAST(cid AS VARCHAR)
+        """
+
+        score_map_sql = """
+        SELECT
+            __messy_uid,
+            map(list(__cand_id), list(__score)) AS signature_score_map
+        FROM {cand_scores}
+        GROUP BY __messy_uid
+        """
+
+        # Join back to base and add the blocking + scoring columns
         final_sql = """
         SELECT
             base.* EXCLUDE (__tokens),
-            COALESCE(d.exploding_unique_ids, []) AS exploding_unique_ids
+            COALESCE(d.exploding_unique_ids, []) AS exploding_unique_ids,
+            COALESCE(
+                s.signature_score_map,
+                MAP([]::VARCHAR[], []::DOUBLE[])
+            ) AS signature_score_map
         FROM {base} AS base
         LEFT JOIN {deduplicated} AS d ON base.unique_id = d.__messy_uid
+        LEFT JOIN {score_map} AS s ON base.unique_id = s.__messy_uid
         """
 
         steps = [
@@ -261,6 +311,10 @@ def _lookup_keys_in_inverted_index(strategies=None):
             CTEStep("unnested_keys", unnested_keys_sql),
             CTEStep("matched", matched_sql),
             CTEStep("deduplicated", deduplicated_sql),
+            CTEStep("distinct_keys", distinct_keys_sql),
+            CTEStep("key_scores", key_scores_sql),
+            CTEStep("cand_scores", cand_scores_sql),
+            CTEStep("score_map", score_map_sql),
             CTEStep("final", final_sql),
         ]
 
@@ -290,7 +344,8 @@ def _set_exploding_unique_ids_to_self():
     sql = """
     SELECT
         *,
-        [unique_id] AS exploding_unique_ids
+        [unique_id] AS exploding_unique_ids,
+        MAP([]::VARCHAR[], []::DOUBLE[]) AS signature_score_map
     FROM {input}
     """
     return sql

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -809,6 +809,49 @@
                 }
             ],
             "comparison_description": "CustomComparison"
+        },
+        {
+            "output_column_name": "signature_evidence",
+            "comparison_levels": [
+                {
+                    "sql_condition": "list_extract(map_extract(signature_score_map_r, CAST(unique_id_l AS VARCHAR)), 1) IS NULL",
+                    "label_for_charts": "No signature overlap",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "list_extract(map_extract(signature_score_map_r, CAST(unique_id_l AS VARCHAR)), 1) >= 40",
+                    "label_for_charts": "Signature IDF sum >= 40 (very strong)",
+                    "m_probability": 8,
+                    "u_probability": 1,
+                    "fix_m_probability": true,
+                    "fix_u_probability": true
+                },
+                {
+                    "sql_condition": "list_extract(map_extract(signature_score_map_r, CAST(unique_id_l AS VARCHAR)), 1) >= 20",
+                    "label_for_charts": "Signature IDF sum >= 20 (strong)",
+                    "m_probability": 3,
+                    "u_probability": 1,
+                    "fix_m_probability": true,
+                    "fix_u_probability": true
+                },
+                {
+                    "sql_condition": "list_extract(map_extract(signature_score_map_r, CAST(unique_id_l AS VARCHAR)), 1) >= 8",
+                    "label_for_charts": "Signature IDF sum >= 8 (weak)",
+                    "m_probability": 1.5,
+                    "u_probability": 1,
+                    "fix_m_probability": true,
+                    "fix_u_probability": true
+                },
+                {
+                    "sql_condition": "ELSE",
+                    "label_for_charts": "Signature IDF sum < 8 (negligible)",
+                    "m_probability": 1,
+                    "u_probability": 1,
+                    "fix_m_probability": true,
+                    "fix_u_probability": true
+                }
+            ],
+            "comparison_description": "Bigram/trigram inverted-index signature overlap (IDF-weighted)"
         }
     ]
 }

--- a/uk_address_matcher/linking_model/matching/stages/splink_stage_in_practice.md
+++ b/uk_address_matcher/linking_model/matching/stages/splink_stage_in_practice.md
@@ -1,0 +1,357 @@
+# Splink Stage In Practice
+
+This note summarises the full Splink stage as it runs today. It is intended to
+be read alongside [splink.py](splink.py), which orchestrates the steps described
+here.
+
+There are really two separate pieces:
+
+1. the Splink model itself, which scores pairwise candidates using the cleaned
+   address fields and a set of fixed comparison rules,
+2. a second pass which looks only at the candidate matches already generated
+   for one messy record and adjusts the scores using within-group token rarity.
+
+The code path starts in [splink.py](splink.py), builds the linker in [../../splink_model.py](../../splink_model.py), applies the local re-ranking in [../../../post_linkage/identify_distinguishing_tokens.py](../../../post_linkage/identify_distinguishing_tokens.py), and finally computes distinguishability in [../../../post_linkage/analyse_results.py](../../../post_linkage/analyse_results.py).
+
+## 1. High-level flow
+
+For one Splink stage pass, the runtime flow is:
+
+1. take only the still-unresolved messy rows,
+2. build pairwise candidate rows using the configured blocking rules,
+3. score those pairs with the Splink model,
+4. keep only the stronger candidate pairs,
+5. re-rank those pairs using token rarity inside each messy-row candidate group,
+6. compute the gap between the best and second-best candidate,
+7. emit only the top candidate per messy row if it clears the final thresholds.
+
+In code terms inside [splink.py](splink.py):
+
+| Runtime step | Implementation |
+| --- | --- |
+| build linker | `_get_linker(...)` |
+| pairwise scoring | `linker.inference.predict(...)` |
+| local re-ranking | `improve_predictions_using_distinguishing_tokens(...)` |
+| best-candidate selection | `best_matches_with_distinguishability(...)` |
+| final filter | `final_match_weight_threshold` and `final_distinguishability_threshold` |
+
+### Side convention
+
+Throughout the Splink stage the canonical (gazetteer) record is the left side
+and the messy input record is the right side:
+
+| Side | Suffix | Meaning |
+| --- | --- | --- |
+| left | `_l` | canonical candidate record (`unique_id_l`) |
+| right | `_r` | messy input record being matched (`unique_id_r`) |
+
+This is why [splink.py](splink.py) projects `unique_id_l` to
+`resolved_canonical_id` and `ukam_address_id_r` to the messy `ukam_address_id`.
+
+## 2. Stage 1: the Splink model itself
+
+### 2.1 What Stage 1 is doing
+
+Stage 1 is a pairwise probabilistic scorer.
+
+For each candidate pair `(canonical_l, messy_r)`, Splink evaluates a fixed set
+of comparisons from [../../../data/splink_model.json](../../../data/splink_model.json). Each comparison contributes positive, neutral, or negative evidence to the final `match_weight`.
+
+Conceptually:
+
+$$
+\text{match\_weight} \approx \sum_i \log_2\left(\frac{m_i}{u_i}\right)
+$$
+
+where each comparison level contributes a Bayes-factor-style term.
+
+### 2.2 Candidate generation before scoring
+
+The model is not run across every possible pair. Candidate rows are generated
+through blocking rules in [../../../data/splink_model.json](../../../data/splink_model.json).
+
+Today those rules mix:
+
+- postcode plus numeric-token rules,
+- postcode plus unusual-token rules,
+- a special rule based on `exploding_unique_ids` coming from the inverted index.
+
+That means the inverted index already plays a major role before scoring even
+starts. It is part of candidate generation, not just a later feature.
+
+### 2.3 Main Stage 1 evidence sources
+
+The current model combines several kinds of evidence.
+
+| Evidence type | Practical purpose |
+| --- | --- |
+| exact cleaned-address agreement | strong positive evidence when the normalised strings line up exactly |
+| address-without-numbers similarity | rewards near matches once house numbers are stripped |
+| flat identity and sub-premise logic | protects against false matches across flats and sub-units |
+| numeric token comparisons | checks house, flat, and secondary numbers explicitly |
+| postcode structure | rewards district or unit agreement and penalises disagreement |
+| signature evidence | adds positive evidence when the messy row shares rare bigram or trigram keys with the candidate canonical row |
+
+### 2.4 Where TF adjustment fits
+
+There is a specific term-frequency adjustment path for numeric tokens.
+
+The linker registers term-frequency lookup tables for `numeric_token_1`,
+`numeric_token_2`, and `numeric_token_3` in [../../splink_model.py](../../splink_model.py), and the comparison definitions in [../../training.py](../../training.py) use `tf_adjustment_column` on the exact numeric-match levels.
+
+Importantly, these numeric frequencies are not recomputed from the current
+canonical set at runtime. They are read from a pre-baked, package-bundled
+`numeric_token_frequencies.parquet` (loaded in [../../../cleaning/pipelines.py](../../../cleaning/pipelines.py) and re-registered with Splink in [../../splink_model.py](../../splink_model.py)).
+
+This means:
+
+- a match on a rare number is worth more than a match on a very common number,
+- the adjustment uses a fixed, global frequency table rather than per-run
+  canonical counts,
+- it applies during Stage 1 scoring and independently of the local candidate
+  group used by Stage 2.
+
+### 2.5 Where signature evidence fits
+
+The current production model also consumes `signature_score_map` through the
+`signature_evidence` comparison.
+
+That score is built from the inverted index and measures rare shared bigram and
+trigram overlap between the messy row and each candidate canonical id.
+
+The levels in [../../../data/splink_model.json](../../../data/splink_model.json) are:
+
+| Condition | Effect |
+| --- | --- |
+| no map entry | neutral |
+| score `>= 40` | very strong positive evidence |
+| score `>= 20` | strong positive evidence |
+| score `>= 8` | weak positive evidence |
+| score `< 8` | neutral |
+
+So Stage 1 already contains both:
+
+- global numeric rarity from TF adjustment,
+- pair-specific lexical rarity from the inverted index.
+
+## 3. Stage 2: local re-ranking using distinguishing tokens
+
+### 3.1 Why this second pass exists
+
+Splink alone scores each pair independently.
+
+That is useful, but it does not directly ask a crucial ranking question:
+
+> among the small set of plausible candidates for this one messy row, which
+> candidate contains the tokens that are most specific to this row?
+
+The second pass answers that question.
+
+It is not another global model. It is a local competition inside each messy
+row's candidate group.
+
+### 3.2 Which candidate rows Stage 2 sees
+
+In [../../../post_linkage/identify_distinguishing_tokens.py](../../../post_linkage/identify_distinguishing_tokens.py), the re-ranker first narrows to:
+
+1. pairs with `match_weight > improve_threshold_match_weight`,
+2. one row per `(unique_id_r, unique_id_l)` pair,
+3. at most `improve_top_n_matches` candidates per messy record.
+
+With the current `SplinkStage` defaults, that means:
+
+| Parameter | Default |
+| --- | --- |
+| `improve_threshold_match_weight` | `-20` |
+| `improve_top_n_matches` | `5` |
+| `improve_use_bigrams` | `True` |
+
+So Stage 2 is intentionally focused on a short list of plausible candidates,
+not the full candidate universe.
+
+### 3.3 Token preparation
+
+For each retained candidate set, Stage 2:
+
+1. removes some common trailing tokens,
+2. tokenises the messy row and candidate rows,
+3. optionally builds bigrams,
+4. measures token and bigram frequencies inside the candidate block for that
+   single messy row.
+
+The important detail is that these counts are local.
+
+They are not corpus-wide TF values. They are frequencies inside the current
+messy row's candidate group.
+
+### 3.4 What gets rewarded and penalised
+
+The re-ranker computes three unigram-derived structures for each candidate:
+
+| Structure | Meaning |
+| --- | --- |
+| `overlapping_tokens_this_l_and_r` | tokens shared by this candidate and the messy row |
+| `tokens_elsewhere_in_block_but_not_this` | messy-row tokens found in rival candidates but not this candidate |
+| `missing_tokens` | tokens present in the candidate but absent from the messy row |
+
+If bigrams are enabled, it builds the same pattern for bigrams and then filters
+some bigram evidence to avoid double-counting cases already fully explained by
+unigrams.
+
+### 3.5 The actual adjustment formula
+
+The code applies the following score adjustment.
+
+With defaults:
+
+- `REWARD_MULTIPLIER = 3`
+- `PUNISHMENT_MULTIPLIER = 1.5`
+- `BIGRAM_REWARD_MULTIPLIER = 3`
+- `BIGRAM_PUNISHMENT_MULTIPLIER = 1.5`
+- `MISSING_TOKEN_PENALTY = 0.1`
+
+the adjustment is:
+
+$$
+\begin{aligned}
+\text{mw\_adjustment} = {} & 3 \cdot \sum_{t \in \text{shared tokens}} \frac{1}{c(t)^2} \\
+& - 1.5 \cdot \left|\text{tokens elsewhere but not here}\right| \\
+& - 0.1 \cdot |\text{missing tokens}| \\
+& + 3 \cdot \sum_{b \in \text{shared bigrams}} \frac{1}{c(b)^2} \\
+& - 1.5 \cdot \left|\text{bigrams elsewhere but not here}\right|
+\end{aligned}
+$$
+
+where `c(token)` and `c(bigram)` are the counts of that token or bigram among
+the canonical candidates in the current messy-row block. The reward terms are
+frequency-weighted (rarer shared tokens count for more), while the penalty
+terms are simple counts of distinguishing tokens or bigrams that other rival
+candidates carry but this one does not.
+
+The updated score is simply:
+
+$$
+\text{match\_weight}_{\text{new}} = \text{match\_weight}_{\text{original}} + \text{mw\_adjustment}
+$$
+
+### 3.6 Practical interpretation
+
+In practice this means:
+
+- shared tokens are rewarded more when they are rare among rival candidates,
+- if the messy row contains a token that other candidates have but this
+  candidate does not, this candidate is penalised,
+- candidates with extra unmatched tokens are slightly penalised,
+- shared rare bigrams receive the same kind of reward,
+- common evidence inside the candidate set contributes little.
+
+This is why the second pass is often helpful for same-street or same-building
+competitions where multiple candidates already look plausible under the main
+Splink model.
+
+## 4. Final best-match selection
+
+After the local re-ranking, [../../../post_linkage/analyse_results.py](../../../post_linkage/analyse_results.py) computes:
+
+| Output | Meaning |
+| --- | --- |
+| `candidate_rank` | rank of each candidate within one messy row |
+| `distinguishability` | `top match_weight - next best match_weight` |
+| `distinguishability_category` | bucketed human-readable label |
+
+If there is only one plausible candidate left, `distinguishability` is `NULL`.
+
+The final stage then keeps only `candidate_rank = 1` and applies:
+
+- `final_match_weight_threshold`
+- `final_distinguishability_threshold`
+
+before emitting the final match. A `NULL` distinguishability passes the
+distinguishability filter, so a single-candidate match is not rejected purely
+for lacking a runner-up to compare against.
+
+## 5. The three rarity signals in the current system
+
+This is the key architectural point.
+
+The current system has three distinct rarity mechanisms, and they are not doing
+the same job.
+
+| Mechanism | Scope | What it measures |
+| --- | --- | --- |
+| numeric TF adjustment | global, pre-baked table | whether a matched number is common or rare across a fixed global frequency table |
+| signature evidence from inverted index | pair-specific, pre-ranking | rare shared bigram and trigram overlap between messy and candidate |
+| distinguishing-token re-ranking | local per messy row | whether a token or bigram distinguishes one candidate from its direct rivals |
+
+This is why removing one of them is not automatically safe.
+
+## 6. Could inverted-index evidence replace TF adjustment?
+
+Short answer: not cleanly, and not yet.
+
+### 6.1 Why a full replacement is risky
+
+The numeric TF adjustment and the inverted-index signal operate on different
+information.
+
+Numeric TF adjustment is especially useful when the decisive evidence is in the
+house, flat, or secondary numeric tokens. It tells the model that matching on a
+rare number is more informative than matching on `1`, `2`, `10`, or another
+very common value.
+
+The inverted-index signal does not directly model that same question.
+
+It rewards rare shared bigrams and trigrams in the cleaned address string. That
+is powerful lexical evidence, but it is not a direct substitute for global
+number rarity.
+
+### 6.2 Where the inverted index is already the main signal
+
+In one sense, it already is a main signal.
+
+- it drives candidate generation through `exploding_unique_ids`,
+- it adds a direct `signature_evidence` comparison inside the Splink model.
+
+So the inverted index is already doing real work in both recall and ranking.
+
+What it is not doing is replacing the specific numeric-frequency calibration
+currently provided by TF adjustment.
+
+### 6.3 What would probably happen if TF adjustment were removed today
+
+The most likely effect is:
+
+- little change on cases dominated by rare lexical tokens,
+- weaker calibration on rows where the main agreement is numeric,
+- more confusion among nearby addresses sharing the same street and postcode,
+- the biggest risk on flatted and dense urban addresses where numeric tokens
+  carry a lot of the discriminative load.
+
+### 6.4 A more realistic approach
+
+If you want to simplify this area, the safer path is:
+
+1. keep the negative numeric mismatch comparisons,
+2. benchmark removing only the TF adjustment terms from the numeric exact-match
+   levels,
+3. compare PR-AUC, fixed-threshold accuracy, and the overlay charts,
+4. only remove TF fully if the regression is genuinely negligible.
+
+If the long-term goal is to make the inverted index carry more of the scoring,
+the better replacement would be a more explicit rarity feature for numeric or
+structured tokens, not just a blanket assumption that bigram and trigram
+signature evidence covers the same ground.
+
+## 7. Practical conclusion
+
+The current Splink stage is best understood as:
+
+- a global probabilistic model over cleaned address fields,
+- plus a local candidate-group re-ranker,
+- plus a final best-versus-next-best confidence filter.
+
+The inverted index is already an important part of that design, but it is not a
+drop-in replacement for numeric TF adjustment.
+
+If we want to test that hypothesis properly, we should do it as a narrow
+benchmark change rather than as an immediate code simplification.

--- a/uk_address_matcher/linking_model/splink_model.py
+++ b/uk_address_matcher/linking_model/splink_model.py
@@ -152,6 +152,26 @@ def _get_linker(
         "original_address_concat",
     ]
 
+    # Align the signature evidence score map across both inputs. Live messy
+    # cleaning always emits `signature_score_map`, but a prepared canonical
+    # built before this column existed will not have it. The linker concat
+    # selects the messy column set from BOTH frames, so add an empty,
+    # type-compatible map to whichever side is missing it to avoid binder
+    # errors. Only retain it for the comparison when present on the messy side.
+    _empty_score_map = "MAP([]::VARCHAR[], []::DOUBLE[]) AS signature_score_map"
+    messy_has_score_map = "signature_score_map" in df_addresses_to_match.columns
+    canonical_has_score_map = (
+        "signature_score_map" in df_addresses_to_search_within.columns
+    )
+    if messy_has_score_map and not canonical_has_score_map:
+        df_addresses_to_search_within = df_addresses_to_search_within.select(
+            f"*, {_empty_score_map}"
+        )
+    elif canonical_has_score_map and not messy_has_score_map:
+        df_addresses_to_match = df_addresses_to_match.select(f"*, {_empty_score_map}")
+    if messy_has_score_map or canonical_has_score_map:
+        settings_as_dict["additional_columns_to_retain"].append("signature_score_map")
+
     # Auto-detect ukam_label: if present in messy data, retain it for accuracy testing.
     if "ukam_label" in df_addresses_to_match.columns:
         settings_as_dict["additional_columns_to_retain"].append("ukam_label")

--- a/uk_address_matcher/post_linkage/match_result/result.py
+++ b/uk_address_matcher/post_linkage/match_result/result.py
@@ -12,6 +12,7 @@ from uk_address_matcher.analysis.accuracy_analysis import (
     build_threshold_selection_chart_definition,
     render_chart_definition,
 )
+from uk_address_matcher.analysis.accuracy_sql import build_threshold_metrics_sql
 from uk_address_matcher.analysis.accuracy_table import build_accuracy_table
 from uk_address_matcher.analysis.splink_comparison_metrics import (
     SplinkModelComparisonOutput,
@@ -31,120 +32,9 @@ from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
 if TYPE_CHECKING:
     from uk_address_matcher.linking_model.matching.stages.splink import SplinkStage
 
-
 def _build_threshold_metrics_sql(rounding_expr: str) -> str:
-    """Return threshold metrics SQL parameterised by the score-rounding expression.
-
-    This query evaluates top-1 outcomes (one emitted decision per input row):
-
-    - A row is "positive" when ``ukam_label`` exists in the canonical dataset.
-    - A row is a true positive when the emitted ``resolved_canonical_id`` equals
-      ``ukam_label`` and the decision score is above threshold.
-    - Wrong-ID rows are treated as false positives at the emitted score, while
-      also reducing recall via ``FN = P - TP``.
-
-    This means wrong-ID rows are not floored to ``-999``; their emitted score is
-    retained so precision-recall thresholding behaves as expected for top-1
-    systems.
-
-    Two FP concepts are tracked separately:
-
-    - ``fp`` (fp_all): every non-TP accepted row, used for precision.
-    - ``fp_neg``: non-TP rows whose ``ukam_label`` is *not* in the canonical
-      dataset (genuine negatives wrongly accepted).  Used to derive ``tn``,
-      ``tn_rate``, and ``fp_rate``.
-
-    Separating the two prevents TN from going negative when matchable records
-    receive wrong-ID decisions, because wrong-ID rows inflate ``fp`` but should
-    not reduce the count of correctly-rejected genuine negatives.
-    """
-    splink_value = MatchReason.SPLINK.value.replace("'", "''")
-    enum_values = str(MatchReason.enum_values())
-    splink_reason_sql = f"'{splink_value}'::ENUM {enum_values}"
-
-    return f"""
-    WITH canonical_ids AS (
-        SELECT DISTINCT unique_id FROM __ukam_threshold_canonical__
-    ),
-    labelled AS (
-        SELECT
-            m.unique_id,
-            CASE WHEN c.unique_id IS NOT NULL THEN 1 ELSE 0 END AS clerical_positive,
-            CASE
-                WHEN c.unique_id IS NOT NULL
-                 AND m.resolved_canonical_id = m.ukam_label
-                THEN 1
-                ELSE 0
-            END AS true_positive_row,
-            CASE
-                WHEN m.match_reason IS NULL THEN CAST(-999 AS DOUBLE)
-                WHEN m.match_reason = {splink_reason_sql} THEN {rounding_expr}
-                ELSE CAST(999 AS DOUBLE)
-            END AS match_weight_adj
-        FROM __ukam_threshold_matches__ m
-        LEFT JOIN canonical_ids c ON m.ukam_label = c.unique_id
-    ),
-    grouped AS (
-        SELECT
-            match_weight_adj                                           AS truth_threshold,
-            SUM(true_positive_row)                                     AS tp_row,
-            SUM(1 - true_positive_row)                                 AS not_tp_row,
-            SUM(CASE WHEN true_positive_row = 0 AND clerical_positive = 0
-                     THEN 1 ELSE 0 END)                                AS fp_neg_at,
-            SUM(clerical_positive)                                     AS cp,
-            SUM(1 - clerical_positive)                                 AS cn
-        FROM labelled
-        GROUP BY match_weight_adj
-    ),
-    stats AS (
-        SELECT
-            truth_threshold,
-            SUM(tp_row)    OVER (ORDER BY truth_threshold DESC)         AS tp,
-            SUM(not_tp_row) OVER (ORDER BY truth_threshold DESC)        AS fp,
-            SUM(fp_neg_at) OVER (ORDER BY truth_threshold DESC)         AS fp_neg,
-            SUM(cp) OVER ()                                             AS p,
-            SUM(cn) OVER ()                                             AS n
-        FROM grouped
-    ),
-    truth_space AS (
-        SELECT
-            truth_threshold,
-            p                                                          AS p,
-            n                                                          AS n,
-            CAST(tp              AS DOUBLE)                            AS tp,
-            CAST(fp              AS DOUBLE)                            AS fp,
-            CAST(fp_neg          AS DOUBLE)                            AS fp_neg,
-            CAST(p - tp          AS DOUBLE)                            AS fn,
-            CAST(GREATEST(n - fp_neg, 0) AS DOUBLE)                    AS tn
-        FROM stats
-    )
-    SELECT
-        truth_threshold,
-        CASE
-            WHEN truth_threshold >=  999 THEN 1.0
-            WHEN truth_threshold <= -999 THEN 0.0
-            ELSE power(2, truth_threshold)
-                / (1.0 + power(2, truth_threshold))
-        END AS match_probability,
-        tp                                                              AS tp,
-        tn                                                              AS tn,
-        fp                                                              AS fp,
-        fp_neg                                                          AS fp_neg,
-        fn                                                              AS fn,
-        tp / NULLIF(p, 0)                                               AS tp_rate,
-        tn / NULLIF(CAST(n AS DOUBLE), 0)                               AS tn_rate,
-        fp_neg / NULLIF(CAST(n AS DOUBLE), 0)                           AS fp_rate,
-        fn / NULLIF(p, 0)                                               AS fn_rate,
-        CASE WHEN tp + fp = 0 THEN 1.0 ELSE tp / (tp + fp) END         AS precision,
-        tp / NULLIF(p, 0)                                               AS recall,
-        CASE
-            WHEN 2.0 * tp + fp + fn = 0 THEN 0.0
-            ELSE 2.0 * tp / (2.0 * tp + fp + fn)
-        END                                                             AS f1
-    FROM truth_space
-    ORDER BY truth_threshold ASC
-    """
-
+    """Backward-compatible wrapper for threshold-metrics SQL generation."""
+    return build_threshold_metrics_sql(rounding_expr)
 
 @dataclass
 class MatchResult:
@@ -443,6 +333,7 @@ class MatchResult:
         return build_accuracy_table(
             self.con,
             self._relation,
+            canonical_relation=self._canonical_relation,
             splink_match_weight_threshold=splink_match_weight_threshold,
             splink_match_probability_threshold=splink_match_probability_threshold,
         )

--- a/uk_address_matcher/post_linkage/match_result/result.py
+++ b/uk_address_matcher/post_linkage/match_result/result.py
@@ -27,14 +27,15 @@ from uk_address_matcher.post_linkage.match_result.debug_tools import (
     _MatchResultDebugTools,
 )
 from uk_address_matcher.post_linkage.match_result.splink_inspector import _SplinkInspector
-from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
 
 if TYPE_CHECKING:
     from uk_address_matcher.linking_model.matching.stages.splink import SplinkStage
 
+
 def _build_threshold_metrics_sql(rounding_expr: str) -> str:
     """Backward-compatible wrapper for threshold-metrics SQL generation."""
     return build_threshold_metrics_sql(rounding_expr)
+
 
 @dataclass
 class MatchResult:

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -65,6 +65,7 @@ PARQUET_COMPRESSION_LEVEL = 9
 # which ZSTD and dictionary/run-length encoding exploit. Row order is irrelevant
 # to matching, so this is a free win.
 CANONICAL_SORT_COLUMNS = ("postcode", "clean_full_address")
+INVERTED_INDEX_SORT_COLUMNS = ("index_strategy", "key")
 
 # Columns that are trivially recomputable at load time and therefore not persisted,
 # to reduce file size. They are restored in ``load_prepared_canonical_data``.
@@ -546,7 +547,12 @@ def prepare_canonical_folder(
     )
 
     _write_parquet_artefact(con, tf_table, tf_path)
-    _write_parquet_artefact(con, inverted_index, idx_path)
+    _write_parquet_artefact(
+        con,
+        inverted_index,
+        idx_path,
+        sort_columns=INVERTED_INDEX_SORT_COLUMNS,
+    )
 
     canonical_paths: list[str | Path]
     chunk_output_location: str | Path | None = None


### PR DESCRIPTION
## PR Summary

Adds two primary changes:
1. Makes better use of our inverted index code signatures in our Splink stage
2. Include PR-AUC as a proxy for the "area under the precision curve" (measure of precision across our data)

I've added some documentation summarising the experiments undertaken in more detail in https://github.com/moj-analytical-services/uk_address_matcher/blob/db2f13e6d8065e914af70181accde24a5b09a7b4/docs/experiments/signature_evidence_overview.md

This is just the first phase of experimentation on this work. I imagine there's a lot more accuracy we can squeeze out of our inverted index and far more we could do with signature-based matching.

## Benchmarking results

Across all three of our test datasets, we're seeing a slight uplift across the board (and a marked increase in recall at our usual MW 8 and 10 baselines).

### Hackney
<img width="958" height="751" alt="Screenshot 2026-06-23 at 12 31 28" src="https://github.com/user-attachments/assets/54d1e61b-d77f-48dd-8118-6ed8d1a2f36b" />

### Rhondda

<img width="908" height="722" alt="Screenshot 2026-06-23 at 12 31 33" src="https://github.com/user-attachments/assets/680743f3-09f3-4bc9-ae9a-402e0adbb52b" />

### Aberdeenshire
<img width="948" height="732" alt="Screenshot 2026-06-23 at 12 31 39" src="https://github.com/user-attachments/assets/8154393b-31ea-48c4-9052-7ac8b94bebc3" />



