### PR TITLE
Add sub-premise/business-unit reranker discriminants and fix business…

### DIFF
--- a/benchmarking/run_benchmarking.py
+++ b/benchmarking/run_benchmarking.py
@@ -28,7 +28,8 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # SELECTED_DATASETS: str | list[str] = "all"
-SELECTED_DATASETS: str | list[str] = "hackney"
+SELECTED_DATASETS: str | list[str] = "pooled_councils"
+# SELECTED_DATASETS: str | list[str] = "hackney"
 # SELECTED_DATASETS: str | list[str] = "aberdeenshire"
 # SELECTED_DATASETS: str | list[str] = "lambeth_llpg"
 STAGES = [
@@ -39,7 +40,7 @@ STAGES = [
 # Set to a persisted run hash to force a specific baseline, or use "latest"
 # to compare against the latest other persisted run for the same dataset.
 # Run IDs are preferred; internal dedupe hashes are still accepted for older runs.
-COMPARISON_BASELINE_RUN_ID: str | None = "bc216071cb56fb21"
+COMPARISON_BASELINE_RUN_ID: str | None = "192e02e409b7f100"
 
 
 # Defaults: print benchmark summaries and persistence output.

--- a/scripts/audit_parser_features.py
+++ b/scripts/audit_parser_features.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import argparse
+
+from benchmarking.config.datasets import load_dataset
+from benchmarking.utils.io import setup_connection
+from uk_address_matcher.cleaning.chunking_strategies import (
+    clean_data_pre_term_frequencies,
+)
+
+
+def _print_section(title: str, rows) -> None:
+    print(f"\n=== {title} ===")
+    for row in rows:
+        print(row)
+
+
+def _queries(table_name: str) -> dict[str, str]:
+    return {
+        "flat_false_positive_counts": f"""
+            SELECT
+                COUNT(*) AS total_rows,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '\\b\\d{{1,4}}[A-Z]\\b') THEN 1 ELSE 0 END) AS any_alnum_number_rows,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '\\b\\d{{1,4}}[A-Z]\\b') AND NOT has_flat_indicator THEN 1 ELSE 0 END) AS alnum_number_now_not_flat,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^\\d{{1,4}}[A-Z]\\b') AND NOT has_flat_indicator THEN 1 ELSE 0 END) AS leading_alnum_now_not_flat
+            FROM {table_name}
+        """,
+        "flat_false_positive_samples": f"""
+            SELECT
+                clean_full_address,
+                flat_letter,
+                flat_number,
+                flat_positional,
+                has_flat_indicator,
+                numeric_token_1
+            FROM {table_name}
+            WHERE regexp_matches(clean_full_address, '^\\d{{1,4}}[A-Z]\\b')
+              AND NOT has_flat_indicator
+            ORDER BY clean_full_address
+            LIMIT 15
+        """,
+        "still_flat_leading_alnum_samples": f"""
+            SELECT
+                clean_full_address,
+                flat_letter,
+                flat_number,
+                flat_positional,
+                has_flat_indicator
+            FROM {table_name}
+            WHERE regexp_matches(clean_full_address, '^\\d{{1,4}}[A-Z]\\b')
+              AND has_flat_indicator
+            ORDER BY clean_full_address
+            LIMIT 15
+        """,
+        "business_unit_suppression_counts": f"""
+            SELECT
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^UNIT\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\b') THEN 1 ELSE 0 END) AS unit_shell_rows,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^UNIT\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\b') AND has_business_unit THEN 1 ELSE 0 END) AS unit_shell_current_business,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^UNIT\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\b') AND regexp_matches(clean_full_address, '\\b(LEFT|RIGHT|FRONT|REAR|FLOOR|BASEMENT|GARDEN)\\b') THEN 1 ELSE 0 END) AS residential_like_unit_rows,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^UNIT\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\b') AND regexp_matches(clean_full_address, '\\b(LEFT|RIGHT|FRONT|REAR|FLOOR|BASEMENT|GARDEN)\\b') AND has_business_unit THEN 1 ELSE 0 END) AS residential_like_unit_still_business,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^STUDIO\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\b') THEN 1 ELSE 0 END) AS studio_shell_rows,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^STUDIO\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\b') AND has_business_unit THEN 1 ELSE 0 END) AS studio_shell_current_business,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^STUDIO\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\s+\\d') THEN 1 ELSE 0 END) AS residential_like_studio_rows,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^STUDIO\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\s+\\d') AND has_business_unit THEN 1 ELSE 0 END) AS residential_like_studio_still_business
+            FROM {table_name}
+        """,
+        "business_unit_suppression_samples": f"""
+            SELECT
+                clean_full_address,
+                has_business_unit,
+                business_unit_type,
+                business_unit_id,
+                sub_premise_location,
+                flat_positional
+            FROM {table_name}
+            WHERE (
+                regexp_matches(clean_full_address, '^UNIT\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\b')
+                AND regexp_matches(clean_full_address, '\\b(LEFT|RIGHT|FRONT|REAR|FLOOR|BASEMENT|GARDEN)\\b')
+            ) OR regexp_matches(clean_full_address, '^STUDIO\\s+[A-Za-z]?\\d{{1,5}}[A-Za-z]?\\s+\\d')
+            ORDER BY clean_full_address
+            LIMIT 15
+        """,
+        "centre_hits": f"""
+            SELECT
+                clean_full_address,
+                sub_premise_location,
+                flat_positional,
+                flat_letter,
+                flat_number,
+                has_business_unit,
+                business_unit_type
+            FROM {table_name}
+            WHERE sub_premise_location = 'CENTRE'
+            ORDER BY clean_full_address
+            LIMIT 25
+        """,
+        "new_only_subpremise_counts": f"""
+            SELECT
+                SUM(
+                    CASE WHEN sub_premise_location IS NOT NULL
+                        AND regexp_matches(clean_full_address, '^(APARTMENT|PENTHOUSE|ROOM|UNIT|STUDIO)\\b')
+                        AND flat_positional IS NULL
+                        AND flat_letter IS NULL
+                        AND flat_number IS NULL
+                        AND NOT regexp_matches(clean_full_address, '\\b(FLAT|MAISONETTE)\\b')
+                    THEN 1 ELSE 0 END
+                ) AS new_only_rows,
+                SUM(
+                    CASE WHEN sub_premise_location IS NOT NULL
+                        AND regexp_matches(clean_full_address, '^UNIT\\b')
+                        AND flat_positional IS NULL
+                        AND flat_letter IS NULL
+                        AND flat_number IS NULL
+                        AND NOT regexp_matches(clean_full_address, '\\b(FLAT|MAISONETTE)\\b')
+                    THEN 1 ELSE 0 END
+                ) AS new_only_unit_rows,
+                SUM(
+                    CASE WHEN sub_premise_location IS NOT NULL
+                        AND regexp_matches(clean_full_address, '^STUDIO\\b')
+                        AND flat_positional IS NULL
+                        AND flat_letter IS NULL
+                        AND flat_number IS NULL
+                        AND NOT regexp_matches(clean_full_address, '\\b(FLAT|MAISONETTE)\\b')
+                    THEN 1 ELSE 0 END
+                ) AS new_only_studio_rows,
+                SUM(
+                    CASE WHEN sub_premise_location IS NOT NULL
+                        AND regexp_matches(clean_full_address, '^APARTMENT\\b')
+                        AND flat_positional IS NULL
+                        AND flat_letter IS NULL
+                        AND flat_number IS NULL
+                        AND NOT regexp_matches(clean_full_address, '\\b(FLAT|MAISONETTE)\\b')
+                    THEN 1 ELSE 0 END
+                ) AS new_only_apartment_rows
+            FROM {table_name}
+        """,
+        "new_only_subpremise_samples": f"""
+            SELECT
+                clean_full_address,
+                sub_premise_location,
+                flat_positional,
+                flat_letter,
+                flat_number
+            FROM {table_name}
+            WHERE sub_premise_location IS NOT NULL
+              AND regexp_matches(clean_full_address, '^(APARTMENT|PENTHOUSE|ROOM|UNIT|STUDIO)\\b')
+              AND flat_positional IS NULL
+              AND flat_letter IS NULL
+              AND flat_number IS NULL
+              AND NOT regexp_matches(clean_full_address, '\\b(FLAT|MAISONETTE)\\b')
+            ORDER BY clean_full_address
+            LIMIT 20
+        """,
+        "numeric_token_preservation_counts": f"""
+            SELECT
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^\\d{{1,4}}[A-Z]\\b') THEN 1 ELSE 0 END) AS leading_alnum_rows,
+                SUM(CASE WHEN regexp_matches(clean_full_address, '^\\d{{1,4}}[A-Z]\\b') AND regexp_matches(COALESCE(numeric_token_1, ''), '^[0-9]+[A-Z]$') THEN 1 ELSE 0 END) AS leading_alnum_preserved_in_numeric_token_1
+            FROM {table_name}
+        """,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit parser feature deltas on a benchmark dataset without relying on "
+            "canonical-side benchmark matches."
+        )
+    )
+    parser.add_argument("--dataset", default="hackney")
+    parser.add_argument("--sample-mode", action="store_true")
+    parser.add_argument("--num-of-chunks", type=int, default=1)
+    args = parser.parse_args()
+
+    con = setup_connection()
+    messy = load_dataset(con, dataset_key=args.dataset, sample_mode=args.sample_mode)
+    cleaned = clean_data_pre_term_frequencies(
+        messy,
+        con,
+        num_of_chunks=args.num_of_chunks,
+        show_progress=False,
+    )
+
+    table_name = f"tmp_parser_feature_audit_{args.dataset}"
+    con.sql(f"DROP TABLE IF EXISTS {table_name}")
+    cleaned.create(table_name)
+
+    print(
+        f"Auditing dataset={args.dataset} sample_mode={args.sample_mode} "
+        f"num_of_chunks={args.num_of_chunks}"
+    )
+
+    for title, sql in _queries(table_name).items():
+        _print_section(title, con.sql(sql).fetchall())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cleaning/test_cleaning_steps.py
+++ b/tests/cleaning/test_cleaning_steps.py
@@ -4,8 +4,10 @@ from uk_address_matcher.cleaning.chunking_strategies import prepare_data_for_mat
 from uk_address_matcher.cleaning.steps import (
     _parse_out_business_unit,
     _parse_out_flat_position_and_letter,
+    _parse_out_numbers,
     _parse_out_sub_premise_location,
     _remove_duplicate_end_tokens,
+    _split_numeric_tokens_to_cols,
 )
 from uk_address_matcher.sql_pipeline.runner import DebugOptions, DuckDBPipeline
 
@@ -30,7 +32,7 @@ def test_parse_out_flat_positional():
     # only the LETTER is a flat determinant.
     # The number is the building/house number, not a flat identifier
     test_cases = [
-        ("11A SPITFIRE COURT BIRMINGHAM", None, "A", None),
+        ("11A SPITFIRE COURT BIRMINGHAM", None, None, None),
         ("FLAT A 11 SPITFIRE COURT BIRMINGHAM", None, "A", None),
         ("BASEMENT FLAT A 11 SPITFIRE COURT BIRMINGHAM", "BASEMENT", "A", None),
         (
@@ -69,18 +71,14 @@ def test_parse_out_flat_positional():
             "B",
             "2",
         ),
-        (
-            "15B LONDON ROAD",
-            None,
-            "B",
-            None,
-        ),  # digit+letter: letter is flat determinant, not the number
+        ("15B LONDON ROAD", None, None, None),
         (
             "BASEMENT 15B LONDON ROAD",
             "BASEMENT",
             "B",
             None,
         ),  # floor + digit+letter
+        ("18A CHURCH ROAD GATLEY CHEADLE", None, None, None),
         (
             "FLAT A MY HOUSE 120-122 SOME ROAD",
             None,
@@ -192,6 +190,8 @@ def test_parse_out_sub_premise_location():
         ("GROUND FLOOR RIGHT FLAT 4 UFTON ROAD LONDON", "RIGHT"),
         ("GROUND FLOOR LEFT FLAT 4 UFTON ROAD LONDON", "LEFT"),
         ("FLAT SECOND FLOOR CENTRE 5 MORESBY ROAD LONDON", "CENTRE"),
+        ("APARTMENT REAR 10 EXAMPLE ROAD LONDON", "REAR"),
+        ("UNIT 2 LEFT 8 TEST STREET LONDON", "LEFT"),
         ("FLAT FIRST FLOOR FRONT 176 LOWER CLAPTON ROAD LONDON", "FRONT"),
         ("FLAT FIRST FLOOR REAR 176 LOWER CLAPTON ROAD LONDON", "REAR"),
         (
@@ -354,6 +354,10 @@ def test_parse_out_business_unit():
         # STUDIO patterns (common for creative/media businesses)
         ("STUDIO 4 CREATIVE QUARTER", "STUDIO", "4", True),
         ("STUDIO B ARTS COMPLEX", "STUDIO", "B", True),
+        ("STUDIO 10001 WORKS HOUSE 45 BRUNSWICK PLACE", "STUDIO", "10001", True),
+        # Residential UNIT/STUDIO shells should not be classified as business units
+        ("UNIT 2 FIRST FLOOR LEFT 8 TEST STREET", None, None, False),
+        ("STUDIO 4 10 HIGH STREET", None, None, False),
         # Non-business addresses (should not match)
         ("FLAT A 15 HIGH STREET", None, None, False),
         ("123 MAIN ROAD LONDON", None, None, False),
@@ -390,3 +394,63 @@ def test_parse_out_business_unit():
             f"Address '{address}' expected has_business_unit={expected_indicator} "
             f"but got {row[indicator_idx]}"
         )
+
+
+def test_bare_alphanumeric_house_numbers_do_not_create_flat_signals():
+    connection = duckdb.connect()
+    input_relation = connection.sql(
+        """
+        SELECT * FROM (VALUES
+            ('154A ASHLEY ROAD HALE', '154A ASHLEY ROAD HALE'),
+            ('18A CHURCH ROAD GATLEY CHEADLE', '18A CHURCH ROAD GATLEY CHEADLE'),
+            (
+                'UNIT 18A SLOUGH BUSINESS PARK 94 FARNHAM ROAD SLOUGH',
+                'UNIT 18A SLOUGH BUSINESS PARK 94 FARNHAM ROAD SLOUGH'
+            )
+        ) AS t(clean_full_address, original_address_concat)
+        """
+    )
+
+    pipeline = DuckDBPipeline(connection, input_relation)
+    pipeline.add_step(_parse_out_flat_position_and_letter())
+    pipeline.add_step(_parse_out_business_unit())
+    pipeline.add_step(_parse_out_numbers())
+    pipeline.add_step(_split_numeric_tokens_to_cols())
+    result = pipeline.run(DebugOptions(pretty_print_sql=False))
+
+    actual = result.project(
+        """
+        clean_full_address,
+        flat_letter,
+        flat_number,
+        has_flat_indicator,
+        business_unit_type,
+        business_unit_id,
+        numeric_token_1,
+        numeric_token_2
+        """
+    ).fetchall()
+
+    assert actual == [
+        ("154A ASHLEY ROAD HALE", None, None, False, None, None, "154A", None),
+        (
+            "18A CHURCH ROAD GATLEY CHEADLE",
+            None,
+            None,
+            False,
+            None,
+            None,
+            "18A",
+            None,
+        ),
+        (
+            "UNIT 18A SLOUGH BUSINESS PARK 94 FARNHAM ROAD SLOUGH",
+            None,
+            None,
+            False,
+            "UNIT",
+            "18A",
+            "18A",
+            "94",
+        ),
+    ]

--- a/uk_address_matcher/cleaning/steps/token_parsing.py
+++ b/uk_address_matcher/cleaning/steps/token_parsing.py
@@ -210,6 +210,8 @@ def _parse_out_flat_position_and_letter():
     )
     flat_letter_after_flat = r"\bFLAT\s+([A-Za-z])\b"  # FLAT A
     block_letter = r"\bBLOCK\s+([A-Za-z])\b"  # BLOCK A / BLOCK B
+    explicit_sub_premise_signal = r"\b(FLAT|MAISONETTE|ROOM)\b"
+    business_unit_signal = r"^\s*(UNIT|SUITE|OFFICE|WORKSHOP|WAREHOUSE|STUDIO)S?\b"
 
     # Scottish style "FLAT 3/2" → use the right-hand number as the unit/flat number
     scottish_flat = r"\bFLAT\s+(\d+)\s*/\s*(\d+)\b"
@@ -255,6 +257,16 @@ def _parse_out_flat_position_and_letter():
             )
         END AS flat_positional,
 
+        regexp_matches(
+            i.clean_full_address,
+            '{explicit_sub_premise_signal}'
+        ) AS has_explicit_sub_premise_signal,
+
+        regexp_matches(
+            i.clean_full_address,
+            '{business_unit_signal}'
+        ) AS starts_with_business_unit_signal,
+
         -- 2) flat_letter (priority:
         -- FLAT 12A → A, FLAT A → A, BLOCK A → A,
         -- 11A start → A, 15B anywhere → B)
