### PR TITLE
refactor(logging): move logging code into a separate folder

### DIFF
--- a/tests/cleaning/test_cleaning_steps.py
+++ b/tests/cleaning/test_cleaning_steps.py
@@ -337,7 +337,7 @@ def test_prepare_data_progress_off_suppresses_stage_status_logs(caplog):
         cleaned = prepare_data_for_matching(
             input_relation,
             con=connection,
-            progress="off",
+            show_progress="off",
         )
 
     assert cleaned.count("*").fetchone()[0] == 1

--- a/tests/cleaning/test_cleaning_steps.py
+++ b/tests/cleaning/test_cleaning_steps.py
@@ -1,3 +1,5 @@
+import logging
+
 import duckdb
 
 from uk_address_matcher.cleaning.chunking_strategies import prepare_data_for_matching
@@ -319,6 +321,36 @@ def test_supplied_postcode_does_not_strip_postcode_like_floor_tokens():
         ("d", "SW1A 2AA", "10 DOWNING STREET"),
         ("e", "SW1A 2AA", "10 DOWNING STREET"),
     ]
+
+
+def test_prepare_data_progress_off_suppresses_stage_status_logs(caplog):
+    connection = duckdb.connect()
+    input_relation = connection.sql(
+        """
+        SELECT * FROM (VALUES
+            ('1', '10 DOWNING STREET', 'SW1A 2AA')
+        ) AS t(unique_id, address_concat, postcode)
+        """
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
+        cleaned = prepare_data_for_matching(
+            input_relation,
+            con=connection,
+            progress="off",
+        )
+
+    assert cleaned.count("*").fetchone()[0] == 1
+    stage_prefixes = ("Cleaning and preprocessing", "Applying term frequencies")
+    assert not any(
+        record.getMessage().startswith(stage_prefix)
+        and (
+            " records across " in record.getMessage()
+            or " completed:" in record.getMessage()
+        )
+        for record in caplog.records
+        for stage_prefix in stage_prefixes
+    )
 
 
 def test_parse_out_business_unit():

--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -262,7 +262,7 @@ def test_matcher_progress_stages_logs_boundaries_without_chunk_updates(
         addresses_to_match=messy_data,
         con=con,
         stages=[ExactMatchStage()],
-        progress="stages",
+        show_progress="stages",
     )
 
     with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
@@ -284,7 +284,7 @@ def test_matcher_progress_off_suppresses_stage_status_logs(
         addresses_to_match=messy_data,
         con=con,
         stages=[ExactMatchStage()],
-        progress="off",
+        show_progress="off",
     )
 
     with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
@@ -309,12 +309,12 @@ def test_matcher_progress_off_suppresses_stage_status_logs(
 
 
 def test_matcher_rejects_unknown_progress_mode(con, canonical_data, messy_data):
-    with pytest.raises(ValueError, match="progress must be one of"):
+    with pytest.raises(ValueError, match="show_progress must be a boolean"):
         AddressMatcher(
             canonical_addresses=canonical_data,
             addresses_to_match=messy_data,
             con=con,
-            progress="verbose",
+            show_progress="verbose",
         )
 
 

--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -254,6 +254,70 @@ def test_cleaning_num_chunks_is_propagated_to_cleaning_steps(
     )
 
 
+def test_matcher_progress_stages_logs_boundaries_without_chunk_updates(
+    con, canonical_data, messy_data, caplog
+):
+    matcher = AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=messy_data,
+        con=con,
+        stages=[ExactMatchStage()],
+        progress="stages",
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
+        matcher._resolve_canonical_data()
+        matcher._resolve_messy_data()
+
+    messages = [record.getMessage() for record in caplog.records]
+
+    assert any(message.startswith("Cleaning for TF derivation:") for message in messages)
+    assert any(message.startswith("Applying term frequencies:") for message in messages)
+    assert not any("chunk 1/" in message for message in messages)
+
+
+def test_matcher_progress_off_suppresses_stage_status_logs(
+    con, canonical_data, messy_data, caplog
+):
+    matcher = AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=messy_data,
+        con=con,
+        stages=[ExactMatchStage()],
+        progress="off",
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
+        matcher._resolve_canonical_data()
+        matcher._resolve_messy_data()
+
+    stage_prefixes = (
+        "Cleaning for TF derivation",
+        "Cleaning and preprocessing",
+        "Applying term frequencies",
+        "Building inverted index",
+    )
+    assert not any(
+        record.getMessage().startswith(stage_prefix)
+        and (
+            " records across " in record.getMessage()
+            or " completed:" in record.getMessage()
+        )
+        for record in caplog.records
+        for stage_prefix in stage_prefixes
+    )
+
+
+def test_matcher_rejects_unknown_progress_mode(con, canonical_data, messy_data):
+    with pytest.raises(ValueError, match="progress must be one of"):
+        AddressMatcher(
+            canonical_addresses=canonical_data,
+            addresses_to_match=messy_data,
+            con=con,
+            progress="verbose",
+        )
+
+
 def test_match_with_custom_splink_stage(con, canonical_data, messy_data):
     """SplinkStage parameters should be passable directly."""
     matcher = AddressMatcher(

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -273,7 +273,7 @@ def test_prepare_can_create_chunked_canonical_output(con, canonical_data, tmp_pa
     assert not (tmp_path / "ukam_canonical_addresses.parquet").exists()
 
 
-def test_prepare_progress_off_suppresses_live_output(
+def test_prepare_show_progress_false_suppresses_live_output(
     con, canonical_data, tmp_path, monkeypatch
 ):
     stream = _FakeStream(isatty_value=True)
@@ -284,7 +284,7 @@ def test_prepare_progress_off_suppresses_live_output(
         output_folder=tmp_path / "prepared",
         con=con,
         overwrite=True,
-        progress="off",
+        show_progress=False,
     )
 
     assert stream.getvalue() == ""
@@ -302,7 +302,7 @@ def test_prepare_progress_stages_logs_boundaries_without_chunk_updates(
             output_folder=tmp_path / "prepared",
             con=con,
             overwrite=True,
-            progress="stages",
+            show_progress="stages",
         )
 
     messages = [record.getMessage() for record in caplog.records]
@@ -325,7 +325,7 @@ def test_prepare_progress_off_suppresses_stage_status_logs(
             output_folder=tmp_path / "prepared",
             con=con,
             overwrite=True,
-            progress="off",
+            show_progress="off",
         )
 
     stage_prefixes = (
@@ -345,7 +345,7 @@ def test_prepare_progress_off_suppresses_stage_status_logs(
     )
 
 
-def test_prepare_default_progress_enables_live_output(
+def test_prepare_default_show_progress_enables_live_output(
     con, canonical_data, tmp_path, monkeypatch
 ):
     enabled_values: list[bool] = []
@@ -387,7 +387,7 @@ def test_prepare_default_progress_enables_live_output(
     assert all(value is True for value in enabled_values)
 
 
-def test_prepare_progress_auto_emits_live_output(
+def test_prepare_show_progress_true_emits_live_output(
     con, canonical_data, tmp_path, monkeypatch
 ):
     enabled_values: list[bool] = []
@@ -423,7 +423,7 @@ def test_prepare_progress_auto_emits_live_output(
         output_folder=tmp_path / "prepared",
         con=con,
         overwrite=True,
-        progress="auto",
+        show_progress="auto",
     )
 
     assert enabled_values
@@ -439,7 +439,7 @@ def test_prepare_logs_sparse_info_and_debug_progress(
             output_folder=tmp_path / "prepared",
             con=con,
             overwrite=True,
-            progress="auto",
+            show_progress=True,
         )
 
     info_messages = [
@@ -640,19 +640,19 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "derive_term_frequencies_table",
-        lambda data, con, num_of_chunks, progress="auto": tf_relation,
+        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, progress="auto": (
+        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
             clean_relation
         ),
     )
     monkeypatch.setattr(
         chunking_strategies,
         "derive_inverted_index",
-        lambda df_clean, con, num_of_chunks, progress="auto": inverted_relation,
+        lambda df_clean, con, num_of_chunks, show_progress=True: inverted_relation,
     )
 
     prepare_canonical_folder(
@@ -716,19 +716,19 @@ def test_prepare_remote_output_writes_chunked_paths(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "derive_term_frequencies_table",
-        lambda data, con, num_of_chunks, progress="auto": tf_relation,
+        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, progress="auto": (
+        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
             clean_relation
         ),
     )
     monkeypatch.setattr(
         chunking_strategies,
         "derive_inverted_index",
-        lambda df_clean, con, num_of_chunks, progress="auto": inverted_relation,
+        lambda df_clean, con, num_of_chunks, show_progress=True: inverted_relation,
     )
 
     prepare_canonical_folder(

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -11,8 +11,8 @@ import pytest
 
 from uk_address_matcher import prepare_canonical_folder
 from uk_address_matcher.cleaning import chunking_strategies
-from uk_address_matcher.helpers import progress as progress_helpers
-from uk_address_matcher.helpers.progress import _ProgressBar
+from uk_address_matcher.logging import progress as progress_helpers
+from uk_address_matcher.logging.progress import _ProgressBar
 from uk_address_matcher.prepare_canonical import (
     MAX_CHUNK_COUNT,
     _coerce_prepare_input_to_relation,
@@ -148,13 +148,14 @@ def test_progress_bar_caps_progress_at_total():
     assert f"▕{'▮' * 24}▏" in stream.getvalue()
 
 
-def test_progress_bar_defaults_to_enabled():
+def test_progress_bar_disables_live_output_for_non_tty_stream():
     stream = _FakeStream(isatty_value=False)
     progress = _ProgressBar(label="Testing", total=10, stream=stream)
 
     progress.update(5)
 
-    assert stream.getvalue()
+    assert progress.enabled is False
+    assert stream.getvalue() == ""
 
 
 def test_progress_bar_disables_itself_when_stream_cannot_render():
@@ -272,7 +273,7 @@ def test_prepare_can_create_chunked_canonical_output(con, canonical_data, tmp_pa
     assert not (tmp_path / "ukam_canonical_addresses.parquet").exists()
 
 
-def test_prepare_show_progress_false_suppresses_live_output(
+def test_prepare_progress_off_suppresses_live_output(
     con, canonical_data, tmp_path, monkeypatch
 ):
     stream = _FakeStream(isatty_value=True)
@@ -283,13 +284,68 @@ def test_prepare_show_progress_false_suppresses_live_output(
         output_folder=tmp_path / "prepared",
         con=con,
         overwrite=True,
-        show_progress=False,
+        progress="off",
     )
 
     assert stream.getvalue() == ""
 
 
-def test_prepare_default_show_progress_enables_live_output(
+def test_prepare_progress_stages_logs_boundaries_without_chunk_updates(
+    con, canonical_data, tmp_path, monkeypatch, caplog
+):
+    stream = _FakeStream(isatty_value=True)
+    monkeypatch.setattr(progress_helpers.sys, "stderr", stream)
+
+    with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
+        prepare_canonical_folder(
+            canonical_data,
+            output_folder=tmp_path / "prepared",
+            con=con,
+            overwrite=True,
+            progress="stages",
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+
+    assert any(message.startswith("Cleaning for TF derivation:") for message in messages)
+    assert any(
+        message.startswith("Cleaning for TF derivation completed:")
+        for message in messages
+    )
+    assert not any("chunk 1/" in message for message in messages)
+    assert stream.getvalue() == ""
+
+
+def test_prepare_progress_off_suppresses_stage_status_logs(
+    con, canonical_data, tmp_path, caplog
+):
+    with caplog.at_level(logging.DEBUG, logger="uk_address_matcher"):
+        prepare_canonical_folder(
+            canonical_data,
+            output_folder=tmp_path / "prepared",
+            con=con,
+            overwrite=True,
+            progress="off",
+        )
+
+    stage_prefixes = (
+        "Cleaning for TF derivation",
+        "Cleaning and preprocessing",
+        "Applying term frequencies",
+        "Building inverted index",
+    )
+    assert not any(
+        record.getMessage().startswith(stage_prefix)
+        and (
+            " records across " in record.getMessage()
+            or " completed:" in record.getMessage()
+        )
+        for record in caplog.records
+        for stage_prefix in stage_prefixes
+    )
+
+
+def test_prepare_default_progress_enables_live_output(
     con, canonical_data, tmp_path, monkeypatch
 ):
     enabled_values: list[bool] = []
@@ -331,7 +387,7 @@ def test_prepare_default_show_progress_enables_live_output(
     assert all(value is True for value in enabled_values)
 
 
-def test_prepare_show_progress_true_emits_live_output(
+def test_prepare_progress_auto_emits_live_output(
     con, canonical_data, tmp_path, monkeypatch
 ):
     enabled_values: list[bool] = []
@@ -367,7 +423,7 @@ def test_prepare_show_progress_true_emits_live_output(
         output_folder=tmp_path / "prepared",
         con=con,
         overwrite=True,
-        show_progress=True,
+        progress="auto",
     )
 
     assert enabled_values
@@ -383,7 +439,7 @@ def test_prepare_logs_sparse_info_and_debug_progress(
             output_folder=tmp_path / "prepared",
             con=con,
             overwrite=True,
-            show_progress=False,
+            progress="auto",
         )
 
     info_messages = [
@@ -584,19 +640,19 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "derive_term_frequencies_table",
-        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
+        lambda data, con, num_of_chunks, progress="auto": tf_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
+        lambda data, con, num_of_chunks, term_frequency_lookup, progress="auto": (
             clean_relation
         ),
     )
     monkeypatch.setattr(
         chunking_strategies,
         "derive_inverted_index",
-        lambda df_clean, con, num_of_chunks, show_progress=True: inverted_relation,
+        lambda df_clean, con, num_of_chunks, progress="auto": inverted_relation,
     )
 
     prepare_canonical_folder(
@@ -660,19 +716,19 @@ def test_prepare_remote_output_writes_chunked_paths(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "derive_term_frequencies_table",
-        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
+        lambda data, con, num_of_chunks, progress="auto": tf_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
+        lambda data, con, num_of_chunks, term_frequency_lookup, progress="auto": (
             clean_relation
         ),
     )
     monkeypatch.setattr(
         chunking_strategies,
         "derive_inverted_index",
-        lambda df_clean, con, num_of_chunks, show_progress=True: inverted_relation,
+        lambda df_clean, con, num_of_chunks, progress="auto": inverted_relation,
     )
 
     prepare_canonical_folder(

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -2,11 +2,47 @@ from __future__ import annotations
 
 from io import StringIO
 
-from uk_address_matcher.helpers.progress import _ProgressBar
+import pytest
+
+from uk_address_matcher.logging.progress import _ProgressBar, resolve_progress_mode
+
+
+class _TtyStringIO(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def test_progress_bar_does_not_render_to_non_tty_stream() -> None:
+    progress = _ProgressBar(label="Stage", total=10, stream=StringIO())
+
+    progress.update(5, completed_units=1)
+
+    assert progress.enabled is False
+
+
+def test_progress_bar_does_not_render_in_databricks_runtime(monkeypatch) -> None:
+    stream = _TtyStringIO()
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "16.4")
+    progress = _ProgressBar(label="Stage", total=10, stream=stream)
+
+    progress.update(5, completed_units=1)
+
+    assert progress.enabled is False
+    assert stream.getvalue() == ""
+
+
+@pytest.mark.parametrize("progress", ["auto", "stages", "off"])
+def test_resolve_progress_mode_accepts_supported_values(progress: str) -> None:
+    assert resolve_progress_mode(progress) == progress
+
+
+def test_resolve_progress_mode_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="progress must be one of"):
+        resolve_progress_mode("verbose")
 
 
 def test_progress_bar_ensure_line_break_flushes_active_render() -> None:
-    stream = StringIO()
+    stream = _TtyStringIO()
     progress = _ProgressBar(label="Stage", total=10, stream=stream)
 
     progress.update(5, completed_units=1)
@@ -17,7 +53,7 @@ def test_progress_bar_ensure_line_break_flushes_active_render() -> None:
 
 
 def test_progress_bar_close_does_not_duplicate_newline_after_line_break() -> None:
-    stream = StringIO()
+    stream = _TtyStringIO()
     progress = _ProgressBar(label="Stage", total=10, stream=stream)
 
     progress.update(5, completed_units=1)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -31,13 +31,19 @@ def test_progress_bar_does_not_render_in_databricks_runtime(monkeypatch) -> None
     assert stream.getvalue() == ""
 
 
-@pytest.mark.parametrize("progress", ["auto", "stages", "off"])
-def test_resolve_progress_mode_accepts_supported_values(progress: str) -> None:
-    assert resolve_progress_mode(progress) == progress
+@pytest.mark.parametrize(
+    ("show_progress", "expected_mode"),
+    [(True, "auto"), (False, "off"), ("auto", "auto"), ("stages", "stages")],
+)
+def test_resolve_progress_mode_accepts_boolean_and_named_values(
+    show_progress: bool | str,
+    expected_mode: str,
+) -> None:
+    assert resolve_progress_mode(show_progress) == expected_mode
 
 
 def test_resolve_progress_mode_rejects_unknown_value() -> None:
-    with pytest.raises(ValueError, match="progress must be one of"):
+    with pytest.raises(ValueError, match="show_progress must be a boolean"):
         resolve_progress_mode("verbose")
 
 

--- a/uk_address_matcher/address_matcher.py
+++ b/uk_address_matcher/address_matcher.py
@@ -16,7 +16,7 @@ from uk_address_matcher.linking_model.address_record import AddressRecord
 from uk_address_matcher.linking_model.matching.runner import _run_matching
 from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
 from uk_address_matcher.linking_model.matching.stages.splink import SplinkStage
-from uk_address_matcher.logging.progress import ProgressMode, resolve_progress_mode
+from uk_address_matcher.logging.progress import ShowProgress, resolve_progress_mode
 from uk_address_matcher.post_linkage.match_result import MatchResult
 from uk_address_matcher.prepare_canonical import load_prepared_canonical_data
 from uk_address_matcher.sql_pipeline.helpers import (
@@ -70,9 +70,10 @@ class AddressMatcher:
         cleaning_num_chunks: Number of chunks to use for cleaning and term
             frequency derivation when canonical input is a raw relation. Also
             used for messy-address cleaning. Must be a positive integer.
-        progress: Progress output mode. ``"auto"`` renders live updates only
-            in a supported interactive terminal and otherwise logs stage
-            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+        show_progress: ``True`` uses automatic live progress when supported;
+            ``False`` suppresses progress output. ``"auto"`` renders live
+            updates only in a supported interactive terminal and otherwise logs
+            stage boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
             suppresses progress output.
         debug_options: Optional `DebugOptions` to control debug output and logging.
 
@@ -135,12 +136,12 @@ class AddressMatcher:
         stages: Optional[list[MatchingStage]] = None,
         debug_options: Optional[DebugOptions] = None,
         cleaning_num_chunks: int = 10,
-        progress: ProgressMode = "auto",
+        show_progress: ShowProgress = True,
     ):
         self.con = con
         self.stages = stages if stages is not None else _default_stages()
         self.debug_options = debug_options
-        self.progress = resolve_progress_mode(progress)
+        self.show_progress = resolve_progress_mode(show_progress)
         self.canonical_address_filter = canonical_address_filter
         if not isinstance(cleaning_num_chunks, int):
             raise TypeError("cleaning_num_chunks must be an integer.")
@@ -238,7 +239,7 @@ class AddressMatcher:
                 con=self.con,
                 num_of_chunks=self.cleaning_num_chunks,
                 debug_options=self.debug_options,
-                progress=self.progress,
+                show_progress=self.show_progress,
             )
 
             logger.debug("Cleaning canonical data")
@@ -249,7 +250,7 @@ class AddressMatcher:
                 term_frequency_lookup=self._tf_table,
                 dataset_role="canonical",
                 debug_options=self.debug_options,
-                progress=self.progress,
+                show_progress=self.show_progress,
             )
 
             logger.debug("Building inverted index from canonical data")
@@ -257,7 +258,7 @@ class AddressMatcher:
                 self._canonical_clean,
                 con=self.con,
                 debug_options=self.debug_options,
-                progress=self.progress,
+                show_progress=self.show_progress,
             )
             self._register_inverted_index(inverted_index)
 
@@ -278,7 +279,7 @@ class AddressMatcher:
             inverted_index_n=inverted_index_n,
             dataset_role="messy",
             debug_options=self.debug_options,
-            progress=self.progress,
+            show_progress=self.show_progress,
         )
 
     def _coerce_addresses_to_match(

--- a/uk_address_matcher/address_matcher.py
+++ b/uk_address_matcher/address_matcher.py
@@ -16,6 +16,7 @@ from uk_address_matcher.linking_model.address_record import AddressRecord
 from uk_address_matcher.linking_model.matching.runner import _run_matching
 from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
 from uk_address_matcher.linking_model.matching.stages.splink import SplinkStage
+from uk_address_matcher.logging.progress import ProgressMode, resolve_progress_mode
 from uk_address_matcher.post_linkage.match_result import MatchResult
 from uk_address_matcher.prepare_canonical import load_prepared_canonical_data
 from uk_address_matcher.sql_pipeline.helpers import (
@@ -69,6 +70,10 @@ class AddressMatcher:
         cleaning_num_chunks: Number of chunks to use for cleaning and term
             frequency derivation when canonical input is a raw relation. Also
             used for messy-address cleaning. Must be a positive integer.
+        progress: Progress output mode. ``"auto"`` renders live updates only
+            in a supported interactive terminal and otherwise logs stage
+            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+            suppresses progress output.
         debug_options: Optional `DebugOptions` to control debug output and logging.
 
     Examples:
@@ -130,10 +135,12 @@ class AddressMatcher:
         stages: Optional[list[MatchingStage]] = None,
         debug_options: Optional[DebugOptions] = None,
         cleaning_num_chunks: int = 10,
+        progress: ProgressMode = "auto",
     ):
         self.con = con
         self.stages = stages if stages is not None else _default_stages()
         self.debug_options = debug_options
+        self.progress = resolve_progress_mode(progress)
         self.canonical_address_filter = canonical_address_filter
         if not isinstance(cleaning_num_chunks, int):
             raise TypeError("cleaning_num_chunks must be an integer.")
@@ -231,6 +238,7 @@ class AddressMatcher:
                 con=self.con,
                 num_of_chunks=self.cleaning_num_chunks,
                 debug_options=self.debug_options,
+                progress=self.progress,
             )
 
             logger.debug("Cleaning canonical data")
@@ -241,6 +249,7 @@ class AddressMatcher:
                 term_frequency_lookup=self._tf_table,
                 dataset_role="canonical",
                 debug_options=self.debug_options,
+                progress=self.progress,
             )
 
             logger.debug("Building inverted index from canonical data")
@@ -248,6 +257,7 @@ class AddressMatcher:
                 self._canonical_clean,
                 con=self.con,
                 debug_options=self.debug_options,
+                progress=self.progress,
             )
             self._register_inverted_index(inverted_index)
 
@@ -268,6 +278,7 @@ class AddressMatcher:
             inverted_index_n=inverted_index_n,
             dataset_role="messy",
             debug_options=self.debug_options,
+            progress=self.progress,
         )
 
     def _coerce_addresses_to_match(

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import time
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -22,7 +21,16 @@ from uk_address_matcher.cleaning.steps.inverted_index import (
     _build_inverted_index_from_keys,
     _derive_keys_for_strategy,
 )
-from uk_address_matcher.helpers.progress import _ProgressBar
+from uk_address_matcher.logging.chunking import (
+    log_chunk_progress,
+    log_stage_complete,
+    log_stage_start,
+)
+from uk_address_matcher.logging.progress import (
+    ProgressMode,
+    _ProgressBar,
+    resolve_progress_mode,
+)
 from uk_address_matcher.sql_pipeline.helpers import (
     _drop_table_and_registered_aliases,
     _uid,
@@ -31,8 +39,6 @@ from uk_address_matcher.sql_pipeline.runner import create_sql_pipeline
 
 if TYPE_CHECKING:
     from uk_address_matcher.sql_pipeline.runner import DebugOptions
-
-logger = logging.getLogger("uk_address_matcher")
 
 
 def _materialise_relation(
@@ -76,75 +82,6 @@ def _drop_tables_with_prefix(con: DuckDBPyConnection, prefix: str) -> None:
             _drop_table_and_registered_aliases(con, table_name)
 
 
-def _format_elapsed(elapsed_seconds: float) -> str:
-    total_seconds = int(round(max(0.0, elapsed_seconds)))
-    minutes, seconds = divmod(total_seconds, 60)
-    return f"{minutes}m {seconds:02d}s"
-
-
-def _format_elapsed_brief(elapsed_seconds: float) -> str:
-    total_seconds = int(round(max(0.0, elapsed_seconds)))
-    if total_seconds < 60:
-        return f"{total_seconds}s"
-    return _format_elapsed(elapsed_seconds)
-
-
-def _log_stage_start(stage_label: str, total_records: int, total_chunks: int) -> None:
-    logger.info(
-        "%s: %s records across %s chunk%s",
-        stage_label,
-        f"{total_records:,}",
-        total_chunks,
-        "" if total_chunks == 1 else "s",
-    )
-
-
-def _log_stage_complete(
-    stage_label: str,
-    total_records: int,
-    elapsed_seconds: float,
-) -> None:
-    logger.info(
-        "%s completed: %s records in %s",
-        stage_label,
-        f"{total_records:,}",
-        _format_elapsed_brief(elapsed_seconds),
-    )
-
-
-def _log_progress(
-    total_records: int,
-    processed_records: int,
-    stage_label: str,
-    *,
-    progress: _ProgressBar | None = None,
-    chunk_index: int | None = None,
-    total_chunks: int | None = None,
-    chunk_elapsed_seconds: float | None = None,
-) -> None:
-    if progress is not None:
-        ensure_line_break = getattr(progress, "ensure_line_break", None)
-        if callable(ensure_line_break):
-            ensure_line_break()
-
-    chunk_position = "?/?"
-    if chunk_index is not None and total_chunks is not None:
-        chunk_position = f"{chunk_index + 1}/{total_chunks}"
-
-    elapsed_suffix = ""
-    if chunk_elapsed_seconds is not None:
-        elapsed_suffix = f", elapsed={_format_elapsed_brief(chunk_elapsed_seconds)}"
-
-    logger.debug(
-        "%s: chunk %s, %s/%s records%s",
-        stage_label,
-        chunk_position,
-        f"{processed_records:,}",
-        f"{total_records:,}",
-        elapsed_suffix,
-    )
-
-
 def _calculate_chunk_size(total_records: int, num_of_chunks: int) -> int:
     if total_records <= 0:
         raise ValueError(
@@ -164,7 +101,7 @@ def clean_data_pre_term_frequencies(
     num_of_chunks: int = 10,
     *,
     debug_options: Optional[DebugOptions] = None,
-    show_progress: bool = True,
+    progress: ProgressMode = "auto",
 ) -> DuckDBPyRelation:
     """Clean address data with foundational steps only (no term frequencies).
 
@@ -184,6 +121,7 @@ def clean_data_pre_term_frequencies(
     Returns:
         Cleaned address data without term frequencies, materialised as a relation.
     """
+    progress_mode = resolve_progress_mode(progress)
     uid = _uid()
     input_name = f"__ukam_input_addresses_{uid}"
     con.register(input_name, address_table)
@@ -199,13 +137,18 @@ def clean_data_pre_term_frequencies(
         label=stage_label,
         total=total_rows,
         total_units=total_chunks,
-        enabled=show_progress,
+        enabled=progress_mode == "auto",
     )
 
     con.execute(f"DROP TABLE IF EXISTS __ukam_chunked_addresses_{uid}")
 
     stage_started_at = time.perf_counter()
-    _log_stage_start(stage_label, total_rows, total_chunks)
+    log_stage_start(
+        stage_label,
+        total_rows,
+        total_chunks,
+        progress_mode=progress_mode,
+    )
 
     try:
         for chunk_index in range(total_chunks):
@@ -244,10 +187,11 @@ def clean_data_pre_term_frequencies(
                 completed_units=chunk_index + 1,
             )
 
-            _log_progress(
+            log_chunk_progress(
                 total_rows,
                 processed_records,
                 stage_label=stage_label,
+                progress_mode=progress_mode,
                 progress=progress,
                 chunk_index=chunk_index,
                 total_chunks=total_chunks,
@@ -258,7 +202,12 @@ def clean_data_pre_term_frequencies(
     finally:
         progress.close()
 
-    _log_stage_complete(stage_label, total_rows, time.perf_counter() - stage_started_at)
+    log_stage_complete(
+        stage_label,
+        total_rows,
+        time.perf_counter() - stage_started_at,
+        progress_mode=progress_mode,
+    )
 
     _drop_table_and_registered_aliases(con, input_name)
     _drop_tables_with_prefix(con, f"__ukam_chunk_input_{uid}_")
@@ -272,7 +221,7 @@ def derive_term_frequencies_table(
     num_of_chunks: int = 10,
     *,
     debug_options: Optional["DebugOptions"] = None,
-    show_progress: bool = True,
+    progress: ProgressMode = "auto",
 ) -> DuckDBPyRelation:
     """Derive a term frequency lookup table from address data.
 
@@ -300,10 +249,15 @@ def derive_term_frequencies_table(
         num_of_chunks: Number of chunks to split the data into for cleaning.
             Set to 1 for no chunking.
         debug_options: Optional debug configuration for pipeline execution.
+        progress: Progress output mode. ``"auto"`` renders live updates only
+            in a supported interactive terminal and otherwise logs stage
+            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+            suppresses progress output.
 
     Returns:
         Term frequency table with 'token' and 'rel_freq' columns.
     """
+    progress_mode = resolve_progress_mode(progress)
     uid = _uid()
 
     # Ensure postcode column exists
@@ -323,7 +277,7 @@ def derive_term_frequencies_table(
         label=stage_label,
         total=total_rows,
         total_units=total_chunks,
-        enabled=show_progress,
+        enabled=progress_mode == "auto",
     )
 
     cleaned_table = f"__ukam_tf_derive_cleaned_{uid}"
@@ -331,7 +285,12 @@ def derive_term_frequencies_table(
 
     # Process in chunks using minimal pipeline (clean + tokenise only)
     stage_started_at = time.perf_counter()
-    _log_stage_start(stage_label, total_rows, total_chunks)
+    log_stage_start(
+        stage_label,
+        total_rows,
+        total_chunks,
+        progress_mode=progress_mode,
+    )
 
     try:
         for chunk_index in range(total_chunks):
@@ -373,10 +332,11 @@ def derive_term_frequencies_table(
                 completed_units=chunk_index + 1,
             )
 
-            _log_progress(
+            log_chunk_progress(
                 total_rows,
                 processed_records,
                 stage_label=stage_label,
+                progress_mode=progress_mode,
                 progress=progress,
                 chunk_index=chunk_index,
                 total_chunks=total_chunks,
@@ -387,7 +347,12 @@ def derive_term_frequencies_table(
     finally:
         progress.close()
 
-    _log_stage_complete(stage_label, total_rows, time.perf_counter() - stage_started_at)
+    log_stage_complete(
+        stage_label,
+        total_rows,
+        time.perf_counter() - stage_started_at,
+        progress_mode=progress_mode,
+    )
 
     # Compute token frequencies from clean_full_address tokens
     tf_sql = f"""
@@ -423,7 +388,7 @@ def derive_inverted_index(
     strategies: list[IndexingStrategy] | None = None,
     *,
     debug_options: Optional["DebugOptions"] = None,
-    show_progress: bool = True,
+    progress: ProgressMode = "auto",
 ) -> DuckDBPyRelation:
     """Derive an inverted index from already-cleaned canonical data.
 
@@ -460,11 +425,17 @@ def derive_inverted_index(
         strategies: List of :class:`IndexingStrategy` instances.  Defaults
             to :data:`DEFAULT_INDEXING_STRATEGIES` (trigram + bigram).
         debug_options: Optional debug configuration for pipeline execution.
+        progress: Progress output mode. ``"auto"`` renders live updates only
+            in a supported interactive terminal and otherwise logs stage
+            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+            suppresses progress output.
 
     Returns:
         Inverted index table with ``key`` (VARCHAR), ``unique_ids`` (LIST),
         and ``index_strategy`` (VARCHAR) columns.
     """
+    progress_mode = resolve_progress_mode(progress)
+
     if strategies is None:
         strategies = DEFAULT_INDEXING_STRATEGIES
 
@@ -481,7 +452,12 @@ def derive_inverted_index(
         stage_label = f"Building inverted index ({strategy.name})"
         if num_of_chunks == 1:
             stage_started_at = time.perf_counter()
-            _log_stage_start(stage_label, total_rows, 1)
+            log_stage_start(
+                stage_label,
+                total_rows,
+                1,
+                progress_mode=progress_mode,
+            )
             # Single-pass for this strategy
             pipeline = create_sql_pipeline(
                 con,
@@ -502,18 +478,20 @@ def derive_inverted_index(
                 first_insert = False
             else:
                 chunk_result.insert_into(result_table)
-            _log_progress(
+            log_chunk_progress(
                 total_rows,
                 total_rows,
                 stage_label=stage_label,
+                progress_mode=progress_mode,
                 chunk_index=0,
                 total_chunks=1,
                 chunk_elapsed_seconds=time.perf_counter() - stage_started_at,
             )
-            _log_stage_complete(
+            log_stage_complete(
                 stage_label,
                 total_rows,
                 time.perf_counter() - stage_started_at,
+                progress_mode=progress_mode,
             )
         else:
             # Chunked path for this strategy
@@ -522,9 +500,14 @@ def derive_inverted_index(
                 label=stage_label,
                 total=total_rows,
                 total_units=num_of_chunks,
-                enabled=show_progress,
+                enabled=progress_mode == "auto",
             )
-            _log_stage_start(stage_label, total_rows, num_of_chunks)
+            log_stage_start(
+                stage_label,
+                total_rows,
+                num_of_chunks,
+                progress_mode=progress_mode,
+            )
             try:
                 for chunk_index in range(num_of_chunks):
                     chunk_started_at = time.perf_counter()
@@ -566,10 +549,11 @@ def derive_inverted_index(
                         processed_records,
                         completed_units=chunk_index + 1,
                     )
-                    _log_progress(
+                    log_chunk_progress(
                         total_rows,
                         processed_records,
                         stage_label=stage_label,
+                        progress_mode=progress_mode,
                         progress=progress,
                         chunk_index=chunk_index,
                         total_chunks=num_of_chunks,
@@ -578,10 +562,11 @@ def derive_inverted_index(
             finally:
                 progress.close()
 
-            _log_stage_complete(
+            log_stage_complete(
                 stage_label,
                 total_rows,
                 time.perf_counter() - stage_started_at,
+                progress_mode=progress_mode,
             )
 
     return con.table(result_table)
@@ -603,7 +588,7 @@ def prepare_data_for_matching(
     *,
     dataset_role: Literal["messy", "canonical"] | None = None,
     debug_options: Optional[DebugOptions] = None,
-    show_progress: bool = True,
+    progress: ProgressMode = "auto",
 ) -> DuckDBPyRelation:
     """Prepare address data for matching.
 
@@ -631,6 +616,10 @@ def prepare_data_for_matching(
         debug_options: Optional debug configuration for pipeline execution.
             Note: Debug options are only applied on the first iteration to avoid
             excessive logging output.
+        progress: Progress output mode. ``"auto"`` renders live updates only
+            in a supported interactive terminal and otherwise logs stage
+            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+            suppresses progress output.
 
     Returns:
         Cleaned address data with computed term frequencies, including numeric
@@ -659,6 +648,7 @@ def prepare_data_for_matching(
         # Using pre-baked term frequencies (default):
         df_prepared = prepare_data_for_matching(df_addresses, con)
     """
+    progress_mode = resolve_progress_mode(progress)
     uid = _uid()
 
     # Clean data in chunks (without term frequencies)
@@ -667,7 +657,7 @@ def prepare_data_for_matching(
         con,
         num_of_chunks=num_of_chunks,
         debug_options=debug_options,
-        show_progress=show_progress,
+        progress=progress_mode,
     )
 
     total_rows = cleaned_address_table.count("*").fetchone()[0]
@@ -692,7 +682,7 @@ def prepare_data_for_matching(
         label=stage_label,
         total=total_rows,
         total_units=total_chunks,
-        enabled=show_progress,
+        enabled=progress_mode == "auto",
     )
 
     # Get the underlying table name for direct access
@@ -709,7 +699,12 @@ def prepare_data_for_matching(
 
     # Apply term frequencies and trigram blocking to cleaned chunks
     stage_started_at = time.perf_counter()
-    _log_stage_start(stage_label, total_rows, total_chunks)
+    log_stage_start(
+        stage_label,
+        total_rows,
+        total_chunks,
+        progress_mode=progress_mode,
+    )
     try:
         for chunk_index in range(total_chunks):
             chunk_started_at = time.perf_counter()
@@ -754,10 +749,11 @@ def prepare_data_for_matching(
                 processed_records,
                 completed_units=chunk_index + 1,
             )
-            _log_progress(
+            log_chunk_progress(
                 total_rows,
                 processed_records,
                 stage_label=stage_label,
+                progress_mode=progress_mode,
                 progress=progress,
                 chunk_index=chunk_index,
                 total_chunks=total_chunks,
@@ -768,7 +764,12 @@ def prepare_data_for_matching(
     finally:
         progress.close()
 
-    _log_stage_complete(stage_label, total_rows, time.perf_counter() - stage_started_at)
+    log_stage_complete(
+        stage_label,
+        total_rows,
+        time.perf_counter() - stage_started_at,
+        progress_mode=progress_mode,
+    )
 
     # Verify the intermediate table is now empty (all chunks processed)
     remaining_rows = con.sql(f"SELECT COUNT(*) FROM {cleaned_table_name}").fetchone()[0]

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -27,7 +27,7 @@ from uk_address_matcher.logging.chunking import (
     log_stage_start,
 )
 from uk_address_matcher.logging.progress import (
-    ProgressMode,
+    ShowProgress,
     _ProgressBar,
     resolve_progress_mode,
 )
@@ -101,7 +101,7 @@ def clean_data_pre_term_frequencies(
     num_of_chunks: int = 10,
     *,
     debug_options: Optional[DebugOptions] = None,
-    progress: ProgressMode = "auto",
+    show_progress: ShowProgress = True,
 ) -> DuckDBPyRelation:
     """Clean address data with foundational steps only (no term frequencies).
 
@@ -121,7 +121,7 @@ def clean_data_pre_term_frequencies(
     Returns:
         Cleaned address data without term frequencies, materialised as a relation.
     """
-    progress_mode = resolve_progress_mode(progress)
+    progress_mode = resolve_progress_mode(show_progress)
     uid = _uid()
     input_name = f"__ukam_input_addresses_{uid}"
     con.register(input_name, address_table)
@@ -221,7 +221,7 @@ def derive_term_frequencies_table(
     num_of_chunks: int = 10,
     *,
     debug_options: Optional["DebugOptions"] = None,
-    progress: ProgressMode = "auto",
+    show_progress: ShowProgress = True,
 ) -> DuckDBPyRelation:
     """Derive a term frequency lookup table from address data.
 
@@ -249,15 +249,16 @@ def derive_term_frequencies_table(
         num_of_chunks: Number of chunks to split the data into for cleaning.
             Set to 1 for no chunking.
         debug_options: Optional debug configuration for pipeline execution.
-        progress: Progress output mode. ``"auto"`` renders live updates only
-            in a supported interactive terminal and otherwise logs stage
-            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+        show_progress: ``True`` uses automatic live progress when supported;
+            ``False`` suppresses progress output. ``"auto"`` renders live
+            updates only in a supported interactive terminal and otherwise logs
+            stage boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
             suppresses progress output.
 
     Returns:
         Term frequency table with 'token' and 'rel_freq' columns.
     """
-    progress_mode = resolve_progress_mode(progress)
+    progress_mode = resolve_progress_mode(show_progress)
     uid = _uid()
 
     # Ensure postcode column exists
@@ -388,7 +389,7 @@ def derive_inverted_index(
     strategies: list[IndexingStrategy] | None = None,
     *,
     debug_options: Optional["DebugOptions"] = None,
-    progress: ProgressMode = "auto",
+    show_progress: ShowProgress = True,
 ) -> DuckDBPyRelation:
     """Derive an inverted index from already-cleaned canonical data.
 
@@ -425,16 +426,17 @@ def derive_inverted_index(
         strategies: List of :class:`IndexingStrategy` instances.  Defaults
             to :data:`DEFAULT_INDEXING_STRATEGIES` (trigram + bigram).
         debug_options: Optional debug configuration for pipeline execution.
-        progress: Progress output mode. ``"auto"`` renders live updates only
-            in a supported interactive terminal and otherwise logs stage
-            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+        show_progress: ``True`` uses automatic live progress when supported;
+            ``False`` suppresses progress output. ``"auto"`` renders live
+            updates only in a supported interactive terminal and otherwise logs
+            stage boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
             suppresses progress output.
 
     Returns:
         Inverted index table with ``key`` (VARCHAR), ``unique_ids`` (LIST),
         and ``index_strategy`` (VARCHAR) columns.
     """
-    progress_mode = resolve_progress_mode(progress)
+    progress_mode = resolve_progress_mode(show_progress)
 
     if strategies is None:
         strategies = DEFAULT_INDEXING_STRATEGIES
@@ -588,7 +590,7 @@ def prepare_data_for_matching(
     *,
     dataset_role: Literal["messy", "canonical"] | None = None,
     debug_options: Optional[DebugOptions] = None,
-    progress: ProgressMode = "auto",
+    show_progress: ShowProgress = True,
 ) -> DuckDBPyRelation:
     """Prepare address data for matching.
 
@@ -616,9 +618,10 @@ def prepare_data_for_matching(
         debug_options: Optional debug configuration for pipeline execution.
             Note: Debug options are only applied on the first iteration to avoid
             excessive logging output.
-        progress: Progress output mode. ``"auto"`` renders live updates only
-            in a supported interactive terminal and otherwise logs stage
-            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+        show_progress: ``True`` uses automatic live progress when supported;
+            ``False`` suppresses progress output. ``"auto"`` renders live
+            updates only in a supported interactive terminal and otherwise logs
+            stage boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
             suppresses progress output.
 
     Returns:
@@ -648,7 +651,7 @@ def prepare_data_for_matching(
         # Using pre-baked term frequencies (default):
         df_prepared = prepare_data_for_matching(df_addresses, con)
     """
-    progress_mode = resolve_progress_mode(progress)
+    progress_mode = resolve_progress_mode(show_progress)
     uid = _uid()
 
     # Clean data in chunks (without term frequencies)
@@ -657,7 +660,7 @@ def prepare_data_for_matching(
         con,
         num_of_chunks=num_of_chunks,
         debug_options=debug_options,
-        progress=progress_mode,
+        show_progress=progress_mode,
     )
 
     total_rows = cleaned_address_table.count("*").fetchone()[0]

--- a/uk_address_matcher/logging/__init__.py
+++ b/uk_address_matcher/logging/__init__.py
@@ -1,0 +1,1 @@
+"""Package-specific logging and progress output helpers."""

--- a/uk_address_matcher/logging/chunking.py
+++ b/uk_address_matcher/logging/chunking.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+
+from uk_address_matcher.logging.progress import ProgressMode, _ProgressBar
+
+logger = logging.getLogger("uk_address_matcher")
+
+
+def _format_elapsed(elapsed_seconds: float) -> str:
+    total_seconds = int(round(max(0.0, elapsed_seconds)))
+    minutes, seconds = divmod(total_seconds, 60)
+    return f"{minutes}m {seconds:02d}s"
+
+
+def _format_elapsed_brief(elapsed_seconds: float) -> str:
+    total_seconds = int(round(max(0.0, elapsed_seconds)))
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+    return _format_elapsed(elapsed_seconds)
+
+
+def log_stage_start(
+    stage_label: str,
+    total_records: int,
+    total_chunks: int,
+    *,
+    progress_mode: ProgressMode,
+) -> None:
+    """Log the start of a chunked preparation stage."""
+    if progress_mode == "off":
+        return
+
+    logger.info(
+        "%s: %s records across %s chunk%s",
+        stage_label,
+        f"{total_records:,}",
+        total_chunks,
+        "" if total_chunks == 1 else "s",
+    )
+
+
+def log_stage_complete(
+    stage_label: str,
+    total_records: int,
+    elapsed_seconds: float,
+    *,
+    progress_mode: ProgressMode,
+) -> None:
+    """Log completion of a chunked preparation stage."""
+    if progress_mode == "off":
+        return
+
+    logger.info(
+        "%s completed: %s records in %s",
+        stage_label,
+        f"{total_records:,}",
+        _format_elapsed_brief(elapsed_seconds),
+    )
+
+
+def log_chunk_progress(
+    total_records: int,
+    processed_records: int,
+    stage_label: str,
+    *,
+    progress_mode: ProgressMode,
+    progress: _ProgressBar | None = None,
+    chunk_index: int | None = None,
+    total_chunks: int | None = None,
+    chunk_elapsed_seconds: float | None = None,
+) -> None:
+    """Log chunk progress and separate it from an active live display."""
+    if progress_mode != "auto":
+        return
+
+    if progress is not None:
+        ensure_line_break = getattr(progress, "ensure_line_break", None)
+        if callable(ensure_line_break):
+            ensure_line_break()
+
+    chunk_position = "?/?"
+    if chunk_index is not None and total_chunks is not None:
+        chunk_position = f"{chunk_index + 1}/{total_chunks}"
+
+    elapsed_suffix = ""
+    if chunk_elapsed_seconds is not None:
+        elapsed_suffix = f", elapsed={_format_elapsed_brief(chunk_elapsed_seconds)}"
+
+    logger.debug(
+        "%s: chunk %s, %s/%s records%s",
+        stage_label,
+        chunk_position,
+        f"{processed_records:,}",
+        f"{total_records:,}",
+        elapsed_suffix,
+    )

--- a/uk_address_matcher/logging/progress.py
+++ b/uk_address_matcher/logging/progress.py
@@ -6,6 +6,7 @@ import time
 from typing import Literal, TypeAlias, cast
 
 ProgressMode: TypeAlias = Literal["auto", "stages", "off"]
+ShowProgress: TypeAlias = bool | ProgressMode
 
 _PROGRESS_MODES = frozenset({"auto", "stages", "off"})
 _NOTEBOOK_ENVIRONMENT_VARIABLES = (
@@ -16,15 +17,21 @@ _NOTEBOOK_ENVIRONMENT_VARIABLES = (
 
 
 def resolve_progress_mode(
-    progress: str = "auto",
+    show_progress: ShowProgress = True,
 ) -> ProgressMode:
-    """Validate progress output configuration."""
-    if not isinstance(progress, str):
-        raise TypeError("progress must be one of: 'auto', 'stages', or 'off'.")
-    if progress not in _PROGRESS_MODES:
-        raise ValueError("progress must be one of: 'auto', 'stages', or 'off'.")
+    """Normalise boolean and named progress-output settings."""
+    if isinstance(show_progress, bool):
+        return "auto" if show_progress else "off"
+    if not isinstance(show_progress, str):
+        raise TypeError(
+            "show_progress must be a boolean or one of: 'auto', 'stages', or 'off'."
+        )
+    if show_progress not in _PROGRESS_MODES:
+        raise ValueError(
+            "show_progress must be a boolean or one of: 'auto', 'stages', or 'off'."
+        )
 
-    return cast(ProgressMode, progress)
+    return cast(ProgressMode, show_progress)
 
 
 def _is_notebook_environment() -> bool:

--- a/uk_address_matcher/logging/progress.py
+++ b/uk_address_matcher/logging/progress.py
@@ -17,19 +17,12 @@ _NOTEBOOK_ENVIRONMENT_VARIABLES = (
 
 def resolve_progress_mode(
     progress: str = "auto",
-    *,
-    show_progress: bool | None = None,
 ) -> ProgressMode:
-    """Validate progress output configuration and support the legacy alias."""
+    """Validate progress output configuration."""
     if not isinstance(progress, str):
         raise TypeError("progress must be one of: 'auto', 'stages', or 'off'.")
     if progress not in _PROGRESS_MODES:
         raise ValueError("progress must be one of: 'auto', 'stages', or 'off'.")
-
-    if show_progress is not None:
-        if not isinstance(show_progress, bool):
-            raise TypeError("show_progress must be a boolean or None.")
-        return "auto" if show_progress else "off"
 
     return cast(ProgressMode, progress)
 

--- a/uk_address_matcher/logging/progress.py
+++ b/uk_address_matcher/logging/progress.py
@@ -1,7 +1,68 @@
 from __future__ import annotations
 
+import os
 import sys
 import time
+from typing import Literal, TypeAlias, cast
+
+ProgressMode: TypeAlias = Literal["auto", "stages", "off"]
+
+_PROGRESS_MODES = frozenset({"auto", "stages", "off"})
+_NOTEBOOK_ENVIRONMENT_VARIABLES = (
+    "DATABRICKS_RUNTIME_VERSION",
+    "DATABRICKS_CLUSTER_ID",
+    "DATABRICKS_HOST",
+)
+
+
+def resolve_progress_mode(
+    progress: str = "auto",
+    *,
+    show_progress: bool | None = None,
+) -> ProgressMode:
+    """Validate progress output configuration and support the legacy alias."""
+    if not isinstance(progress, str):
+        raise TypeError("progress must be one of: 'auto', 'stages', or 'off'.")
+    if progress not in _PROGRESS_MODES:
+        raise ValueError("progress must be one of: 'auto', 'stages', or 'off'.")
+
+    if show_progress is not None:
+        if not isinstance(show_progress, bool):
+            raise TypeError("show_progress must be a boolean or None.")
+        return "auto" if show_progress else "off"
+
+    return cast(ProgressMode, progress)
+
+
+def _is_notebook_environment() -> bool:
+    """Return whether the current process is running in a notebook runtime."""
+    if any(os.environ.get(name) for name in _NOTEBOOK_ENVIRONMENT_VARIABLES):
+        return True
+
+    ipython = sys.modules.get("IPython")
+    get_ipython = getattr(ipython, "get_ipython", None)
+    if not callable(get_ipython):
+        return False
+
+    try:
+        shell = get_ipython()
+    except Exception:
+        return False
+
+    shell_module = getattr(shell.__class__, "__module__", "") if shell else ""
+    return shell_module.startswith(("ipykernel.", "google.colab."))
+
+
+def _supports_live_progress(stream: object) -> bool:
+    """Return whether a stream can safely render an overwriting progress bar."""
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty):
+        return False
+
+    try:
+        return bool(isatty()) and not _is_notebook_environment()
+    except (OSError, ValueError):
+        return False
 
 
 class _ProgressBar:
@@ -30,7 +91,7 @@ class _ProgressBar:
         self._filled_glyph = "▮"
         self._empty_glyph = "▯"
 
-        self.enabled = enabled
+        self.enabled = enabled and _supports_live_progress(self.stream)
         self._configure_glyphs()
 
     def _configure_glyphs(self) -> None:

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -24,7 +24,7 @@ from uk_address_matcher.helpers.path_parsing import (
     read_duckdb_relation_from_path,
     relative_remote_path,
 )
-from uk_address_matcher.logging.progress import ProgressMode, resolve_progress_mode
+from uk_address_matcher.logging.progress import ShowProgress, resolve_progress_mode
 from uk_address_matcher.sql_pipeline.helpers import _register_input_relation_once
 
 if TYPE_CHECKING:
@@ -430,7 +430,7 @@ def prepare_canonical_folder(
     num_of_chunks: int = 10,
     output_chunk_count: int = 1,
     overwrite: bool = False,
-    progress: ProgressMode = "auto",
+    show_progress: ShowProgress = True,
 ) -> None:
     """Prepare canonical data and persist to a folder for later use.
 
@@ -461,9 +461,10 @@ def prepare_canonical_folder(
         overwrite: Whether to overwrite existing files in the folder. When
             `True`, all known artefacts are removed before writing to ensure
             the folder ends up in a consistent state.
-        progress: Progress output mode. ``"auto"`` renders live updates only
-            in a supported interactive terminal and otherwise logs stage
-            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+        show_progress: ``True`` uses automatic live progress when supported;
+            ``False`` suppresses progress output. ``"auto"`` renders live
+            updates only in a supported interactive terminal and otherwise logs
+            stage boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
             suppresses progress output.
 
     Raises:
@@ -479,7 +480,7 @@ def prepare_canonical_folder(
     output_is_remote = is_remote_folder_reference(output_folder)
     output_folder_uri = str(output_folder) if output_is_remote else None
     output_folder_path = None if output_is_remote else Path(output_folder)
-    progress_mode = resolve_progress_mode(progress)
+    progress_mode = resolve_progress_mode(show_progress)
     data = _coerce_prepare_input_to_relation(data, con=con)
 
     logger.info("Preparing canonical data from '%s'", _describe_prepare_input(data))
@@ -518,7 +519,7 @@ def prepare_canonical_folder(
         data,
         con=con,
         num_of_chunks=num_of_chunks,
-        progress=progress_mode,
+        show_progress=progress_mode,
     )
 
     logger.debug("Cleaning canonical addresses")
@@ -527,7 +528,7 @@ def prepare_canonical_folder(
         con=con,
         num_of_chunks=num_of_chunks,
         term_frequency_lookup=tf_table,
-        progress=progress_mode,
+        show_progress=progress_mode,
     )
 
     logger.debug("Building inverted index")
@@ -535,7 +536,7 @@ def prepare_canonical_folder(
         df_clean,
         con=con,
         num_of_chunks=num_of_chunks,
-        progress=progress_mode,
+        show_progress=progress_mode,
     )
 
     # Write parquet files

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -24,6 +24,7 @@ from uk_address_matcher.helpers.path_parsing import (
     read_duckdb_relation_from_path,
     relative_remote_path,
 )
+from uk_address_matcher.logging.progress import ProgressMode, resolve_progress_mode
 from uk_address_matcher.sql_pipeline.helpers import _register_input_relation_once
 
 if TYPE_CHECKING:
@@ -429,7 +430,7 @@ def prepare_canonical_folder(
     num_of_chunks: int = 10,
     output_chunk_count: int = 1,
     overwrite: bool = False,
-    show_progress: bool = True,
+    progress: ProgressMode = "auto",
 ) -> None:
     """Prepare canonical data and persist to a folder for later use.
 
@@ -460,8 +461,10 @@ def prepare_canonical_folder(
         overwrite: Whether to overwrite existing files in the folder. When
             `True`, all known artefacts are removed before writing to ensure
             the folder ends up in a consistent state.
-        show_progress: Whether to show live interactive progress bars for
-            chunked cleaning stages.
+        progress: Progress output mode. ``"auto"`` renders live updates only
+            in a supported interactive terminal and otherwise logs stage
+            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
+            suppresses progress output.
 
     Raises:
         FileExistsError: If the output folder already contains prepared files
@@ -476,6 +479,7 @@ def prepare_canonical_folder(
     output_is_remote = is_remote_folder_reference(output_folder)
     output_folder_uri = str(output_folder) if output_is_remote else None
     output_folder_path = None if output_is_remote else Path(output_folder)
+    progress_mode = resolve_progress_mode(progress)
     data = _coerce_prepare_input_to_relation(data, con=con)
 
     logger.info("Preparing canonical data from '%s'", _describe_prepare_input(data))
@@ -514,7 +518,7 @@ def prepare_canonical_folder(
         data,
         con=con,
         num_of_chunks=num_of_chunks,
-        show_progress=show_progress,
+        progress=progress_mode,
     )
 
     logger.debug("Cleaning canonical addresses")
@@ -523,7 +527,7 @@ def prepare_canonical_folder(
         con=con,
         num_of_chunks=num_of_chunks,
         term_frequency_lookup=tf_table,
-        show_progress=show_progress,
+        progress=progress_mode,
     )
 
     logger.debug("Building inverted index")
@@ -531,7 +535,7 @@ def prepare_canonical_folder(
         df_clean,
         con=con,
         num_of_chunks=num_of_chunks,
-        show_progress=show_progress,
+        progress=progress_mode,
     )
 
     # Write parquet files


### PR DESCRIPTION
See discussion at:
- https://github.com/moj-analytical-services/uk_address_matcher/pull/440

These changes now provide a new `progress` argument to anywhere that we run cleaning that can be one of three values:
```
        progress: Progress output mode. ``"auto"`` renders live updates only
            in a supported interactive terminal and otherwise logs stage
            boundaries. ``"stages"`` logs only stage boundaries; ``"off"``
            suppresses progress output.
```

This lets users determine whether they want the more verbose logs, some trimmed logs showing start/end progress or switch off the core cleaning logs altogether. This allows users to decide how much log spam they want to see.