### PR TITLE
feat(splink): add bi/trigram unique signature hit condition

### DIFF
--- a/uk_address_matcher/cleaning/steps/inverted_index.py
+++ b/uk_address_matcher/cleaning/steps/inverted_index.py
@@ -265,6 +265,7 @@ def _lookup_keys_in_inverted_index(strategies=None):
         SELECT
             dk.__messy_uid,
             ii.unique_ids AS __cand_ids,
+            len(ii.unique_ids) AS __posting_size,
             log2(
                 (SELECT n FROM __ukam_index_meta)::DOUBLE
                 / len(ii.unique_ids)
@@ -279,7 +280,8 @@ def _lookup_keys_in_inverted_index(strategies=None):
         SELECT
             __messy_uid,
             CAST(cid AS VARCHAR) AS __cand_id,
-            SUM(__key_idf) AS __score
+            SUM(__key_idf) AS __score,
+            SUM(CASE WHEN __posting_size = 1 THEN 1 ELSE 0 END) AS __unique_hits
         FROM {key_scores}, unnest(__cand_ids) AS t(cid)
         GROUP BY __messy_uid, CAST(cid AS VARCHAR)
         """
@@ -287,7 +289,14 @@ def _lookup_keys_in_inverted_index(strategies=None):
         score_map_sql = """
         SELECT
             __messy_uid,
-            map(list(__cand_id), list(__score)) AS signature_score_map
+            map(
+                list(__cand_id ORDER BY __cand_id),
+                list(__score ORDER BY __cand_id)
+            ) AS signature_score_map,
+            map(
+                list(__cand_id ORDER BY __cand_id),
+                list(__unique_hits ORDER BY __cand_id)
+            ) AS signature_unique_hits_map
         FROM {cand_scores}
         GROUP BY __messy_uid
         """
@@ -300,7 +309,11 @@ def _lookup_keys_in_inverted_index(strategies=None):
             COALESCE(
                 s.signature_score_map,
                 MAP([]::VARCHAR[], []::DOUBLE[])
-            ) AS signature_score_map
+            ) AS signature_score_map,
+            COALESCE(
+                s.signature_unique_hits_map,
+                MAP([]::VARCHAR[], []::BIGINT[])
+            ) AS signature_unique_hits_map
         FROM {base} AS base
         LEFT JOIN {deduplicated} AS d ON base.unique_id = d.__messy_uid
         LEFT JOIN {score_map} AS s ON base.unique_id = s.__messy_uid
@@ -345,7 +358,8 @@ def _set_exploding_unique_ids_to_self():
     SELECT
         *,
         [unique_id] AS exploding_unique_ids,
-        MAP([]::VARCHAR[], []::DOUBLE[]) AS signature_score_map
+        MAP([]::VARCHAR[], []::DOUBLE[]) AS signature_score_map,
+        MAP([]::VARCHAR[], []::BIGINT[]) AS signature_unique_hits_map
     FROM {input}
     """
     return sql

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -734,8 +734,16 @@
           "is_null_level": true
         },
         {
+          "sql_condition": "list_extract(map_extract(signature_unique_hits_map_r, CAST(unique_id_l AS VARCHAR)), 1) >= 2 AND numeric_token_1_l = numeric_token_1_r AND NOT (flat_identity_l IS NOT NULL AND flat_identity_r IS NOT NULL AND flat_identity_l != flat_identity_r)",
+          "label_for_charts": "2+ unique signature hits + number agreement",
+          "m_probability": 256.0,
+          "u_probability": 1,
+          "fix_m_probability": true,
+          "fix_u_probability": true
+        },
+        {
           "sql_condition": "list_extract(map_extract(signature_unique_hits_map_r, CAST(unique_id_l AS VARCHAR)), 1) >= 1 AND numeric_token_1_l = numeric_token_1_r AND NOT (flat_identity_l IS NOT NULL AND flat_identity_r IS NOT NULL AND flat_identity_l != flat_identity_r)",
-          "label_for_charts": "Unique signature hit + number agreement",
+          "label_for_charts": "1 unique signature hit + number agreement",
           "m_probability": 80.0,
           "u_probability": 1,
           "fix_m_probability": true,

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -734,6 +734,14 @@
           "is_null_level": true
         },
         {
+          "sql_condition": "list_extract(map_extract(signature_unique_hits_map_r, CAST(unique_id_l AS VARCHAR)), 1) >= 1 AND numeric_token_1_l = numeric_token_1_r AND NOT (flat_identity_l IS NOT NULL AND flat_identity_r IS NOT NULL AND flat_identity_l != flat_identity_r)",
+          "label_for_charts": "Unique signature hit + number agreement",
+          "m_probability": 80.0,
+          "u_probability": 1,
+          "fix_m_probability": true,
+          "fix_u_probability": true
+        },
+        {
           "sql_condition": "list_extract(map_extract(signature_score_map_r, CAST(unique_id_l AS VARCHAR)), 1) >= 40",
           "label_for_charts": "Signature IDF sum >= 40 (very strong)",
           "m_probability": 64.0,

--- a/uk_address_matcher/linking_model/splink_model.py
+++ b/uk_address_matcher/linking_model/splink_model.py
@@ -176,12 +176,8 @@ def _get_linker(
     # candidate canonical id, the number of shared inverted-index keys whose
     # posting list has size 1 (i.e. a key unique to that canonical) so the
     # signature comparison can reward unique rare-span hits.
-    _empty_hits_map = (
-        "MAP([]::VARCHAR[], []::BIGINT[]) AS signature_unique_hits_map"
-    )
-    messy_has_hits_map = (
-        "signature_unique_hits_map" in df_addresses_to_match.columns
-    )
+    _empty_hits_map = "MAP([]::VARCHAR[], []::BIGINT[]) AS signature_unique_hits_map"
+    messy_has_hits_map = "signature_unique_hits_map" in df_addresses_to_match.columns
     canonical_has_hits_map = (
         "signature_unique_hits_map" in df_addresses_to_search_within.columns
     )

--- a/uk_address_matcher/linking_model/splink_model.py
+++ b/uk_address_matcher/linking_model/splink_model.py
@@ -172,6 +172,30 @@ def _get_linker(
     if messy_has_score_map or canonical_has_score_map:
         settings_as_dict["additional_columns_to_retain"].append("signature_score_map")
 
+    # Align the parallel unique-hit count map the same way. It carries, per
+    # candidate canonical id, the number of shared inverted-index keys whose
+    # posting list has size 1 (i.e. a key unique to that canonical) so the
+    # signature comparison can reward unique rare-span hits.
+    _empty_hits_map = (
+        "MAP([]::VARCHAR[], []::BIGINT[]) AS signature_unique_hits_map"
+    )
+    messy_has_hits_map = (
+        "signature_unique_hits_map" in df_addresses_to_match.columns
+    )
+    canonical_has_hits_map = (
+        "signature_unique_hits_map" in df_addresses_to_search_within.columns
+    )
+    if messy_has_hits_map and not canonical_has_hits_map:
+        df_addresses_to_search_within = df_addresses_to_search_within.select(
+            f"*, {_empty_hits_map}"
+        )
+    elif canonical_has_hits_map and not messy_has_hits_map:
+        df_addresses_to_match = df_addresses_to_match.select(f"*, {_empty_hits_map}")
+    if messy_has_hits_map or canonical_has_hits_map:
+        settings_as_dict["additional_columns_to_retain"].append(
+            "signature_unique_hits_map"
+        )
+
     # Auto-detect ukam_label: if present in messy data, retain it for accuracy testing.
     if "ukam_label" in df_addresses_to_match.columns:
         settings_as_dict["additional_columns_to_retain"].append("ukam_label")


### PR DESCRIPTION
## PR Summary

This PR adds a new token signature check that adds two levels:
1. Do we have 2+ unique signatures between our two records (which has a big uplift)
2. Do we have a single unique signature between our two records (large uplift)

From my testing, this has very high-predictive power and precision and trigger surprisingly frequently across our labelled datasets (our labelled datasets contain approx 115k records each):
```
| dataset | best level | true | false | precision |
|---|---|---:|---:|---:|---:|
| Hackney | `p9_unique_num` | 20,408 | 3,369 | 0.8583 | 
| Rhondda | `p9_unique_num` | 11,134 | 1,212 | 0.9018 |
| Mid Sussex | `p9_unique_num` | 1,136 | 315 | 0.7829 | 
| Aberdeenshire | `p9_unique_num` | 6,719 | 1,307 | 0.8372 | 
| Aberdeenshire | `p9_unique_num_flatconflict` | 122 | 7 | 0.9457 | 
```

This is also effectively free as an addition given that our inverted index will already have been constructed by this point in the process.