@@ -275,14 +287,50 @@ def _parse_out_flat_position_and_letter():
                 regexp_extract(i.clean_full_address, '{block_letter}', 1),
                 ''
             ),
-            NULLIF(
-                regexp_extract(i.clean_full_address, '{leading_num_letter}', 2),
-                ''
-            ),
-            NULLIF(
-                regexp_extract(i.clean_full_address, '{num_letter_anywhere}', 2),
-                ''
-            )
+            CASE
+                WHEN (
+                    regexp_matches(i.clean_full_address, '{explicit_sub_premise_signal}')
+                    OR NULLIF(
+                        regexp_extract(i.clean_full_address, '{floor_positions}', 1),
+                        ''
+                    ) IS NOT NULL
+                    OR NULLIF(
+                        regexp_extract(
+                            i.clean_full_address,
+                            '{leading_bare_floor_position}',
+                            1
+                        ),
+                        ''
+                    ) IS NOT NULL
+                )
+                AND NOT regexp_matches(i.clean_full_address, '{business_unit_signal}')
+                THEN NULLIF(
+                    regexp_extract(i.clean_full_address, '{leading_num_letter}', 2),
+                    ''
+                )
+            END,
+            CASE
+                WHEN (
+                    regexp_matches(i.clean_full_address, '{explicit_sub_premise_signal}')
+                    OR NULLIF(
+                        regexp_extract(i.clean_full_address, '{floor_positions}', 1),
+                        ''
+                    ) IS NOT NULL
+                    OR NULLIF(
+                        regexp_extract(
+                            i.clean_full_address,
+                            '{leading_bare_floor_position}',
+                            1
+                        ),
+                        ''
+                    ) IS NOT NULL
+                )
+                AND NOT regexp_matches(i.clean_full_address, '{business_unit_signal}')
+                THEN NULLIF(
+                    regexp_extract(i.clean_full_address, '{num_letter_anywhere}', 2),
+                    ''
+                )
+            END
         ) AS flat_letter,
 
         -- 3) flat_number (priority explained inline)
