### PR TITLE
Local distinguishing tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+benchmarking/
+data/
 old_del/*
 .tmp
 try_*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-benchmarking/
-data/
 old_del/*
 .tmp
 try_*

--- a/tests/cleaning/test_cleaning_steps.py
+++ b/tests/cleaning/test_cleaning_steps.py
@@ -2,12 +2,14 @@ import logging
 
 import duckdb
 
+from uk_address_matcher.cleaning import chunking_strategies
 from uk_address_matcher.cleaning.chunking_strategies import prepare_data_for_matching
 from uk_address_matcher.cleaning.steps import (
     _parse_out_business_unit,
     _parse_out_flat_position_and_letter,
     _parse_out_sub_premise_location,
     _remove_duplicate_end_tokens,
+    _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records,
 )
 from uk_address_matcher.sql_pipeline.runner import DebugOptions, DuckDBPipeline
 
@@ -16,6 +18,138 @@ def _run_single_stage(stage_factory, input_relation, connection):
     pipeline = DuckDBPipeline(connection, input_relation)
     pipeline.add_step(stage_factory())
     return pipeline.run(DebugOptions(pretty_print_sql=False))
+
+
+def test_separate_distinguishing_tokens_uses_valid_local_neighbours():
+    connection = duckdb.connect()
+    input_relation = connection.sql(
+        """
+        SELECT * FROM (VALUES
+            (1, 'A1', 'FLAT A 1 HIGH STREET CAMDEN LONDON', 'preserved-a'),
+            (2, 'A2', '1 HIGH STREET CAMDEN LONDON', 'preserved-b'),
+            (3, 'B1', 'OLD STATION HOUSE RAINBOW LANE TAUNTON', 'preserved-c'),
+            (4, 'B2', 'NEW STATION RAINBOW LANE TAUNTON', 'preserved-d'),
+            (5, 'C1', '9 SOLO ROAD YORK', 'preserved-e')
+        ) AS t(ukam_address_id, unique_id, clean_full_address, source_marker)
+        """
+    )
+
+    result = _run_single_stage(
+        _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records,
+        input_relation,
+        connection,
+    )
+    assert result.columns.count("ukam_address_id") == 1
+    actual = {
+        unique_id: (distinguishing, common, source_marker)
+        for unique_id, distinguishing, common, source_marker in result.project(
+            """
+            unique_id,
+            distinguishing_adj_start_tokens,
+            common_adj_start_tokens,
+            source_marker
+            """
+        ).fetchall()
+    }
+
+    assert actual == {
+        "A1": (
+            ["FLAT", "A"],
+            ["1", "HIGH", "STREET", "CAMDEN", "LONDON"],
+            "preserved-a",
+        ),
+        "A2": ([], ["1", "HIGH", "STREET", "CAMDEN", "LONDON"], "preserved-b"),
+        "B1": (
+            ["OLD", "STATION", "HOUSE"],
+            ["RAINBOW", "LANE", "TAUNTON"],
+            "preserved-c",
+        ),
+        "B2": (
+            ["NEW", "STATION"],
+            ["RAINBOW", "LANE", "TAUNTON"],
+            "preserved-d",
+        ),
+        "C1": ([], ["9", "SOLO", "ROAD", "YORK"], "preserved-e"),
+    }
+
+
+def test_prepare_data_derives_distinguishing_tokens_across_cleaning_chunks(
+    monkeypatch,
+):
+    connection = duckdb.connect()
+    candidate_addresses = [
+        f"FLAT {letter} 1 HIGH STREET CAMDEN LONDON" for letter in ("A", "B", "C", "D")
+    ]
+    partitioned_addresses = connection.sql(
+        "SELECT address, abs(hash(address)) % 2 AS partition FROM (VALUES "
+        + ", ".join(f"('{address}')" for address in candidate_addresses)
+        + ") AS candidates(address)"
+    ).fetchall()
+    first_address = partitioned_addresses[0][0]
+    first_partition = partitioned_addresses[0][1]
+    second_address = next(
+        address
+        for address, partition in partitioned_addresses[1:]
+        if partition != first_partition
+    )
+    input_relation = connection.sql(
+        f"""
+        SELECT * FROM (VALUES
+            ('A1', '{first_address}', 'N1 1AA'),
+            ('A2', '{second_address}', 'N1 1AA')
+        ) AS t(unique_id, address_concat, postcode)
+        """
+    )
+
+    monkeypatch.setattr(
+        chunking_strategies,
+        "_calculate_chunk_size",
+        lambda total_records, num_of_chunks: 1,
+    )
+    result = prepare_data_for_matching(
+        input_relation,
+        con=connection,
+        num_of_chunks=2,
+        derive_distinguishing_wrt_adjacent_records=True,
+        dataset_role="canonical",
+        show_progress=False,
+    )
+
+    rows = result.project(
+        "unique_id, distinguishing_adj_start_tokens, common_adj_start_tokens"
+    ).fetchall()
+    assert len(rows) == 2
+    assert all(distinguishing for _, distinguishing, _ in rows)
+    assert all(
+        common == ["1", "HIGH", "STREET", "CAMDEN", "LONDON"] for _, _, common in rows
+    )
+
+
+def test_separate_distinguishing_tokens_skips_same_id_to_offset_three():
+    connection = duckdb.connect()
+    input_relation = connection.sql(
+        """
+        SELECT * FROM (VALUES
+            (1, 'U4', 'DELTA LANE TAUNTON'),
+            (2, 'U3', 'ALPHA RAINBOW LANE TAUNTON'),
+            (3, 'U3', 'ALPHB RAINBOW LANE TAUNTON'),
+            (4, 'U3', 'ALPHC RAINBOW LANE TAUNTON')
+        ) AS t(ukam_address_id, unique_id, clean_full_address)
+        """
+    )
+
+    result = _run_single_stage(
+        _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records,
+        input_relation,
+        connection,
+    )
+    target = (
+        result.filter("clean_full_address = 'ALPHC RAINBOW LANE TAUNTON'")
+        .project("distinguishing_adj_start_tokens, common_adj_start_tokens")
+        .fetchone()
+    )
+
+    assert target == (["ALPHC", "RAINBOW"], ["LANE", "TAUNTON"])
 
 
 def test_parse_out_flat_positional():

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -1,6 +1,9 @@
 import math
 
 import pytest
+from splink import DuckDBAPI
+from splink.comparison_level_library import CustomLevel
+from splink.internals.testing import is_in_level
 
 from uk_address_matcher import AddressMatcher
 from uk_address_matcher.cleaning.chunking_strategies import prepare_data_for_matching
@@ -154,6 +157,7 @@ def test_packaged_distinguishing_token_comparison_has_exact_fixed_weights():
 
     assert [level["label_for_charts"] for level in levels] == [
         "No distinguishing tokens",
+        "Ordered two-token signature with up to two safe gaps, postcode exact",
         "All distinguishing tokens present",
         "Some distinguishing tokens present",
         "No distinguishing tokens present",
@@ -166,12 +170,61 @@ def test_packaged_distinguishing_token_comparison_has_exact_fixed_weights():
         "label_for_charts": "No distinguishing tokens",
         "is_null_level": True,
     }
+    assert levels[1]["sql_condition"].startswith(
+        "postcode_l = postcode_r AND list_slice("
+    )
     assert [
         math.log2(level["m_probability"] / level["u_probability"]) for level in levels[1:]
-    ] == [1.0, 0.5000000000000001, -10.0]
+    ] == [10.0, 1.0, 0.5000000000000001, -10.0]
     assert all(
         level["fix_m_probability"] and level["fix_u_probability"] for level in levels[1:]
     )
+
+
+@pytest.mark.parametrize(
+    ("messy_address", "messy_postcode", "expected"),
+    [
+        ("FLAT A 1 HIGH STREET CAMDEN", "N1 1AA", True),
+        ("FLAT A NORTH SOUTH 1 HIGH STREET CAMDEN", "N1 1AA", True),
+        ("FLAT A NORTH 1 SOUTH HIGH STREET CAMDEN", "N1 1AA", True),
+        ("FLAT A 1 HIGH STREET CAMDEN", "N1 1AB", False),
+        ("FLAT A 9 1 HIGH STREET CAMDEN", "N1 1AA", False),
+        ("FLAT A HOUSE 1 HIGH STREET CAMDEN", "N1 1AA", False),
+        ("FLAT A NORTH SOUTH EAST 1 HIGH STREET", "N1 1AA", False),
+        ("FLAT A HIGH 1 STREET CAMDEN", "N1 1AA", False),
+        ("1 HIGH STREET FLAT A CAMDEN", "N1 1AA", False),
+    ],
+)
+def test_postcode_exact_safe_gap_level_matches_expected_rows(
+    duck_con,
+    messy_address,
+    messy_postcode,
+    expected,
+):
+    settings = _get_model_settings_dict()
+    comparison = next(
+        comparison
+        for comparison in settings["comparisons"]
+        if comparison["output_column_name"] == "neighbour_distinguishing_tokens"
+    )
+    safe_gap_level = CustomLevel(
+        comparison["comparison_levels"][1]["sql_condition"],
+        base_dialect_str="duckdb",
+    )
+
+    actual = is_in_level(
+        safe_gap_level,
+        {
+            "postcode_l": "N1 1AA",
+            "postcode_r": messy_postcode,
+            "distinguishing_adj_start_tokens_l": ["FLAT", "A"],
+            "clean_full_address_l": "FLAT A 1 HIGH STREET CAMDEN LONDON",
+            "clean_full_address_r": messy_address,
+        },
+        DuckDBAPI(connection=duck_con),
+    )
+
+    assert actual is expected
 
 
 def test_sanitise_null_comparison_level_removes_probabilities():
@@ -250,7 +303,7 @@ def test_distinguishing_token_comparison_contributes_expected_match_weights(duck
     prediction_rows = predictions.as_pandas_dataframe()
 
     expected_weights = {
-        frozenset(("c_all", "m_all")): 1.0,
+        frozenset(("c_all", "m_all")): 10.0,
         frozenset(("c_some", "m_some")): 0.5,
         frozenset(("c_some", "m_none")): -10.0,
     }

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -1,6 +1,15 @@
+import math
+
 import pytest
 
-from uk_address_matcher.linking_model.splink_model import _get_linker
+from uk_address_matcher import AddressMatcher
+from uk_address_matcher.cleaning.chunking_strategies import prepare_data_for_matching
+from uk_address_matcher.linking_model.splink_model import (
+    _align_distinguishing_token_columns,
+    _get_linker,
+    _get_model_settings_dict,
+    _sanitise_null_comparison_levels,
+)
 from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
 
 
@@ -113,3 +122,177 @@ def test_get_linker_raises_when_canonical_empty(
             df_addresses_to_search_within=canonical_empty,
             con=duck_con,
         )
+
+
+def test_align_distinguishing_tokens_adds_typed_empty_and_preserves_values(duck_con):
+    messy = duck_con.sql("SELECT 1 AS unique_id")
+    canonical = duck_con.sql(
+        "SELECT 2 AS unique_id, ['FLAT', 'A']::VARCHAR[] "
+        "AS distinguishing_adj_start_tokens"
+    )
+
+    aligned_messy, aligned_canonical = _align_distinguishing_token_columns(
+        messy,
+        canonical,
+    )
+
+    assert aligned_messy.project("distinguishing_adj_start_tokens").fetchone() == ([],)
+    assert str(aligned_messy.types[-1]) == "VARCHAR[]"
+    assert aligned_canonical.project("distinguishing_adj_start_tokens").fetchone() == (
+        ["FLAT", "A"],
+    )
+
+
+def test_packaged_distinguishing_token_comparison_has_exact_fixed_weights():
+    settings = _get_model_settings_dict()
+    comparison = next(
+        comparison
+        for comparison in settings["comparisons"]
+        if comparison["output_column_name"] == "neighbour_distinguishing_tokens"
+    )
+    levels = comparison["comparison_levels"]
+
+    assert [level["label_for_charts"] for level in levels] == [
+        "No distinguishing tokens",
+        "All distinguishing tokens present",
+        "Some distinguishing tokens present",
+        "No distinguishing tokens present",
+    ]
+    assert levels[0] == {
+        "sql_condition": (
+            "distinguishing_adj_start_tokens_l IS NULL OR "
+            "len(distinguishing_adj_start_tokens_l) = 0"
+        ),
+        "label_for_charts": "No distinguishing tokens",
+        "is_null_level": True,
+    }
+    assert [
+        math.log2(level["m_probability"] / level["u_probability"]) for level in levels[1:]
+    ] == [1.0, 0.5000000000000001, -10.0]
+    assert all(
+        level["fix_m_probability"] and level["fix_u_probability"] for level in levels[1:]
+    )
+
+
+def test_sanitise_null_comparison_level_removes_probabilities():
+    settings = {
+        "comparisons": [
+            {
+                "comparison_levels": [
+                    {
+                        "is_null_level": True,
+                        "m_probability": 1.0,
+                        "u_probability": 1.0,
+                    }
+                ]
+            }
+        ]
+    }
+
+    sanitised = _sanitise_null_comparison_levels(settings)
+
+    assert sanitised["comparisons"][0]["comparison_levels"][0] == {"is_null_level": True}
+
+
+def test_distinguishing_token_comparison_contributes_expected_match_weights(duck_con):
+    canonical = duck_con.sql(
+        """
+        SELECT * FROM (VALUES
+            ('c_all', 'FLAT A 1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            ('c_all_base', '1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            (
+                'c_some',
+                'OLD STATION HOUSE RAINBOW LANE TAUNTON',
+                'TA1 1AA'
+            ),
+            ('c_some_neighbour', 'NEW RAINBOW LANE TAUNTON', 'TA1 1AA')
+        ) AS t(unique_id, address_concat, postcode)
+        """
+    )
+    messy = duck_con.sql(
+        """
+        SELECT * FROM (VALUES
+            ('m_all', 'FLAT A 1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            ('m_some', 'OLD RAINBOW LANE TAUNTON', 'TA1 1AA'),
+            ('m_none', 'RAINBOW LANE TAUNTON', 'TA1 1AA')
+        ) AS t(unique_id, address_concat, postcode)
+        """
+    )
+    canonical_clean = prepare_data_for_matching(
+        canonical,
+        con=duck_con,
+        num_of_chunks=1,
+        derive_distinguishing_wrt_adjacent_records=True,
+        dataset_role="canonical",
+        show_progress=False,
+    )
+    messy_clean = prepare_data_for_matching(
+        messy,
+        con=duck_con,
+        num_of_chunks=1,
+        dataset_role="messy",
+        show_progress=False,
+    )
+
+    assert canonical_clean.filter("unique_id = 'c_some'").project(
+        "distinguishing_adj_start_tokens"
+    ).fetchone() == (["OLD", "STATION", "HOUSE"],)
+
+    linker = _get_linker(
+        messy_clean,
+        canonical_clean,
+        con=duck_con,
+        include_full_postcode_block=True,
+        include_outside_postcode_block=False,
+        retain_intermediate_calculation_columns=True,
+    )
+    predictions = linker.inference.predict(threshold_match_weight=-100)
+    prediction_rows = predictions.as_pandas_dataframe()
+
+    expected_weights = {
+        frozenset(("c_all", "m_all")): 1.0,
+        frozenset(("c_some", "m_some")): 0.5,
+        frozenset(("c_some", "m_none")): -10.0,
+    }
+    actual_weights = {}
+    for _, row in prediction_rows.iterrows():
+        pair = frozenset((row["unique_id_l"], row["unique_id_r"]))
+        if pair in expected_weights:
+            actual_weights[pair] = math.log2(
+                float(row["bf_neighbour_distinguishing_tokens"])
+            )
+
+    assert actual_weights == pytest.approx(expected_weights)
+
+
+def test_address_matcher_derives_distinguishing_tokens_only_for_canonical(duck_con):
+    canonical = duck_con.sql(
+        """
+        SELECT * FROM (VALUES
+            ('c_flat', 'FLAT A 1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            ('c_base', '1 HIGH STREET CAMDEN LONDON', 'N1 1AA')
+        ) AS t(unique_id, address_concat, postcode)
+        """
+    )
+    messy = duck_con.sql(
+        """
+        SELECT * FROM (VALUES
+            ('m_flat', 'FLAT A 1 HIGH STREET CAMDEN LONDON', 'N1 1AA')
+        ) AS t(unique_id, address_concat, postcode)
+        """
+    )
+    matcher = AddressMatcher(
+        canonical_addresses=canonical,
+        addresses_to_match=messy,
+        con=duck_con,
+        show_progress=False,
+    )
+
+    matcher._resolve_canonical_data()
+    matcher._resolve_messy_data()
+
+    assert "distinguishing_adj_start_tokens" in matcher._canonical_clean.columns
+    assert matcher._canonical_clean.filter("unique_id = 'c_flat'").project(
+        "distinguishing_adj_start_tokens"
+    ).fetchone() == (["FLAT", "A"],)
+    assert "distinguishing_adj_start_tokens" not in matcher._messy_clean.columns

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -645,7 +645,7 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
+        lambda data, con, num_of_chunks, term_frequency_lookup, derive_distinguishing_wrt_adjacent_records, dataset_role, show_progress=True: (
             clean_relation
         ),
     )
@@ -721,7 +721,7 @@ def test_prepare_remote_output_writes_chunked_paths(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
+        lambda data, con, num_of_chunks, term_frequency_lookup, derive_distinguishing_wrt_adjacent_records, dataset_role, show_progress=True: (
             clean_relation
         ),
     )
@@ -847,6 +847,85 @@ def test_load_prepared_data_has_expected_row_counts(con, prepared_folder):
     assert result.addresses.count("*").fetchone()[0] == 3
     assert result.term_frequencies.count("*").fetchone()[0] > 0
     assert result.inverted_index.count("*").fetchone()[0] > 0
+
+
+@pytest.mark.parametrize("output_chunk_count", [1, 2])
+def test_prepare_persists_distinguishing_tokens_with_array_types(
+    con,
+    tmp_path,
+    output_chunk_count,
+):
+    canonical = con.sql(
+        """
+        SELECT * FROM (VALUES
+            ('C1', 'FLAT A 1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            ('C2', '1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            ('C3', '9 SOLO ROAD YORK', 'Y1 1AA')
+        ) AS t(unique_id, address_concat, postcode)
+        """
+    )
+    prepare_canonical_folder(
+        canonical,
+        output_folder=tmp_path,
+        con=con,
+        output_chunk_count=output_chunk_count,
+        overwrite=True,
+        show_progress=False,
+    )
+
+    loaded = load_prepared_canonical_data(tmp_path, con=con).addresses
+    column_types = dict(zip(loaded.columns, map(str, loaded.types)))
+    actual = {
+        unique_id: (distinguishing, common)
+        for unique_id, distinguishing, common in loaded.project(
+            """
+            unique_id,
+            distinguishing_adj_start_tokens,
+            common_adj_start_tokens
+            """
+        ).fetchall()
+    }
+
+    assert column_types["distinguishing_adj_start_tokens"] == "VARCHAR[]"
+    assert column_types["common_adj_start_tokens"] == "VARCHAR[]"
+    assert (
+        loaded.filter(
+            "distinguishing_adj_start_tokens IS NULL OR common_adj_start_tokens IS NULL"
+        )
+        .count("*")
+        .fetchone()[0]
+        == 0
+    )
+    assert actual == {
+        "C1": (
+            ["FLAT", "A"],
+            ["1", "HIGH", "STREET", "CAMDEN", "LONDON"],
+        ),
+        "C2": ([], ["1", "HIGH", "STREET", "CAMDEN", "LONDON"]),
+        "C3": ([], ["9", "SOLO", "ROAD", "YORK"]),
+    }
+
+
+def test_prepare_can_disable_distinguishing_token_derivation(con, tmp_path):
+    prepare_canonical_folder(
+        con.sql(
+            """
+            SELECT * FROM (VALUES
+                ('C1', '1 HIGH STREET CAMDEN LONDON', 'N1 1AA')
+            ) AS t(unique_id, address_concat, postcode)
+            """
+        ),
+        output_folder=tmp_path,
+        con=con,
+        derive_distinguishing_wrt_adjacent_records=False,
+        overwrite=True,
+        show_progress=False,
+    )
+
+    loaded = load_prepared_canonical_data(tmp_path, con=con).addresses
+
+    assert "distinguishing_adj_start_tokens" not in loaded.columns
+    assert "common_adj_start_tokens" not in loaded.columns
 
 
 def test_chunked_canonical_manifest_row_audit(con, canonical_data, tmp_path):

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -645,9 +645,7 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, derive_distinguishing_wrt_adjacent_records, dataset_role, show_progress=True: (
-            clean_relation
-        ),
+        lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
@@ -721,9 +719,7 @@ def test_prepare_remote_output_writes_chunked_paths(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, derive_distinguishing_wrt_adjacent_records, dataset_role, show_progress=True: (
-            clean_relation
-        ),
+        lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,

--- a/uk_address_matcher/address_matcher.py
+++ b/uk_address_matcher/address_matcher.py
@@ -248,6 +248,7 @@ class AddressMatcher:
                 con=self.con,
                 num_of_chunks=self.cleaning_num_chunks,
                 term_frequency_lookup=self._tf_table,
+                derive_distinguishing_wrt_adjacent_records=True,
                 dataset_role="canonical",
                 debug_options=self.debug_options,
                 show_progress=self.show_progress,

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -21,6 +21,9 @@ from uk_address_matcher.cleaning.steps.inverted_index import (
     _build_inverted_index_from_keys,
     _derive_keys_for_strategy,
 )
+from uk_address_matcher.cleaning.steps.token_parsing import (
+    _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records,
+)
 from uk_address_matcher.logging.chunking import (
     log_chunk_progress,
     log_stage_complete,
@@ -653,6 +656,7 @@ def prepare_data_for_matching(
     """
     progress_mode = resolve_progress_mode(show_progress)
     uid = _uid()
+    distinguishing_table_name = None
 
     # Clean data in chunks (without term frequencies)
     cleaned_address_table = clean_data_pre_term_frequencies(
@@ -662,6 +666,28 @@ def prepare_data_for_matching(
         debug_options=debug_options,
         show_progress=progress_mode,
     )
+
+    if derive_distinguishing_wrt_adjacent_records:
+        distinguishing_pipeline = create_sql_pipeline(
+            con,
+            input_rel=cleaned_address_table,
+            stage_specs=[
+                _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records(
+                    include_input_columns=False
+                )
+            ],
+            pipeline_name="Derive locally distinguishing canonical tokens",
+            pipeline_description=(
+                "Compare each canonical address with nearby suffix-similar records"
+            ),
+        )
+        distinguishing_tokens = distinguishing_pipeline.run(debug_options)
+        distinguishing_table_name = f"__ukam_distinguishing_tokens_{uid}"
+        _materialise_relation(
+            con,
+            distinguishing_tokens,
+            distinguishing_table_name,
+        )
 
     total_rows = cleaned_address_table.count("*").fetchone()[0]
     _create_term_frequency_tables(con, term_frequency_lookup=term_frequency_lookup)
@@ -690,6 +716,17 @@ def prepare_data_for_matching(
 
     # Get the underlying table name for direct access
     cleaned_table_name = cleaned_address_table.alias
+    if distinguishing_table_name is None:
+        distinguishing_select_sql = ""
+        distinguishing_join_sql = ""
+    else:
+        distinguishing_select_sql = """,
+                distinguishing.distinguishing_adj_start_tokens,
+                distinguishing.common_adj_start_tokens"""
+        distinguishing_join_sql = f"""
+            LEFT JOIN {distinguishing_table_name} AS distinguishing
+              ON cleaned.ukam_address_id = distinguishing.ukam_address_id
+        """
 
     if dataset_role == "canonical":
         processed_table = f"__ukam__processed_canonical_{uid}"
@@ -712,10 +749,11 @@ def prepare_data_for_matching(
         for chunk_index in range(total_chunks):
             chunk_started_at = time.perf_counter()
             chunk_query = con.sql(f"""
-            SELECT *
-                FROM {cleaned_table_name}
+            SELECT cleaned.*{distinguishing_select_sql}
+                FROM {cleaned_table_name} AS cleaned
+                {distinguishing_join_sql}
                 WHERE
-                    (abs(hash(original_address_concat)) % {total_chunks})
+                    (abs(hash(cleaned.original_address_concat)) % {total_chunks})
                     = {chunk_index}
             """)
             chunk_table = f"__ukam_post_tf_chunk_input_{uid}_{chunk_index}"
@@ -726,9 +764,6 @@ def prepare_data_for_matching(
                 chunk,
                 con=con,
                 pre_cleaned_addresses=True,
-                derive_distinguishing_wrt_adjacent_records=(
-                    derive_distinguishing_wrt_adjacent_records
-                ),
                 additional_stages=inverted_index_stages,
                 debug_options=debug_options if chunk_index == 0 else None,
             )
@@ -785,6 +820,8 @@ def prepare_data_for_matching(
 
     # Drop the now-empty intermediate table
     con.execute(f"DROP TABLE IF EXISTS {cleaned_table_name}")
+    if distinguishing_table_name is not None:
+        con.execute(f"DROP TABLE IF EXISTS {distinguishing_table_name}")
 
     # Clean up inverted index table if it was registered
     if inv_idx_table_name == "__ukam_inverted_index":

--- a/uk_address_matcher/cleaning/steps/token_parsing.py
+++ b/uk_address_matcher/cleaning/steps/token_parsing.py
@@ -9,121 +9,166 @@ from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
 
 
 @pipeline_stage(
-    name="separate_distinguishing_start_tokens_from_with_respect_to_adjacent_recrods",
+    name="separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records",
     description=(
         "Identify common suffixes between addresses and separate them "
         "into unique and common token parts"
     ),
     tags=["token_analysis", "address_comparison"],
 )
-def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records():
-    """
-    Identifies common suffixes between addresses and separates them
-    into unique and common parts.
-
-    This function analyses each address in relation to its neighbours
-    (previous and next addresses when sorted by unique_id) to find
-    common suffix patterns. It then splits each address into:
-
-        - unique_tokens: tokens unique to this address,
-            typically the beginning part.
-        - common_tokens: tokens shared with neighbouring addresses,
-            typically the end part.
-
-    Args:
-        ddb_pyrel (DuckDBPyRelation): The input relation
-        con (DuckDBPyConnection): The DuckDB connection
-
-    Returns:
-        DuckDBPyRelation: The modified table with unique_tokens and common_tokens fields
-    """
-    # We will only ever have FLAT in the code by this point, as APARTMENT and UNIT
-    # have already been removed in earlier cleaning steps
-    tokens_sql = """
+def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records(
+    *,
+    include_input_columns: bool = True,
+):
+    """Split each address around its longest suffix shared by a local neighbour."""
+    tokenised_addresses_sql = r"""
     SELECT
-        ['FLAT'] AS __tokens_to_remove,
-        list_filter(
-            regexp_split_to_array(clean_full_address, '\\s+'),
-            x -> NOT list_contains(__tokens_to_remove, x)
-        ) AS __tokens,
-        row_number() OVER (ORDER BY reverse(clean_full_address)) AS row_order,
-        *
-    FROM {input}
+        ukam_address_id,
+        unique_id,
+        clean_full_address,
+        regexp_split_to_array(clean_full_address, '\s+')::VARCHAR[] AS __tokens
+    FROM {input} AS input_address
     """
 
-    neighbors_sql = """
+    neighbouring_addresses_sql = """
     SELECT
-        lag(__tokens) OVER (ORDER BY row_order) AS __prev_tokens,
-        lead(__tokens) OVER (ORDER BY row_order) AS __next_tokens,
-        *
-    FROM {tokens}
+        ukam_address_id,
+        unique_id,
+        __tokens,
+        lag(unique_id, 1) OVER address_order AS __lag_1_unique_id,
+        lag(clean_full_address, 1) OVER address_order AS __lag_1_address,
+        lag(unique_id, 2) OVER address_order AS __lag_2_unique_id,
+        lag(clean_full_address, 2) OVER address_order AS __lag_2_address,
+        lag(unique_id, 3) OVER address_order AS __lag_3_unique_id,
+        lag(clean_full_address, 3) OVER address_order AS __lag_3_address,
+        lead(unique_id, 1) OVER address_order AS __lead_1_unique_id,
+        lead(clean_full_address, 1) OVER address_order AS __lead_1_address,
+        lead(unique_id, 2) OVER address_order AS __lead_2_unique_id,
+        lead(clean_full_address, 2) OVER address_order AS __lead_2_address,
+        lead(unique_id, 3) OVER address_order AS __lead_3_unique_id,
+        lead(clean_full_address, 3) OVER address_order AS __lead_3_address
+    FROM {tokenised_addresses} AS tokenised
+    WINDOW address_order AS (
+        ORDER BY
+            reverse(clean_full_address),
+            CAST(unique_id AS VARCHAR),
+            ukam_address_id
+    )
     """
+
+    neighbour_names = (
+        "lag_1",
+        "lag_2",
+        "lag_3",
+        "lead_1",
+        "lead_2",
+        "lead_3",
+    )
+    suffix_length_expressions = []
+    for neighbour_name in neighbour_names:
+        neighbour_id = f"__{neighbour_name}_unique_id"
+        neighbour_tokens = (
+            f"regexp_split_to_array(__{neighbour_name}_address, '\\s+')::VARCHAR[]"
+        )
+        suffix_length_expressions.append(f"""
+        CASE
+            WHEN {neighbour_id} IS NULL OR {neighbour_id} = unique_id THEN 0
+            ELSE COALESCE(
+                list_position(
+                    list_transform(
+                        list_zip(
+                            list_reverse(__tokens),
+                            list_reverse({neighbour_tokens}),
+                            true
+                        ),
+                        token_pair -> token_pair[1] != token_pair[2]
+                    ),
+                    true
+                ) - 1,
+                least(len(__tokens), len({neighbour_tokens}))
+            )
+        END AS __{neighbour_name}_common_suffix_length
+        """)
 
     suffix_lengths_sql = """
     SELECT
-        len(__tokens) AS __token_count,
-        CASE WHEN __prev_tokens IS NOT NULL THEN
-            (
-                SELECT max(i)
-                FROM range(0, least(len(__tokens), len(__prev_tokens))) AS t(i)
-                WHERE list_slice(list_reverse(__tokens), 1, i + 1) =
-                    list_slice(list_reverse(__prev_tokens), 1, i + 1)
-            )
-        ELSE 0 END AS prev_common_suffix,
-        CASE WHEN __next_tokens IS NOT NULL THEN
-            (
-                SELECT max(i)
-                FROM range(0, least(len(__tokens), len(__next_tokens))) AS t(i)
-                WHERE list_slice(list_reverse(__tokens), 1, i + 1) =
-                    list_slice(list_reverse(__next_tokens), 1, i + 1)
-            )
-        ELSE 0 END AS next_common_suffix,
-        *
-    FROM {with_neighbors}
-    """
+        ukam_address_id,
+        __tokens,
+        {suffix_length_expressions}
+    FROM {neighbouring_addresses} AS neighbours
+    """.replace(
+        "{suffix_length_expressions}",
+        ",\n".join(suffix_length_expressions),
+    )
 
-    unique_parts_sql = """
+    maximum_suffix_lengths_sql = """
     SELECT
-        *,
-        greatest(prev_common_suffix, next_common_suffix) AS max_common_suffix,
-        list_filter(
-            __tokens,
-            (token, i) ->
-                i < __token_count - greatest(prev_common_suffix, next_common_suffix)
-        ) AS unique_tokens,
-        list_filter(
-            __tokens,
-            (token, i) ->
-                i >= __token_count - greatest(prev_common_suffix, next_common_suffix)
-        ) AS common_tokens
-    FROM {with_suffix_lengths}
+        suffix_lengths.ukam_address_id,
+        suffix_lengths.__tokens,
+        greatest(
+            __lag_1_common_suffix_length,
+            __lag_2_common_suffix_length,
+            __lag_3_common_suffix_length,
+            __lead_1_common_suffix_length,
+            __lead_2_common_suffix_length,
+            __lead_3_common_suffix_length
+        ) AS __max_common_suffix_length
+    FROM {suffix_lengths} AS suffix_lengths
     """
 
+    output_columns_sql = (
+        "input_address.*," if include_input_columns else "maximums.ukam_address_id,"
+    )
+    output_source_sql = (
+        "FROM {input} AS input_address\n"
+        "LEFT JOIN {maximum_suffix_lengths} AS maximums\n"
+        "  ON input_address.ukam_address_id = maximums.ukam_address_id"
+        if include_input_columns
+        else "FROM {maximum_suffix_lengths} AS maximums"
+    )
     final_sql = """
     SELECT
-        * EXCLUDE (
-            __tokens,
-            __prev_tokens,
-            __next_tokens,
-            __token_count,
-            __tokens_to_remove,
-            max_common_suffix,
-            next_common_suffix,
-            prev_common_suffix,
-            row_order,
-            common_tokens,
-            unique_tokens
-        ),
-        COALESCE(unique_tokens, ARRAY[]) AS distinguishing_adj_start_tokens,
-        COALESCE(common_tokens, ARRAY[]) AS common_adj_start_tokens
-    FROM {with_unique_parts}
-    """
+        {output_columns_sql}
+        CASE
+            WHEN COALESCE(maximums.__max_common_suffix_length, 0) > 0
+                THEN COALESCE(
+                    list_slice(
+                        maximums.__tokens,
+                        1,
+                        len(maximums.__tokens)
+                            - maximums.__max_common_suffix_length
+                    ),
+                    []::VARCHAR[]
+                )
+            ELSE []::VARCHAR[]
+        END::VARCHAR[] AS distinguishing_adj_start_tokens,
+        CASE
+            WHEN COALESCE(maximums.__max_common_suffix_length, 0) > 0
+                THEN COALESCE(
+                    list_slice(
+                        maximums.__tokens,
+                        len(maximums.__tokens)
+                            - maximums.__max_common_suffix_length + 1,
+                        len(maximums.__tokens)
+                    ),
+                    []::VARCHAR[]
+                )
+            ELSE COALESCE(maximums.__tokens, []::VARCHAR[])
+        END::VARCHAR[] AS common_adj_start_tokens
+    {output_source_sql}
+    """.replace(
+        "{output_columns_sql}",
+        output_columns_sql,
+    ).replace(
+        "{output_source_sql}",
+        output_source_sql,
+    )
 
     steps = [
-        CTEStep("tokens", tokens_sql),
-        CTEStep("with_neighbors", neighbors_sql),
-        CTEStep("with_suffix_lengths", suffix_lengths_sql),
-        CTEStep("with_unique_parts", unique_parts_sql),
+        CTEStep("tokenised_addresses", tokenised_addresses_sql),
+        CTEStep("neighbouring_addresses", neighbouring_addresses_sql),
+        CTEStep("suffix_lengths", suffix_lengths_sql),
+        CTEStep("maximum_suffix_lengths", maximum_suffix_lengths_sql),
         CTEStep("final", final_sql),
     ]
 

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -58,6 +58,41 @@
   ],
   "comparisons": [
     {
+      "output_column_name": "neighbour_distinguishing_tokens",
+      "comparison_levels": [
+        {
+          "sql_condition": "distinguishing_adj_start_tokens_l IS NULL OR len(distinguishing_adj_start_tokens_l) = 0",
+          "label_for_charts": "No distinguishing tokens",
+          "is_null_level": true
+        },
+        {
+          "sql_condition": "list_has_all(regexp_split_to_array(clean_full_address_r, '\\s+'), distinguishing_adj_start_tokens_l)",
+          "label_for_charts": "All distinguishing tokens present",
+          "m_probability": 2.0,
+          "u_probability": 1.0,
+          "fix_m_probability": true,
+          "fix_u_probability": true
+        },
+        {
+          "sql_condition": "list_has_any(regexp_split_to_array(clean_full_address_r, '\\s+'), distinguishing_adj_start_tokens_l)",
+          "label_for_charts": "Some distinguishing tokens present",
+          "m_probability": 1.4142135623730951,
+          "u_probability": 1.0,
+          "fix_m_probability": true,
+          "fix_u_probability": true
+        },
+        {
+          "sql_condition": "ELSE",
+          "label_for_charts": "No distinguishing tokens present",
+          "m_probability": 1.0,
+          "u_probability": 1024.0,
+          "fix_m_probability": true,
+          "fix_u_probability": true
+        }
+      ],
+      "comparison_description": "Locally distinguishing canonical tokens"
+    },
+    {
       "output_column_name": "address_without_numbers",
       "comparison_levels": [
         {

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -66,6 +66,14 @@
           "is_null_level": true
         },
         {
+          "sql_condition": "postcode_l = postcode_r AND list_slice(regexp_split_to_array(clean_full_address_r, '\\s+'), 1, len(distinguishing_adj_start_tokens_l)) = distinguishing_adj_start_tokens_l AND list_contains(flatten(list_transform(range(1, 5), first_offset -> list_transform(range(first_offset + 1, 5), second_offset -> list_extract(regexp_split_to_array(clean_full_address_r, '\\s+'), len(distinguishing_adj_start_tokens_l) + first_offset) = list_extract(regexp_split_to_array(clean_full_address_l, '\\s+'), len(distinguishing_adj_start_tokens_l) + 1) AND list_extract(regexp_split_to_array(clean_full_address_r, '\\s+'), len(distinguishing_adj_start_tokens_l) + second_offset) = list_extract(regexp_split_to_array(clean_full_address_l, '\\s+'), len(distinguishing_adj_start_tokens_l) + 2) AND NOT list_contains(list_transform(list_filter(range(1, second_offset + 1), gap_offset -> gap_offset != first_offset AND gap_offset != second_offset), gap_offset -> regexp_matches(list_extract(regexp_split_to_array(clean_full_address_r, '\\s+'), len(distinguishing_adj_start_tokens_l) + gap_offset), '[0-9]') OR list_extract(regexp_split_to_array(clean_full_address_r, '\\s+'), len(distinguishing_adj_start_tokens_l) + gap_offset) IN ('APARTMENT', 'BLOCK', 'BUILDING', 'COTTAGE', 'FLAT', 'HOUSE', 'MAISONETTE', 'OFFICE', 'STEADING', 'STUDIO', 'SUITE', 'UNIT', 'WAREHOUSE', 'WORKSHOP')), TRUE)))), TRUE)",
+          "label_for_charts": "Ordered two-token signature with up to two safe gaps, postcode exact",
+          "m_probability": 1024.0,
+          "u_probability": 1.0,
+          "fix_m_probability": true,
+          "fix_u_probability": true
+        },
+        {
           "sql_condition": "list_has_all(regexp_split_to_array(clean_full_address_r, '\\s+'), distinguishing_adj_start_tokens_l)",
           "label_for_charts": "All distinguishing tokens present",
           "m_probability": 2.0,

--- a/uk_address_matcher/linking_model/splink_model.py
+++ b/uk_address_matcher/linking_model/splink_model.py
@@ -76,6 +76,22 @@ def _get_precomputed_numeric_tf_table(con: DuckDBPyConnection):
     return con.sql(read_tf_sql)
 
 
+def _align_distinguishing_token_columns(
+    df_addresses_to_match: DuckDBPyRelation,
+    df_addresses_to_search_within: DuckDBPyRelation,
+) -> tuple[DuckDBPyRelation, DuckDBPyRelation]:
+    """Add a neutral typed token array where either Splink input lacks it."""
+    column_name = "distinguishing_adj_start_tokens"
+    empty_tokens = f"[]::VARCHAR[] AS {column_name}"
+    if column_name not in df_addresses_to_match.columns:
+        df_addresses_to_match = df_addresses_to_match.select(f"*, {empty_tokens}")
+    if column_name not in df_addresses_to_search_within.columns:
+        df_addresses_to_search_within = df_addresses_to_search_within.select(
+            f"*, {empty_tokens}"
+        )
+    return df_addresses_to_match, df_addresses_to_search_within
+
+
 def _get_linker(
     df_addresses_to_match: DuckDBPyRelation,
     df_addresses_to_search_within: DuckDBPyRelation,
@@ -130,6 +146,14 @@ def _get_linker(
         raise ValueError(
             "Canonical relation is empty - Splink requires at least one search record."
         )
+
+    (
+        df_addresses_to_match,
+        df_addresses_to_search_within,
+    ) = _align_distinguishing_token_columns(
+        df_addresses_to_match,
+        df_addresses_to_search_within,
+    )
 
     if settings is None:
         settings_as_dict = _get_model_settings_dict()

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -429,6 +429,7 @@ def prepare_canonical_folder(
     con: duckdb.DuckDBPyConnection,
     num_of_chunks: int = 10,
     output_chunk_count: int = 1,
+    derive_distinguishing_wrt_adjacent_records: bool = True,
     overwrite: bool = False,
     show_progress: ShowProgress = True,
 ) -> None:
@@ -458,6 +459,8 @@ def prepare_canonical_folder(
             addresses. Set to 1 to write `ukam_canonical_addresses.parquet`.
             Set above 1 to write hash-partitioned chunks under
             `ukam_canonical_addresses_chunks/`.
+        derive_distinguishing_wrt_adjacent_records: Whether to derive canonical
+            leading tokens that distinguish suffix-similar nearby records.
         overwrite: Whether to overwrite existing files in the folder. When
             `True`, all known artefacts are removed before writing to ensure
             the folder ends up in a consistent state.
@@ -528,6 +531,10 @@ def prepare_canonical_folder(
         con=con,
         num_of_chunks=num_of_chunks,
         term_frequency_lookup=tf_table,
+        derive_distinguishing_wrt_adjacent_records=(
+            derive_distinguishing_wrt_adjacent_records
+        ),
+        dataset_role="canonical",
         show_progress=progress_mode,
     )
 


### PR DESCRIPTION
This PR adds locally distinguishing canonical tokens to improve matching between
addresses that share a common suffix.

During canonical preparation, each address is compared with nearby
suffix-similar addresses. Its tokens are split into a locally distinguishing
prefix and a shared suffix, and both arrays are persisted in the prepared
canonical data. A new fixed-weight Splink comparison scores whether the messy
address contains all (`+1`), some (`+0.5`), or none (`-10`) of the canonical
address's distinguishing tokens.

### Example

Given these neighbouring canonical addresses:

```text
FLAT A 1 HIGH STREET CAMDEN LONDON
1 HIGH STREET CAMDEN LONDON
```

the first address is represented as:

```text
distinguishing tokens: [FLAT, A]
common suffix:         [1, HIGH, STREET, CAMDEN, LONDON]
```

A messy address containing both `FLAT` and `A` receives `+1` additional match
weight. An address containing only one receives `+0.5`; one containing neither
receives `-10`.

The change preserves compatibility with older prepared canonicals that do not
contain the new columns. Area-scoped precision-recall comparisons were run for
Hackney, Rhondda, Aberdeenshire, and Mid Sussex. Hackney prediction time
increased by approximately 5-6%.

# PR timing and storage benchmarks

Hackney prediction performance was compared between `main` (`40d163a`) and the
local distinguishing tokens branch (`5f56980`). The benchmark timed only
`linker.inference.predict()` through materialisation, excluding canonical
preparation, cleaning, deterministic matching stages, and post-prediction
reranking.

The PR increased median prediction time by **5.88%** with an area-scoped
canonical and **3.39%** with the full national canonical.

## Area-scoped canonical

Both revisions used the same environment, 114,166 Hackney input rows,
392,621-row area-scoped canonical, canonical filter, blocking rules, and
thresholds. Each result is based on one warm-up followed by five measured runs.

| Revision | Median | Mean | Range |
|---|---:|---:|---:|
| `main` (`40d163a`) | 6.906 s | 6.941 s | 6.717-7.251 s |
| Branch (`5f56980`) | 7.312 s | 7.302 s | 7.050-7.439 s |
| Change | **+0.406 s (+5.88%)** | **+5.21%** | |

`main` retained 2,363,866 candidate pairs, while the branch retained 2,345,727
(-0.77%) because the additional comparison changes which pairs survive the
production `-50` prediction cutoff. Median time per million retained pairs rose
from 2.921 s to 3.117 s (+6.70%).

The PR therefore slows Hackney prediction by approximately **5-6%**. This is a
modest prediction-stage regression and is consistent with evaluating the ninth
comparison for each candidate pair.

## National canonical

The same benchmark was repeated with Hackney matched against the full
71,438,939-row national prepared canonical.

| Revision | Median | Mean | Range |
|---|---:|---:|---:|
| `main` (`40d163a`) | 11.738 s | 11.599 s | 11.050-12.134 s |
| Branch (`5f56980`) | 12.136 s | 12.050 s | 11.543-12.450 s |
| Change | **+0.398 s (+3.39%)** | **+3.88%** | |

`main` retained 2,421,560 candidate pairs, while the branch retained 2,402,171
(-0.80%). Median time per million retained pairs rose from 4.847 s to 5.052 s
(+4.23%). On the national canonical, the PR therefore slows Hackney prediction
by approximately **3-4%**.

## Full national canonical preparatxion

Full canonical preparation was measured with adjacent-record token derivation
disabled (baseline) and enabled (branch). Both runs used the same 71,438,939-row
source, DuckDB 1.5.0, 14 threads, approximately 28.7 GiB of memory, ten
processing chunks, `preserve_insertion_order=false`, and one canonical Parquet
output file.

| Variant | Total runtime | Preparation phase |
|---|---:|---:|
| Baseline | 519.606 s (8m 39.61s) | 203.351 s |
| Branch | 644.982 s (10m 44.98s) | 340.492 s |
| Change | **+125.376 s (+24.13%)** | **+137.141 s (+67.44%)** |

The feature therefore adds approximately **2m 5s** to a full national build.
Some variation in the other preparation phases offset part of the additional
feature-derivation time in the total runtime.

Persisted sizes below use decimal GB and the same one-file output layout for
both variants.

| Artefact | Baseline | Branch | Change |
|---|---:|---:|---:|
| Canonical addresses | 1,658,938,666 bytes (1.659 GB) | 1,906,923,492 bytes (1.907 GB) | **+247,984,826 bytes (+14.95%)** |
| Term frequencies | 4,946,205 bytes | 4,945,396 bytes | -809 bytes (-0.02%) |
| Inverted index | 696,134,434 bytes | 696,134,434 bytes | No change |
| Manifest | 1,913 bytes | 1,991 bytes | +78 bytes |
| **Total** | **2,360,021,218 bytes (2.360 GB)** | **2,608,005,313 bytes (2.608 GB)** | **+247,984,095 bytes (+10.51%)** |

Peak live DuckDB temporary spill increased from 61.54 GiB to 66.51 GiB, an
increase of approximately 4.97 GiB. The temporary directory was empty after
each completed run.

Each preparation result is one full-scale measured run, so the exact runtime
includes normal system noise. The existing 20-file baseline canonical was not
used for storage comparison because its different Parquet layout inflated its
size; the table uses the controlled one-file baseline rebuild instead.