### PR TITLE
feat(cleaning): improve cleaning performance

### DIFF
--- a/uk_address_matcher/cleaning/steps/term_frequencies.py
+++ b/uk_address_matcher/cleaning/steps/term_frequencies.py
@@ -49,12 +49,20 @@ def _add_term_frequencies_to_address_tokens():
         ON e.token = f.token
     """
 
-    # 3. Aggregate ONLY the frequencies
-    # Sorting (Int, Float) pairs is extremely fast compared to (Int, String, Float)
+    # 3. Aggregate the frequencies back into a per-address array.
+    # A plain `list(rel_freq ORDER BY token_idx)` forces DuckDB to run an
+    # ordered list aggregate, which sorts within every group during the
+    # aggregation and dominates the cleaning plan. Instead we collect a single
+    # `list(struct(idx, freq))` (one aggregate, so idx/freq stay aligned) and
+    # sort it once with `list_sort` (token_idx is the leading struct field and
+    # is unique within a group). This is ~3x faster with identical output.
     reaggregated_freqs_sql = """
     SELECT
         ukam_address_id,
-        list(rel_freq ORDER BY token_idx ASC) AS freq_arr
+        list_transform(
+            list_sort(list(struct_pack(idx := token_idx, freq := rel_freq))),
+            s -> s.freq
+        ) AS freq_arr
     FROM {joined_scalars}
     GROUP BY ukam_address_id
     """
@@ -119,12 +127,20 @@ def _add_term_frequencies_to_address_tokens_using_registered_df():
         ON e.token = __ukam__tmp_rel_tok_freq.token
     """
 
-    # 3. Aggregate ONLY the frequencies
-    # Sorting (Int, Float) pairs is extremely fast compared to (Int, String, Float)
+    # 3. Aggregate the frequencies back into a per-address array.
+    # A plain `list(rel_freq ORDER BY token_idx)` forces DuckDB to run an
+    # ordered list aggregate, which sorts within every group during the
+    # aggregation and dominates the cleaning plan. Instead we collect a single
+    # `list(struct(idx, freq))` (one aggregate, so idx/freq stay aligned) and
+    # sort it once with `list_sort` (token_idx is the leading struct field and
+    # is unique within a group). This is ~3x faster with identical output.
     reaggregated_freqs_sql = """
     SELECT
         ukam_address_id,
-        list(rel_freq ORDER BY token_idx ASC) AS freq_arr
+        list_transform(
+            list_sort(list(struct_pack(idx := token_idx, freq := rel_freq))),
+            s -> s.freq
+        ) AS freq_arr
     FROM {joined_scalars}
     GROUP BY ukam_address_id
     """


### PR DESCRIPTION
Improves cleaning performance with some micro-adjustments:
| Area | Before | After | Result |
| --- | ---: | ---: | --- |
| TF reaggregation `HASH_GROUP_BY` | 2908 ms | 255 ms | about 11.4x faster for that operator |
| Local TF array-build benchmark | 151 ms | 51 ms | about 3x faster end to end for the pattern |