@@ -346,7 +394,7 @@ def _parse_out_flat_position_and_letter():
     # Also check for the word FLAT itself as a flat signal
     final_sql = r"""
     SELECT
-        *,
+        * EXCLUDE (has_explicit_sub_premise_signal, starts_with_business_unit_signal),
         (
             flat_letter IS NOT NULL
             OR flat_number IS NOT NULL
@@ -433,7 +481,10 @@ def _parse_out_sub_premise_location():
                 flat_positional IS NOT NULL
                 OR flat_letter IS NOT NULL
                 OR flat_number IS NOT NULL
-                OR regexp_matches(clean_full_address, '\b(FLAT|MAISONETTE)\b')
+                OR regexp_matches(
+                    clean_full_address,
+                    '\b(FLAT|MAISONETTE|APARTMENT|PENTHOUSE|ROOM|UNIT|STUDIO)\b'
+                )
             ) THEN NULL
             WHEN regexp_matches(
                 sub_premise_location_prefix, '\bRIGHT HAND SIDE\b'
@@ -498,44 +549,105 @@ def _parse_out_business_unit():
       - business_unit_id: The identifier (letter, number, or alphanumeric)
       - has_business_unit: Boolean indicator
     """
-    # Business unit keywords - these indicate commercial/industrial premises
-    # Note: UNIT is normalised FROM residential APARTMENT in earlier cleaning,
-    # but raw UNIT in business contexts (UNIT C, UNIT 5) remains
+    # Business unit keywords - these indicate commercial/industrial premises.
+    # UNIT and STUDIO can also appear in residential shells, so those need
+    # extra gating against nearby residential evidence.
     business_keywords = ["UNIT", "SUITE", "OFFICE", "WORKSHOP", "WAREHOUSE", "STUDIO"]
 
     # Build pattern: (UNIT|SUITE|...) followed by identifier
