### PR TITLE
agents: add a basic benchmarking prompt for agents to use

### DIFF
--- a/.github/instructions/repo-workflow.instructions.md
+++ b/.github/instructions/repo-workflow.instructions.md
@@ -27,6 +27,40 @@ applyTo:
   - Prefer minimal, composable changes that reduce downstream user work.
   - Respect existing workflows and integrations; avoid forcing new patterns without need.
 
+## Change policy
+
+- Make the smallest possible change that fully satisfies the explicit request.
+- Change only code directly required by the request, modifying the fewest files and lines possible.
+- Do not perform unrelated refactoring, cleanup, formatting, renaming, dependency upgrades,
+  documentation rewrites, or architectural changes.
+- Do not introduce abstractions, helpers, dependencies, configuration, or files unless necessary
+  for the requested behaviour; follow existing project patterns and preserve surrounding comments
+  and formatting.
+- Preserve current behaviour outside the request. Prefer local fixes over system-wide redesigns;
+  avoid speculative handling for hypothetical requirements.
+- Do not modify generated files, vendored code, lockfiles, migrations, or build output unless the
+  request requires it.
+- Add or update only focused tests for the requested behaviour; do not rewrite tests to accommodate
+  an unintended behaviour change.
+
+### Public API stability
+
+- Treat the public API as frozen unless the request explicitly authorises a change. This includes
+  public classes, functions, methods, properties, constants, types, signatures, package exports,
+  module paths, routes, request and response formats, CLI behaviour, configuration, environment
+  variables, schemas, serialised data, error types, side effects, defaults, and runtime behaviour.
+- Do not rename, move, remove, reorder, narrow, or otherwise change a public API or existing
+  default merely to make an implementation cleaner.
+- When work appears to require a breaking API change, do not make it. Briefly explain the conflict,
+  propose a backward-compatible alternative, and wait for explicit authorisation.
+
+### Communication
+
+- Before making changes, briefly state which files need to change and why.
+- After making changes, report only what changed, checks performed, and any unresolved limitation.
+- When instructions are ambiguous, choose the interpretation that preserves current behaviour and
+  produces the smallest diff.
+
 - Start from a feature branch off `main`.
 - Keep diffs focused; avoid unrelated formatting/refactor churn.
 - Prefer the smallest viable implementation unless the user asks for a larger feature or experiment.

--- a/.github/prompts/run-benchmark-experiment.prompt.md
+++ b/.github/prompts/run-benchmark-experiment.prompt.md
@@ -1,0 +1,82 @@
+---
+description: "Use when: running a persisted benchmark experiment, comparing a model or threshold change against a baseline, or producing benchmark audit artefacts."
+---
+
+# Run a benchmark experiment
+
+Follow the full [benchmark experiment instructions](../instructions/benchmark-experiments.instructions.md).
+
+## Experiment
+
+```
+Question:
+${input:question:What hypothesis should this experiment test?}
+
+Proposed change:
+${input:change:What exact model, feature, threshold or implementation change should be tested?}
+
+Baseline run:
+${input:baseline:latest}
+
+Datasets:
+${input:datasets:Which benchmark datasets should be used?}
+
+Stages:
+${input:stages:Which matching stages should be run?}
+
+Primary operating point:
+${input:threshold:MW 10}
+
+Record-level audit:
+${input:audit:Yes or no}
+```
+
+## Objective
+
+Use the baseline run as the control.
+
+Unless this experiment specifies otherwise, assess results at MW 6, 8, 10 and 12.
+
+At MW 10, prefer the formulation that recovers the most true positives while preserving precision.
+
+A variant passes the default promotion criterion only when:
+
+```
+TP_new > TP_baseline
+F1_new > F1_baseline
+precision_new >= precision_baseline - 0.02 percentage points
+```
+
+Calculate and report the corresponding maximum permitted false-positive count.
+
+## Required workflow
+
+1. Confirm the hypothesis, exact change, baseline, controls, and whether the reduced canonical requires rebuilding.
+2. Make only the smallest experiment-specific changes.
+3. Run targeted tests for touched behaviour.
+4. Run the persisted benchmark through `benchmarking/run_benchmarking.py`.
+5. Compare the experiment against the resolved baseline.
+6. Interpret the overlay precision-recall chart.
+7. Produce the transition matrix and, where requested, a record-level audit.
+8. Persist a concise Markdown report and JSON companion in the run directory.
+
+## Required analysis
+
+Report:
+
+- Baseline and experiment run IDs.
+- Exact changes and no-change controls.
+- MW 6, 8, 10, and 12 metrics and deltas.
+- TP, FP, FN, precision, recall, F1, F0.5, matched, and unmatched.
+- MW 10 precision floor and maximum-FP assessment.
+- Transition matrix.
+- Model effect versus threshold effect.
+- Ranking changes versus threshold crossings.
+- Truth absent from the candidate set.
+- Overlay precision-recall chart interpretation.
+- Runtime impact.
+- Important newly wrong and recovered examples.
+- Artefact paths.
+- A clear promote, reject, continue-testing, or inconclusive decision.
+
+When results are promising but inconclusive, inspect changed records and run only a narrowly justified follow-up. Do not perform an unrecorded parameter search.


### PR DESCRIPTION
Makes two changes:
1. Updates our existing repo-workflow guidance to try to tweak the change policy for LLMs. They now will actively avoid editing the public API and should make smaller total changes.
2. Adds a benchmarking prompt that should simplify our benchmarking workflows.