### PR TITLE
feat(splink): add new cleaned address exact match blocking rule

### DIFF
--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -49,6 +49,10 @@
       "sql_dialect": "duckdb"
     },
     {
+      "blocking_rule": "regexp_replace(l.clean_full_address, '[^A-Z0-9]', '', 'g') = regexp_replace(r.clean_full_address, '[^A-Z0-9]', '', 'g')",
+      "sql_dialect": "duckdb"
+    },
+    {
       "blocking_rule": "l.exploding_unique_ids = r.exploding_unique_ids",
       "sql_dialect": "duckdb",
       "arrays_to_explode": [
@@ -782,7 +786,7 @@
           "fix_u_probability": true
         }
       ],
-      "comparison_description": "Bigram/trigram inverted-index signature overlap (IDF-weighted)"
+      "comparison_description": "Bigram/trigram inverted-index signature overlap (IDF-weighted; filter_condition IS NULL; outward singleton four-gram rows are candidate-only)"
     }
   ]
 }


### PR DESCRIPTION
Adds an additional block on all address strings where numerics are removed. In practice, this recovers around `413` of our missing (4k) unmatched records in the wider input set. These include records from Rhondda, Aberdeenshrie and Hackney.

The exact logic being used is:
```regexp_replace(l.clean_full_address, '[^A-Z0-9]', '', 'g') = regexp_replace(r.clean_full_address, '[^A-Z0-9]', '', 'g')```

Results in very minor gains for the wider pooled councils dataset:
<img width="408" height="96" alt="Screenshot 2026-07-27 at 09 55 27" src="https://github.com/user-attachments/assets/46ff512f-2d19-4977-914f-a67c320fff44" />