-    # Identifier can be: letter (A-Z), number (1-999), or alphanumeric (5A, A5)
+    # Identifier can be: letter (A-Z), number, or alphanumeric (5A, A5).
+    # We allow up to 5 digits because real commercial studio/unit identifiers
+    # can exceed 4 digits (e.g. STUDIO 10001 WORKS HOUSE ...).
     # Also handle plural forms like "UNITS 1-3" or "UNITS A AND B"
     keywords_pattern = "|".join(business_keywords)
 
     # Pattern for singular: UNIT A, UNIT 5, UNIT 5A, UNIT A5
     singular_pattern = (
-        rf"\b({keywords_pattern})S?\s+([A-Za-z]?\d{{1,4}}[A-Za-z]?|[A-Za-z])\b"
+        rf"\b({keywords_pattern})S?\s+([A-Za-z]?\d{{1,5}}[A-Za-z]?|[A-Za-z])\b"
     )
+    residential_shell_pattern = r"\b(FLAT|MAISONETTE|APARTMENT|PENTHOUSE|ROOM)\b"
+    residential_context_pattern = r"\b(LEFT|RIGHT|FRONT|REAR|FLOOR|BASEMENT|GARDEN)\b"
+    studio_residential_pattern = r"^\s*STUDIO\s+[A-Za-z]?\d{1,5}[A-Za-z]?\s+\d"
 
     sql = f"""
+    WITH business_unit_raw AS (
     SELECT
         i.*,
 
-        -- Extract the business unit type (UNIT, SUITE, OFFICE, etc.)
         NULLIF(
             UPPER(regexp_extract(i.clean_full_address, '{singular_pattern}', 1)),
             ''
-        ) AS business_unit_type,
+        ) AS __business_unit_type,
 
-        -- Extract the business unit identifier (A, 5, 5A, etc.)
         NULLIF(
             UPPER(regexp_extract(i.clean_full_address, '{singular_pattern}', 2)),
             ''
-        ) AS business_unit_id,
+        ) AS __business_unit_id,
 
-        -- Boolean indicator for having a business unit
+        (
+            regexp_matches(i.clean_full_address, '{residential_shell_pattern}')
+            OR regexp_matches(i.clean_full_address, '{residential_context_pattern}')
+        ) AS __has_residential_context,
+
         regexp_matches(
             i.clean_full_address,
-            '\\b({keywords_pattern})S?\\s+([A-Za-z]?\\d{{1,4}}[A-Za-z]?|[A-Za-z])\\b'
-        ) AS has_business_unit
+            '{studio_residential_pattern}'
+        ) AS __looks_like_residential_studio,
+
+        -- Extract the business unit type (UNIT, SUITE, OFFICE, etc.)
+        CASE
+            WHEN __business_unit_type IN ('UNIT', 'STUDIO')
+                 AND (
+                    __has_residential_context
+                    OR (
+                        __business_unit_type = 'STUDIO'
+                        AND __looks_like_residential_studio
+                    )
+                 )
+                THEN NULL
+            ELSE __business_unit_type
+        END AS business_unit_type,
+
+        -- Extract the business unit identifier (A, 5, 5A, etc.)
+        CASE
+            WHEN __business_unit_type IN ('UNIT', 'STUDIO')
+                 AND (
+                    __has_residential_context
+                    OR (
+                        __business_unit_type = 'STUDIO'
+                        AND __looks_like_residential_studio
+                    )
+                 )
+                THEN NULL
+            ELSE __business_unit_id
+        END AS business_unit_id,
+
+        -- Boolean indicator for having a business unit
+        CASE
+            WHEN __business_unit_type IN ('UNIT', 'STUDIO')
+                 AND (
+                    __has_residential_context
+                    OR (
+                        __business_unit_type = 'STUDIO'
+                        AND __looks_like_residential_studio
+                    )
+                 )
+                THEN FALSE
+            ELSE regexp_matches(
+                i.clean_full_address,
+                '\\b({keywords_pattern})S?\\s+([A-Za-z]?\\d{{1,5}}[A-Za-z]?|[A-Za-z])\\b'
+            )
+        END AS has_business_unit
 
     FROM {{input}} i
+    )
+    SELECT * EXCLUDE (
+        __business_unit_type,
+        __business_unit_id,
+        __has_residential_context,
+        __looks_like_residential_studio
+    )
+    FROM business_unit_raw
     """
     return sql
 

--- a/uk_address_matcher/cleaning/steps/tokenisation.py
+++ b/uk_address_matcher/cleaning/steps/tokenisation.py
@@ -15,18 +15,9 @@ def _split_numeric_tokens_to_cols():
     sql = """
     SELECT
         *,
-        regexp_extract_all(
-            array_to_string(numeric_tokens, ' '),
-            '\\d+'
-        )[1] as numeric_token_1,
-        regexp_extract_all(
-            array_to_string(numeric_tokens, ' '),
-            '\\d+'
-        )[2] as numeric_token_2,
-        regexp_extract_all(
-            array_to_string(numeric_tokens, ' '),
-            '\\d+'
-        )[3] as numeric_token_3
+        numeric_tokens[1] as numeric_token_1,
+        numeric_tokens[2] as numeric_token_2,
+        numeric_tokens[3] as numeric_token_3
     FROM {input}
     """
     return sql

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -82,6 +82,14 @@ class SplinkStage(MatchingStage):
     improve_top_n_matches: int = 5
     improve_use_bigrams: bool = True
 
+    # Reranker (improve_predictions) scoring knobs. Defaults match the library
+    # defaults so behaviour is unchanged unless explicitly overridden.
+    improve_reward_multiplier: float = 3.0
+    improve_punishment_multiplier: float = 1.5
+    improve_missing_token_penalty: float = 0.1
+    improve_positional_conflict_penalty: float = 6.0
+    improve_business_unit_conflict_penalty: float = 6.0
+
     # Thresholds for final candidate selection
     final_match_weight_threshold: float = -20.0
     final_distinguishability_threshold: Optional[float] = 0.0
@@ -178,6 +186,11 @@ class SplinkStage(MatchingStage):
             top_n_matches=self.improve_top_n_matches,
             use_bigrams=self.improve_use_bigrams,
             additional_columns_to_retain=effective_columns_to_retain,
+            REWARD_MULTIPLIER=self.improve_reward_multiplier,
+            PUNISHMENT_MULTIPLIER=self.improve_punishment_multiplier,
+            MISSING_TOKEN_PENALTY=self.improve_missing_token_penalty,
+            POSITIONAL_CONFLICT_PENALTY=self.improve_positional_conflict_penalty,
+            BUSINESS_UNIT_CONFLICT_PENALTY=self.improve_business_unit_conflict_penalty,
         )
         self.improved_predictions_table = getattr(df_improved, "alias", None)
 

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -12,6 +12,17 @@ if TYPE_CHECKING:
     from uk_address_matcher.sql_pipeline.runner import DebugOptions
 
 
+# Sub-premise / business-unit discriminants consumed by the stage-2 reranker.
+# The Splink model deliberately does not score these; instead they are retained
+# through prediction so the distinguishing-token step can apply structured
+# conflict penalties (e.g. sub-premise LEFT vs RIGHT, business UNIT 5 vs UNIT 6).
+_RERANK_DISCRIMINANT_COLUMNS = (
+    "sub_premise_location",
+    "business_unit_type",
+    "business_unit_id",
+)
+
+
 @dataclass(repr=False)
 class SplinkStage(MatchingStage):
     """Probabilistic matching stage built on Splink.
@@ -120,6 +131,13 @@ class SplinkStage(MatchingStage):
         if unmatched_count == 0:
             return None
 
+        # Retain the reranker discriminants through prediction in addition to any
+        # caller-supplied columns, de-duplicated to avoid Splink retain conflicts.
+        effective_columns_to_retain = list(self.additional_columns_to_retain or [])
+        for _discriminant in _RERANK_DISCRIMINANT_COLUMNS:
+            if _discriminant not in effective_columns_to_retain:
+                effective_columns_to_retain.append(_discriminant)
+
         # Step 1: Build linker
         linker = _get_linker(
             df_addresses_to_match=df_unmatched,
@@ -127,7 +145,7 @@ class SplinkStage(MatchingStage):
             con=con,
             include_full_postcode_block=self.include_full_postcode_block,
             include_outside_postcode_block=self.include_outside_postcode_block,
-            additional_columns_to_retain=self.additional_columns_to_retain,
+            additional_columns_to_retain=effective_columns_to_retain,
             retain_intermediate_calculation_columns=(
                 self.retain_intermediate_calculation_columns
             ),
@@ -159,7 +177,7 @@ class SplinkStage(MatchingStage):
             match_weight_threshold=self.improve_threshold_match_weight,
             top_n_matches=self.improve_top_n_matches,
             use_bigrams=self.improve_use_bigrams,
-            additional_columns_to_retain=self.additional_columns_to_retain,
+            additional_columns_to_retain=effective_columns_to_retain,
         )
         self.improved_predictions_table = getattr(df_improved, "alias", None)
 

--- a/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
+++ b/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
@@ -21,6 +21,7 @@ def improve_predictions_using_distinguishing_tokens(
     BIGRAM_PUNISHMENT_MULTIPLIER=1.5,
     MISSING_TOKEN_PENALTY=0.1,
     POSITIONAL_CONFLICT_PENALTY=6.0,
+    BUSINESS_UNIT_CONFLICT_PENALTY=6.0,
 ):
     """
     Improve match predictions by identifying distinguishing tokens between addresses.
@@ -436,6 +437,55 @@ def improve_predictions_using_distinguishing_tokens(
 
     windowed_tokens = con.sql(sql_final)  # noqa: F841
 
+    # Structured discriminant conflict penalties (stage-2 reranking).
+    # Prefer the parsed `sub_premise_location` column when it has been retained
+    # through prediction; otherwise fall back to the token-derived positional
+    # descriptors. Penalties only fire when BOTH sides carry the signal and they
+    # disagree, so coarser records that simply lack the finer descriptor are not
+    # punished.
+    predict_columns = set(df_predict.columns)
+
+    if {"sub_premise_location_l", "sub_premise_location_r"} <= predict_columns:
+        positional_conflict_sql = f"""
+        - (CASE
+            WHEN sub_premise_location_l IS NOT NULL
+                AND sub_premise_location_r IS NOT NULL
+                AND sub_premise_location_l <> sub_premise_location_r
+            THEN {POSITIONAL_CONFLICT_PENALTY}
+            ELSE 0
+          END)
+        """
+    else:
+        positional_conflict_sql = f"""
+        - (CASE
+            WHEN len(positional_tokens_l) > 0
+                AND len(positional_tokens_r) > 0
+                AND len(list_intersect(positional_tokens_l, positional_tokens_r)) = 0
+            THEN {POSITIONAL_CONFLICT_PENALTY}
+            ELSE 0
+          END)
+        """
+
+    business_unit_conflict_sql = ""
+    if {"business_unit_id_l", "business_unit_id_r"} <= predict_columns:
+        business_unit_type_clause = ""
+        if {"business_unit_type_l", "business_unit_type_r"} <= predict_columns:
+            business_unit_type_clause = (
+                "OR business_unit_type_l IS DISTINCT FROM business_unit_type_r"
+            )
+        business_unit_conflict_sql = f"""
+        - (CASE
+            WHEN business_unit_id_l IS NOT NULL
+                AND business_unit_id_r IS NOT NULL
+                AND (
+                    business_unit_id_l <> business_unit_id_r
+                    {business_unit_type_clause}
+                )
+            THEN {BUSINESS_UNIT_CONFLICT_PENALTY}
+            ELSE 0
+          END)
+        """
+
     # Calculate new match weights based on distinguishing tokens and bigrams
 
     sql = f"""
@@ -458,16 +508,12 @@ def improve_predictions_using_distinguishing_tokens(
 
         - (len(missing_tokens) * {MISSING_TOKEN_PENALTY})
 
-        -- Sub-premise positional conflict (e.g. messy says LEFT, candidate says RIGHT).
-        -- Only fires when both sides carry a positional descriptor and they disagree;
-        -- silent otherwise so neutral/missing cases are unaffected.
-        - (CASE
-            WHEN len(positional_tokens_l) > 0
-                AND len(positional_tokens_r) > 0
-                AND len(list_intersect(positional_tokens_l, positional_tokens_r)) = 0
-            THEN {POSITIONAL_CONFLICT_PENALTY}
-            ELSE 0
-          END)
+        -- Sub-premise positional conflict (e.g. messy says LEFT, candidate says RIGHT)
+        -- and business-unit conflict (e.g. messy says UNIT 5, candidate says UNIT 6).
+        -- Only fire when both sides carry the signal and they disagree; silent
+        -- otherwise so neutral/missing cases are unaffected.
+        {positional_conflict_sql}
+        {business_unit_conflict_sql}
 
         -- Bigram-based adjustments
         {

--- a/uv.lock
+++ b/uv.lock
@@ -403,7 +403,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2034,7 +2034,7 @@ wheels = [
 
 [[package]]
 name = "uk-address-matcher"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Wires sub_premise_location + business_unit_type/id through Splink prediction into the stage-2 reranker, adding asymmetric positional and business-unit conflict penalties. Fixes a BinderException where internal __-prefixed business-unit temp columns leaked into cleaned output. Includes prior parser work (tokenisation, business-unit parsing) and an audit script.

## Summary

Improves the stage-2 reranker so the matcher can distinguish near-identical addresses
that previously collided (e.g. different flats or business units at the same property).

## What's changed

- **Sub-premise & business-unit discriminants** — wires `sub_premise_location` and
  `business_unit_type`/`id` through Splink prediction into the reranker, so they can
  inform the final match decision.
- **Conflict penalties** — adds asymmetric positional-conflict and business-unit-conflict
  penalties, demoting candidates where these clearly disagree (e.g. "Flat 1" vs "Flat 2").
- **Configurable scoring knobs** — exposes the reward, punishment, missing-token,
  positional-conflict and business-unit-conflict multipliers as `SplinkStage` fields.
  Defaults match the existing library values, so behaviour is unchanged unless overridden.
- **Parser fix** — resolves a `BinderException` where internal `__`-prefixed business-unit
  temporary columns leaked into the cleaned output.
- **Supporting changes** — tokenisation and business-unit parser updates, plus added tests.

## Impact

A small but genuine across-the-board improvement: precision is higher at every recall
level compared with not having the discriminant penalties, with no regression elsewhere.
Defaults are unchanged, so the rollout is low-risk.