### PR TITLE
feat(splink): retain phase1 reranker outputs for advancement to secon…

### DIFF
--- a/tests/post_linkage/test_contextual_residual_reranker.py
+++ b/tests/post_linkage/test_contextual_residual_reranker.py
@@ -5,9 +5,6 @@ from dataclasses import replace
 import duckdb
 import pytest
 
-from uk_address_matcher.linking_model.matching.stages.splink import (
-    _contextual_acceptance_lift_filter,
-)
 from uk_address_matcher.post_linkage.contextual_residual_reranker import (
     PRECISION_K3_CONFIG,
     improve_predictions_using_contextual_residuals,
@@ -410,11 +407,7 @@ def test_production_mode_omits_diagnostics_and_cleans_intermediate_tables() -> N
 def test_maximum_contextual_acceptance_lift_requires_both_thresholds() -> None:
     con = duckdb.connect(database=":memory:")
     try:
-        acceptance_lift_filter = _contextual_acceptance_lift_filter(
-            final_match_weight_threshold=10.0,
-            maximum_acceptance_lift=2.0,
-        )
-        accepted = con.sql(f"""
+        accepted = con.sql("""
             SELECT candidate_id
             FROM (
                 VALUES
@@ -423,7 +416,7 @@ def test_maximum_contextual_acceptance_lift_requires_both_thresholds() -> None:
                     ('below-final-threshold', 8.5, 9.9)
             ) AS best_match(candidate_id, phase1_score, match_weight)
             WHERE best_match.match_weight >= 10.0
-            {acceptance_lift_filter}
+              AND best_match.phase1_score >= 8.0
         """).fetchall()
 
         assert accepted == [("allowed-lift",)]

--- a/tests/post_linkage/test_contextual_residual_reranker.py
+++ b/tests/post_linkage/test_contextual_residual_reranker.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import duckdb
+import pytest
+
+from uk_address_matcher.linking_model.matching.stages.splink import (
+    _contextual_acceptance_lift_filter,
+)
+from uk_address_matcher.post_linkage.contextual_residual_reranker import (
+    PRECISION_K3_CONFIG,
+    improve_predictions_using_contextual_residuals,
+)
+
+
+def _sql_list(tokens: list[str]) -> str:
+    return "[" + ", ".join(f"'{token}'" for token in tokens) + "]"
+
+
+def _predictions(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    query_tokens: list[str],
+    candidates: list[tuple[str, list[str], float]],
+    phase1_scores: dict[str, float] | None = None,
+) -> duckdb.DuckDBPyRelation:
+    candidate_address_ids = {
+        candidate_id: index
+        for index, candidate_id in enumerate(
+            sorted({item[0] for item in candidates}), start=1
+        )
+    }
+    rows = ", ".join(
+        "("
+        + ", ".join(
+            (
+                f"'{candidate_id}'",
+                "'source-1'",
+                str(candidate_address_ids[candidate_id]),
+                "10",
+                _sql_list(tokens),
+                _sql_list(query_tokens),
+                str(splink_match_weight),
+                "0.0",
+                str(
+                    phase1_scores.get(candidate_id, splink_match_weight)
+                    if phase1_scores is not None
+                    else splink_match_weight
+                ),
+            )
+        )
+        + ")"
+        for candidate_id, tokens, splink_match_weight in candidates
+    )
+    return con.sql(f"""
+        SELECT *
+        FROM (VALUES {rows}) AS pairs(
+            unique_id_l,
+            unique_id_r,
+            ukam_address_id_l,
+            ukam_address_id_r,
+            tokens_l,
+            tokens_r,
+            splink_match_weight,
+            mw_adjustment,
+            phase1_score
+        )
+    """)
+
+
+def _result(
+    *,
+    query_tokens: list[str],
+    candidates: list[tuple[str, list[str], float]],
+    **options: object,
+) -> list[dict[str, object]]:
+    con = duckdb.connect(database=":memory:")
+    try:
+        config = options.get("config", PRECISION_K3_CONFIG)
+        assert isinstance(config, type(PRECISION_K3_CONFIG))
+        options["config"] = replace(config, include_diagnostics=True)
+        relation = _predictions(
+            con,
+            query_tokens=query_tokens,
+            candidates=candidates,
+        )
+        result = improve_predictions_using_contextual_residuals(
+            df_predict=relation,
+            con=con,
+            **options,
+        )
+        return [dict(zip(result.columns, row)) for row in result.fetchall()]
+    finally:
+        con.close()
+
+
+def _by_candidate(rows: list[dict[str, object]]) -> dict[str, dict[str, object]]:
+    return {str(row["unique_id_l"]): row for row in rows}
+
+
+def test_consensus_tokens_are_removed_and_unit_is_contextual_winner() -> None:
+    rows = _by_candidate(
+        _result(
+            query_tokens=["UNIT", "3", "WESTGATE", "BUSINESS", "PARK"],
+            candidates=[
+                ("unit-2", ["UNIT", "2", "WESTGATE", "BUSINESS", "PARK"], 10.0),
+                ("unit-3", ["UNIT", "3", "WESTGATE", "BUSINESS", "PARK"], 10.0),
+                ("unit-4", ["UNIT", "4", "WESTGATE", "BUSINESS", "PARK"], 10.0),
+            ],
+        )
+    )
+
+    assert (
+        rows["unit-3"]["contextual_match_weight"]
+        > rows["unit-2"]["contextual_match_weight"]
+    )
+    assert (
+        rows["unit-3"]["contextual_match_weight"]
+        > rows["unit-4"]["contextual_match_weight"]
+    )
+    assert rows["unit-3"]["consensus_query_tokens"] == [
+        "UNIT",
+        "WESTGATE",
+        "BUSINESS",
+        "PARK",
+    ]
+    assert rows["unit-3"]["matched_residual_tokens"] == ["3"]
+
+
+def test_commercial_noise_is_unaddressed_and_excluded_from_evidence() -> None:
+    rows = _by_candidate(
+        _result(
+            query_tokens=[
+                "ACME",
+                "FACILITIES",
+                "ACCOUNTS",
+                "PAYABLE",
+                "UNIT",
+                "3",
+                "WESTGATE",
+                "BUSINESS",
+                "PARK",
+            ],
+            candidates=[
+                ("unit-2", ["UNIT", "2", "WESTGATE", "BUSINESS", "PARK"], 10.0),
+                ("unit-3", ["UNIT", "3", "WESTGATE", "BUSINESS", "PARK"], 10.0),
+                ("unit-4", ["UNIT", "4", "WESTGATE", "BUSINESS", "PARK"], 10.0),
+            ],
+        )
+    )
+
+    winner = rows["unit-3"]
+    assert winner["unaddressed_query_tokens"] == [
+        "ACME",
+        "FACILITIES",
+        "ACCOUNTS",
+        "PAYABLE",
+    ]
+    assert winner["contextual_match_weight"] > rows["unit-2"]["contextual_match_weight"]
+
+
+def test_missing_distinguishing_evidence_has_zero_contextual_adjustment() -> None:
+    rows = _result(
+        query_tokens=["ROSE", "HOUSE", "KING", "STREET"],
+        candidates=[
+            ("flat-1", ["FLAT", "1", "ROSE", "HOUSE", "KING", "STREET"], 10.0),
+            ("flat-2", ["FLAT", "2", "ROSE", "HOUSE", "KING", "STREET"], 10.0),
+            ("flat-3", ["FLAT", "3", "ROSE", "HOUSE", "KING", "STREET"], 10.0),
+        ],
+    )
+
+    for row in rows:
+        assert row["addressable_distinguishing_weight"] == pytest.approx(0.0)
+        assert row["evidence_scale"] == pytest.approx(0.0)
+        assert row["contextual_adjustment"] == pytest.approx(0.0)
+
+
+def test_split_join_can_be_ablated_without_numeric_split() -> None:
+    split_rows = _by_candidate(
+        _result(
+            query_tokens=["UNIT3", "WESTGATE"],
+            candidates=[
+                ("joined", ["UNIT", "3", "WEST", "GATE"], 10.0),
+                ("other", ["UNIT", "2", "WEST", "GATE"], 10.0),
+            ],
+        )
+    )
+    no_split_rows = _by_candidate(
+        _result(
+            query_tokens=["UNIT3", "WESTGATE"],
+            candidates=[
+                ("joined", ["UNIT", "3", "WEST", "GATE"], 10.0),
+                ("other", ["UNIT", "2", "WEST", "GATE"], 10.0),
+            ],
+            config=replace(PRECISION_K3_CONFIG, use_split_join=False),
+        )
+    )
+    numeric_rows = _by_candidate(
+        _result(
+            query_tokens=["12"],
+            candidates=[
+                ("split-number", ["1", "2"], 10.0),
+                ("other", ["3"], 10.0),
+            ],
+        )
+    )
+
+    assert split_rows["joined"]["split_join_rate"] > 0.0
+    assert no_split_rows["joined"]["split_join_rate"] == pytest.approx(0.0)
+    assert numeric_rows["split-number"]["split_join_rate"] == pytest.approx(0.0)
+
+
+def test_soft_matching_is_conservative_and_can_be_disabled() -> None:
+    soft_rows = _by_candidate(
+        _result(
+            query_tokens=["WILOUGHBY"],
+            candidates=[
+                ("near", ["WILLOUGHBY"], 10.0),
+                ("other", ["WILDFLOWER"], 10.0),
+            ],
+        )
+    )
+    no_soft_rows = _by_candidate(
+        _result(
+            query_tokens=["WILOUGHBY"],
+            candidates=[
+                ("near", ["WILLOUGHBY"], 10.0),
+                ("other", ["WILDFLOWER"], 10.0),
+            ],
+            config=replace(PRECISION_K3_CONFIG, use_soft_matching=False),
+        )
+    )
+    excluded_rows = _result(
+        query_tokens=["ABCD", "12345", "A12BC"],
+        candidates=[
+            ("candidate", ["ABCE", "12346", "A12BD"], 10.0),
+            ("other", ["OTHER"], 10.0),
+        ],
+    )
+
+    assert soft_rows["near"]["soft_match_rate"] > 0.0
+    assert (
+        soft_rows["near"]["contextual_match_weight"]
+        > soft_rows["other"]["contextual_match_weight"]
+    )
+    assert no_soft_rows["near"]["soft_match_rate"] == pytest.approx(0.0)
+    assert all(row["soft_match_rate"] == pytest.approx(0.0) for row in excluded_rows)
+
+
+def test_ineligible_candidates_cannot_receive_positive_adjustment() -> None:
+    rows = _by_candidate(
+        _result(
+            query_tokens=["UNIT", "3"],
+            candidates=[
+                ("winner", ["UNIT", "3"], 10.0),
+                ("ineligible", ["UNIT", "2"], -3.0),
+            ],
+        )
+    )
+
+    assert rows["winner"]["eligible_candidate_count"] == 1
+    assert rows["winner"]["contextual_adjustment"] == pytest.approx(0.0)
+    assert not rows["ineligible"]["is_contextually_eligible"]
+    assert rows["ineligible"]["contextual_adjustment"] <= 0.0
+
+
+def test_support_advantage_blocks_positive_lift_for_non_b_candidate() -> None:
+    ungated_rows = _by_candidate(
+        _result(
+            query_tokens=["UNIT", "3", "WESTGATE"],
+            candidates=[
+                ("b-winner", ["UNIT", "2", "WESTGATE"], 11.0),
+                ("contextual-rival", ["UNIT", "3", "WESTGATE"], 10.0),
+            ],
+        )
+    )
+    gated_rows = _by_candidate(
+        _result(
+            query_tokens=["UNIT", "3", "WESTGATE"],
+            candidates=[
+                ("b-winner", ["UNIT", "2", "WESTGATE"], 11.0),
+                ("contextual-rival", ["UNIT", "3", "WESTGATE"], 10.0),
+            ],
+            config=replace(PRECISION_K3_CONFIG, minimum_support_advantage=1.1),
+        )
+    )
+
+    assert ungated_rows["contextual-rival"]["contextual_adjustment"] > 0.0
+    assert gated_rows["contextual-rival"]["contextual_adjustment"] == pytest.approx(0.0)
+
+
+def test_soft_matching_telemetry_counts_each_workload_stage() -> None:
+    telemetry: dict[str, float | int] = {}
+
+    _result(
+        query_tokens=["WESGATE"],
+        candidates=[("near", ["WESTGATE"], 10.0)],
+        telemetry=telemetry,
+    )
+
+    assert telemetry["soft_residual_pairs_considered"] == 1
+    assert telemetry["soft_jaro_winkler_pairs_evaluated"] == 1
+    assert telemetry["soft_threshold_pairs"] == 1
+
+
+def test_pair_deduplication_and_candidate_order_do_not_change_scores() -> None:
+    candidates = [
+        ("unit-2", ["UNIT", "2", "WESTGATE"], 10.0),
+        ("unit-3", ["UNIT", "3", "WESTGATE"], 10.0),
+    ]
+    ordered = _by_candidate(
+        _result(query_tokens=["UNIT", "3", "WESTGATE"], candidates=candidates)
+    )
+    reordered = _by_candidate(
+        _result(
+            query_tokens=["UNIT", "3", "WESTGATE"],
+            candidates=list(reversed(candidates)),
+        )
+    )
+    duplicated = _by_candidate(
+        _result(
+            query_tokens=["UNIT", "3", "3", "WESTGATE"],
+            candidates=candidates + [candidates[1]],
+        )
+    )
+
+    for candidate_id in ordered:
+        assert ordered[candidate_id]["contextual_match_weight"] == pytest.approx(
+            reordered[candidate_id]["contextual_match_weight"]
+        )
+        assert ordered[candidate_id]["contextual_match_weight"] == pytest.approx(
+            duplicated[candidate_id]["contextual_match_weight"]
+        )
+        assert duplicated[candidate_id]["phase1_score"] == pytest.approx(
+            duplicated[candidate_id]["splink_match_weight"]
+            + duplicated[candidate_id]["mw_adjustment"]
+        )
+
+
+def test_contextual_base_score_selects_combined_or_splink_only_mode() -> None:
+    con = duckdb.connect(database=":memory:")
+    try:
+        relation = _predictions(
+            con,
+            query_tokens=["UNIT", "3"],
+            candidates=[
+                ("phase1-winner", ["UNIT", "2"], 10.0),
+                ("splink-winner", ["UNIT", "3"], 11.0),
+            ],
+            phase1_scores={"phase1-winner": 12.0, "splink-winner": 11.0},
+        )
+        combined_relation = improve_predictions_using_contextual_residuals(
+            df_predict=relation,
+            con=con,
+            config=PRECISION_K3_CONFIG,
+        )
+        combined = combined_relation.fetchall()
+        contextual_only_relation = improve_predictions_using_contextual_residuals(
+            df_predict=relation,
+            con=con,
+            config=PRECISION_K3_CONFIG,
+            contextual_base_score="splink_match_weight",
+        )
+        contextual_only = contextual_only_relation.fetchall()
+
+        combined_rows = [dict(zip(combined_relation.columns, row)) for row in combined]
+        contextual_only_rows = [
+            dict(zip(contextual_only_relation.columns, row)) for row in contextual_only
+        ]
+        for row in combined_rows:
+            assert row["contextual_match_weight"] - row[
+                "contextual_adjustment"
+            ] == pytest.approx(row["phase1_score"])
+        for row in contextual_only_rows:
+            assert row["contextual_match_weight"] - row[
+                "contextual_adjustment"
+            ] == pytest.approx(row["splink_match_weight"])
+    finally:
+        con.close()
+
+
+def test_production_mode_omits_diagnostics_and_cleans_intermediate_tables() -> None:
+    con = duckdb.connect(database=":memory:")
+    try:
+        relation = _predictions(
+            con,
+            query_tokens=["UNIT", "3"],
+            candidates=[
+                ("unit-2", ["UNIT", "2"], 10.0),
+                ("unit-3", ["UNIT", "3"], 10.0),
+            ],
+        )
+        result = improve_predictions_using_contextual_residuals(
+            df_predict=relation,
+            con=con,
+        )
+
+        assert "consensus_query_tokens" not in result.columns
+        remaining_tables = con.sql("""
+            SELECT table_name
+            FROM duckdb_tables()
+            WHERE table_name LIKE '__ukam__contextual_%'
+        """).fetchall()
+        assert remaining_tables == [("__ukam__contextual_final",)]
+    finally:
+        con.close()
+
+
+def test_maximum_contextual_acceptance_lift_requires_both_thresholds() -> None:
+    con = duckdb.connect(database=":memory:")
+    try:
+        acceptance_lift_filter = _contextual_acceptance_lift_filter(
+            final_match_weight_threshold=10.0,
+            maximum_acceptance_lift=2.0,
+        )
+        accepted = con.sql(f"""
+            SELECT candidate_id
+            FROM (
+                VALUES
+                    ('allowed-lift', 8.5, 10.1),
+                    ('excessive-lift', 7.9, 11.0),
+                    ('below-final-threshold', 8.5, 9.9)
+            ) AS best_match(candidate_id, phase1_score, match_weight)
+            WHERE best_match.match_weight >= 10.0
+            {acceptance_lift_filter}
+        """).fetchall()
+
+        assert accepted == [("allowed-lift",)]
+    finally:
+        con.close()

--- a/tests/test_flat_matching.py
+++ b/tests/test_flat_matching.py
@@ -609,3 +609,43 @@ def test_sub_premise_location_discrimination_in_reranker():
         "Expected the positional conflict to demote the LEFT sibling by ~one penalty; "
         f"got gap={mw_missing - mw_left:.3f}."
     )
+
+
+def test_reranker_treats_standalone_rear_as_an_ordinary_token():
+    con = duckdb.connect()
+    try:
+        df_predict = con.sql("""
+            SELECT *
+            FROM (
+                VALUES
+                    ('c_rear', 'm_rear', 1, 1, 'REAR 10 HIGH STREET',
+                     'REAR 10 HIGH STREET', 0.0),
+                    ('c_front', 'm_rear', 2, 1, 'FRONT 10 HIGH STREET',
+                     'REAR 10 HIGH STREET', 0.0)
+            ) AS candidates(
+                unique_id_l, unique_id_r, ukam_address_id_l, ukam_address_id_r,
+                clean_full_address_l, clean_full_address_r, match_weight
+            )
+        """).project("""
+            *,
+            0.5 AS match_probability,
+            clean_full_address_l AS original_address_concat_l,
+            clean_full_address_r AS original_address_concat_r,
+            'E1 6AA' AS postcode_l,
+            'E1 6AA' AS postcode_r,
+            MAP([]::VARCHAR[], []::BIGINT[]) AS common_end_tokens_hist_r
+        """)
+
+        results = (
+            improve_predictions_using_distinguishing_tokens(
+                df_predict=df_predict,
+                con=con,
+                match_weight_threshold=-100,
+            )
+            .df()
+            .set_index("unique_id_l")
+        )
+
+        assert results.loc["c_front", "match_weight"] > -6.0
+    finally:
+        con.close()

--- a/tests/test_post_linkage_metrics.py
+++ b/tests/test_post_linkage_metrics.py
@@ -95,17 +95,17 @@ def test_best_matches_with_distinguishability_uses_distinct_canonical_candidates
                 (
                     'U1', 'M1', 101, 1,
                     '10 HIGH STREET', 'AA1 1AA',
-                    10.0, 0.0
+                    10.0, 0.0, NULL, 'source-1'
                 ),
                 (
                     'U1', 'M1', 102, 1,
                     '10 HIGH STREET ANNEX', 'AA1 1AA',
-                    9.8, 0.0
+                    9.8, 0.0, NULL, 'source-1'
                 ),
                 (
                     'U2', 'M1', 201, 1,
                     '12 HIGH STREET', 'AA1 1AA',
-                    8.0, 0.0
+                    8.0, 0.0, NULL, 'source-1'
                 )
         ) AS t(
             unique_id_l,
@@ -115,7 +115,9 @@ def test_best_matches_with_distinguishability_uses_distinct_canonical_candidates
             original_address_concat_l,
             postcode_l,
             match_weight,
-            mw_adjustment
+            mw_adjustment,
+            ukam_reranker_audit_source_unique_id_l,
+            ukam_reranker_audit_source_unique_id_r
         )
         """
     )
@@ -138,6 +140,7 @@ def test_best_matches_with_distinguishability_uses_distinct_canonical_candidates
         df_predict=df_predict,
         df_addresses_to_match=df_addresses_to_match,
         con=con,
+        additional_columns_to_retain=["ukam_reranker_audit_source_unique_id"],
     ).df()
 
     assert len(result) == 1
@@ -146,6 +149,7 @@ def test_best_matches_with_distinguishability_uses_distinct_canonical_candidates
     assert result.loc[0, "match_weight"] == pytest.approx(10.0)
     assert result.loc[0, "distinguishability"] == pytest.approx(2.0)
     assert result.loc[0, "candidate_rank"] == 1
+    assert result.loc[0, "ukam_reranker_audit_source_unique_id_r"] == "source-1"
 
 
 def test_best_matches_with_distinguishability_uses_consistent_top_row_when_tied():

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -4,10 +4,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
 from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
-from uk_address_matcher.post_linkage.contextual_residual_reranker import (
-    PRECISION_K3_CONFIG,
-    ContextualRerankerConfig,
-)
 
 if TYPE_CHECKING:
     import duckdb
@@ -65,6 +61,8 @@ class SplinkStage(MatchingStage):
             use the library defaults.
         retain_intermediate_calculation_columns: Retain Splink comparison
             columns needed for debugging and waterfall charts.
+        use_contextual_reranker: Whether to apply the default contextual residual
+            reranker after token-based score adjustment.
     """
 
     # Prediction threshold for initial Splink predict() call
@@ -74,9 +72,7 @@ class SplinkStage(MatchingStage):
     improve_threshold_match_weight: float = -20
     improve_top_n_matches: int = 5
     improve_use_bigrams: bool = True
-    contextual_reranker_config: ContextualRerankerConfig = field(
-        default=PRECISION_K3_CONFIG
-    )
+    use_contextual_reranker: bool = True
 
     # Thresholds for final candidate selection
     final_match_weight_threshold: float = -20.0
@@ -115,6 +111,7 @@ class SplinkStage(MatchingStage):
             best_matches_with_distinguishability,
         )
         from uk_address_matcher.post_linkage.contextual_residual_reranker import (
+            contextual_acceptance_lift_filter,
             improve_predictions_using_contextual_residuals,
         )
         from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
@@ -171,11 +168,11 @@ class SplinkStage(MatchingStage):
             use_bigrams=self.improve_use_bigrams,
             additional_columns_to_retain=self.additional_columns_to_retain,
         )
-        df_improved = improve_predictions_using_contextual_residuals(
-            df_predict=df_improved,
-            con=con,
-            config=self.contextual_reranker_config,
-        )
+        if self.use_contextual_reranker:
+            df_improved = improve_predictions_using_contextual_residuals(
+                df_predict=df_improved,
+                con=con,
+            )
         self.improved_predictions_table = getattr(df_improved, "alias", None)
 
         # Step 4: Compute distinguishability and select best match per record
@@ -202,13 +199,9 @@ class SplinkStage(MatchingStage):
             )
 
         acceptance_lift_filter = ""
-        if self.contextual_reranker_config.maximum_acceptance_lift is not None:
-            minimum_phase1_score = (
+        if self.use_contextual_reranker:
+            acceptance_lift_filter = contextual_acceptance_lift_filter(
                 self.final_match_weight_threshold
-                - self.contextual_reranker_config.maximum_acceptance_lift
-            )
-            acceptance_lift_filter = (
-                f"AND best_match.phase1_score >= {minimum_phase1_score}"
             )
 
         return con.sql(f"""

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -4,19 +4,16 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
 from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
+from uk_address_matcher.post_linkage.contextual_residual_reranker import (
+    PRECISION_K3_CONFIG,
+    ContextualRerankerConfig,
+)
 
 if TYPE_CHECKING:
     import duckdb
     from splink import SettingsCreator
 
     from uk_address_matcher.sql_pipeline.runner import DebugOptions
-
-
-def _contextual_acceptance_lift_filter(
-    *, final_match_weight_threshold: float, maximum_acceptance_lift: float
-) -> str:
-    minimum_phase1_score = final_match_weight_threshold - maximum_acceptance_lift
-    return f"AND best_match.phase1_score >= {minimum_phase1_score}"
 
 
 @dataclass(repr=False)
@@ -77,6 +74,9 @@ class SplinkStage(MatchingStage):
     improve_threshold_match_weight: float = -20
     improve_top_n_matches: int = 5
     improve_use_bigrams: bool = True
+    contextual_reranker_config: ContextualRerankerConfig = field(
+        default=PRECISION_K3_CONFIG
+    )
 
     # Thresholds for final candidate selection
     final_match_weight_threshold: float = -20.0
@@ -110,12 +110,12 @@ class SplinkStage(MatchingStage):
         debug_options: Optional[DebugOptions] = None,
         explain: bool = False,
     ) -> Optional[duckdb.DuckDBPyRelation]:
-        from uk_address_matcher._experimental import (
-            _current_contextual_residual_reranker,
-        )
         from uk_address_matcher.linking_model.splink_model import _get_linker
         from uk_address_matcher.post_linkage.analyse_results import (
             best_matches_with_distinguishability,
+        )
+        from uk_address_matcher.post_linkage.contextual_residual_reranker import (
+            improve_predictions_using_contextual_residuals,
         )
         from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
             improve_predictions_using_distinguishing_tokens,
@@ -171,19 +171,11 @@ class SplinkStage(MatchingStage):
             use_bigrams=self.improve_use_bigrams,
             additional_columns_to_retain=self.additional_columns_to_retain,
         )
-        contextual_config = _current_contextual_residual_reranker()
-        if contextual_config is not None:
-            from uk_address_matcher.post_linkage.contextual_residual_reranker import (
-                improve_predictions_using_contextual_residuals,
-            )
-
-            df_improved = improve_predictions_using_contextual_residuals(
-                df_predict=df_improved,
-                con=con,
-                config=contextual_config.config,
-                contextual_base_score=contextual_config.contextual_base_score,
-                telemetry=contextual_config.telemetry,
-            )
+        df_improved = improve_predictions_using_contextual_residuals(
+            df_predict=df_improved,
+            con=con,
+            config=self.contextual_reranker_config,
+        )
         self.improved_predictions_table = getattr(df_improved, "alias", None)
 
         # Step 4: Compute distinguishability and select best match per record
@@ -209,32 +201,14 @@ class SplinkStage(MatchingStage):
                 f"OR distinguishability >= {self.final_distinguishability_threshold})"
             )
 
-        threshold_score = (
-            "best_match.phase1_score"
-            if (
-                contextual_config is not None
-                and contextual_config.apply_final_threshold_to_phase1_score
-            )
-            else "best_match.match_weight"
-        )
-        emitted_score = (
-            "best_match.phase1_score"
-            if (
-                contextual_config is not None
-                and contextual_config.apply_final_threshold_to_phase1_score
-            )
-            else "best_match.match_weight"
-        )
         acceptance_lift_filter = ""
-        if (
-            contextual_config is not None
-            and contextual_config.config.maximum_acceptance_lift is not None
-        ):
-            acceptance_lift_filter = _contextual_acceptance_lift_filter(
-                final_match_weight_threshold=self.final_match_weight_threshold,
-                maximum_acceptance_lift=(
-                    contextual_config.config.maximum_acceptance_lift
-                ),
+        if self.contextual_reranker_config.maximum_acceptance_lift is not None:
+            minimum_phase1_score = (
+                self.final_match_weight_threshold
+                - self.contextual_reranker_config.maximum_acceptance_lift
+            )
+            acceptance_lift_filter = (
+                f"AND best_match.phase1_score >= {minimum_phase1_score}"
             )
 
         return con.sql(f"""
@@ -243,14 +217,14 @@ class SplinkStage(MatchingStage):
                 best_match.unique_id_l AS resolved_canonical_id,
                 best_match.ukam_address_id_l AS canonical_ukam_address_id,
                 '{splink_label}' AS match_reason,
-                {emitted_score} AS match_weight,
+                best_match.match_weight,
                 best_match.distinguishability
             FROM (
                 SELECT *
                 FROM {df_best_name}
                 WHERE candidate_rank = 1
             ) AS best_match
-            WHERE {threshold_score} >= {self.final_match_weight_threshold}
+            WHERE best_match.match_weight >= {self.final_match_weight_threshold}
             {acceptance_lift_filter}
             {dist_filter}
             AND best_match.unique_id_l IS NOT NULL

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -12,6 +12,13 @@ if TYPE_CHECKING:
     from uk_address_matcher.sql_pipeline.runner import DebugOptions
 
 
+def _contextual_acceptance_lift_filter(
+    *, final_match_weight_threshold: float, maximum_acceptance_lift: float
+) -> str:
+    minimum_phase1_score = final_match_weight_threshold - maximum_acceptance_lift
+    return f"AND best_match.phase1_score >= {minimum_phase1_score}"
+
+
 @dataclass(repr=False)
 class SplinkStage(MatchingStage):
     """Probabilistic matching stage built on Splink.
@@ -103,6 +110,9 @@ class SplinkStage(MatchingStage):
         debug_options: Optional[DebugOptions] = None,
         explain: bool = False,
     ) -> Optional[duckdb.DuckDBPyRelation]:
+        from uk_address_matcher._experimental import (
+            _current_contextual_residual_reranker,
+        )
         from uk_address_matcher.linking_model.splink_model import _get_linker
         from uk_address_matcher.post_linkage.analyse_results import (
             best_matches_with_distinguishability,
@@ -161,6 +171,19 @@ class SplinkStage(MatchingStage):
             use_bigrams=self.improve_use_bigrams,
             additional_columns_to_retain=self.additional_columns_to_retain,
         )
+        contextual_config = _current_contextual_residual_reranker()
+        if contextual_config is not None:
+            from uk_address_matcher.post_linkage.contextual_residual_reranker import (
+                improve_predictions_using_contextual_residuals,
+            )
+
+            df_improved = improve_predictions_using_contextual_residuals(
+                df_predict=df_improved,
+                con=con,
+                config=contextual_config.config,
+                contextual_base_score=contextual_config.contextual_base_score,
+                telemetry=contextual_config.telemetry,
+            )
         self.improved_predictions_table = getattr(df_improved, "alias", None)
 
         # Step 4: Compute distinguishability and select best match per record
@@ -186,20 +209,49 @@ class SplinkStage(MatchingStage):
                 f"OR distinguishability >= {self.final_distinguishability_threshold})"
             )
 
+        threshold_score = (
+            "best_match.phase1_score"
+            if (
+                contextual_config is not None
+                and contextual_config.apply_final_threshold_to_phase1_score
+            )
+            else "best_match.match_weight"
+        )
+        emitted_score = (
+            "best_match.phase1_score"
+            if (
+                contextual_config is not None
+                and contextual_config.apply_final_threshold_to_phase1_score
+            )
+            else "best_match.match_weight"
+        )
+        acceptance_lift_filter = ""
+        if (
+            contextual_config is not None
+            and contextual_config.config.maximum_acceptance_lift is not None
+        ):
+            acceptance_lift_filter = _contextual_acceptance_lift_filter(
+                final_match_weight_threshold=self.final_match_weight_threshold,
+                maximum_acceptance_lift=(
+                    contextual_config.config.maximum_acceptance_lift
+                ),
+            )
+
         return con.sql(f"""
             SELECT
                 best_match.ukam_address_id_r AS ukam_address_id,
                 best_match.unique_id_l AS resolved_canonical_id,
                 best_match.ukam_address_id_l AS canonical_ukam_address_id,
                 '{splink_label}' AS match_reason,
-                best_match.match_weight,
+                {emitted_score} AS match_weight,
                 best_match.distinguishability
             FROM (
                 SELECT *
                 FROM {df_best_name}
                 WHERE candidate_rank = 1
             ) AS best_match
-            WHERE best_match.match_weight >= {self.final_match_weight_threshold}
+            WHERE {threshold_score} >= {self.final_match_weight_threshold}
+            {acceptance_lift_filter}
             {dist_filter}
             AND best_match.unique_id_l IS NOT NULL
         """)

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -117,9 +117,6 @@ class SplinkStage(MatchingStage):
         from uk_address_matcher.post_linkage.analyse_results import (
             best_matches_with_distinguishability,
         )
-        from uk_address_matcher.post_linkage.distinguishing_features import (
-            relation_markers,
-        )
         from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
             improve_predictions_using_distinguishing_tokens,
         )

--- a/uk_address_matcher/post_linkage/analyse_results.py
+++ b/uk_address_matcher/post_linkage/analyse_results.py
@@ -92,6 +92,10 @@ def best_matches_with_distinguishability(
     if "ukam_label_r" in df_predict.columns:
         add_cols_select += "t.ukam_label_r, "
 
+    phase1_score_select = (
+        "t.phase1_score" if "phase1_score" in df_predict.columns else "NULL"
+    )
+
     if 0 not in distinguishability_thresholds:
         distinguishability_thresholds.append(0)
     thres_sorted = sorted(distinguishability_thresholds, reverse=True)
@@ -165,7 +169,7 @@ def best_matches_with_distinguishability(
         t.original_address_concat_l,
         t.postcode_l,
         t.match_weight,
-        t.phase1_score,
+        {phase1_score_select} AS phase1_score,
         t.distinguishability,
         t.candidate_rank,
         COALESCE(

--- a/uk_address_matcher/post_linkage/analyse_results.py
+++ b/uk_address_matcher/post_linkage/analyse_results.py
@@ -165,6 +165,7 @@ def best_matches_with_distinguishability(
         t.original_address_concat_l,
         t.postcode_l,
         t.match_weight,
+        t.phase1_score,
         t.distinguishability,
         t.candidate_rank,
         COALESCE(

--- a/uk_address_matcher/post_linkage/contextual_residual_reranker.py
+++ b/uk_address_matcher/post_linkage/contextual_residual_reranker.py
@@ -38,6 +38,14 @@ class ContextualRerankerConfig:
 PRECISION_K3_CONFIG = ContextualRerankerConfig()
 
 
+def contextual_acceptance_lift_filter(final_match_weight_threshold: float) -> str:
+    """Return the final-stage filter for the default contextual reranker."""
+    minimum_phase1_score = (
+        final_match_weight_threshold - PRECISION_K3_CONFIG.maximum_acceptance_lift
+    )
+    return f"AND best_match.phase1_score >= {minimum_phase1_score}"
+
+
 def improve_predictions_using_contextual_residuals(
     *,
     df_predict: DuckDBPyRelation,

--- a/uk_address_matcher/post_linkage/contextual_residual_reranker.py
+++ b/uk_address_matcher/post_linkage/contextual_residual_reranker.py
@@ -1,0 +1,975 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+from typing import TYPE_CHECKING
+
+from duckdb import DuckDBPyConnection, DuckDBPyRelation
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+    ContextualTelemetry = MutableMapping[str, float | int]
+
+
+@dataclass(frozen=True)
+class ContextualRerankerConfig:
+    absolute_splink_floor: float = -20.0
+    maximum_splink_gap: float = 12.0
+    consensus_threshold: float = 0.60
+    local_frequency_smoothing: float = 0.50
+    candidate_support_weight: float = 2.25
+    rival_omission_weight: float = 1.75
+    contrast_weight: float = 0.25
+    split_join_weight: float = 2.00
+    soft_match_weight: float = 1.75
+    contextual_multiplier: float = 1.75
+    contextual_cap: float = 4.00
+    minimum_support_advantage: float = 0.50
+    minimum_candidate_support: float = 0.75
+    evidence_sufficiency_target: float = 0.50
+    soft_match_threshold: float = 0.90
+    maximum_acceptance_lift: float = 2.00
+    use_split_join: bool = True
+    use_soft_matching: bool = True
+    include_diagnostics: bool = False
+
+
+PRECISION_K3_CONFIG = ContextualRerankerConfig()
+
+
+def improve_predictions_using_contextual_residuals(
+    *,
+    df_predict: DuckDBPyRelation,
+    con: DuckDBPyConnection,
+    config: ContextualRerankerConfig = PRECISION_K3_CONFIG,
+    contextual_base_score: str = "phase1_score",
+    telemetry: ContextualTelemetry | None = None,
+) -> DuckDBPyRelation:
+    """
+    The input is the output of ``improve_predictions_using_distinguishing_tokens``.
+    Contextual evidence is centred within a raw-Splink-eligible candidate group
+    and is never global IDF.
+    """
+    if contextual_base_score not in {"phase1_score", "splink_match_weight"}:
+        raise ValueError(
+            "contextual_base_score must be 'phase1_score' or 'splink_match_weight'"
+        )
+
+    absolute_splink_floor = config.absolute_splink_floor
+    maximum_splink_gap = config.maximum_splink_gap
+    consensus_threshold = config.consensus_threshold
+    local_frequency_smoothing = config.local_frequency_smoothing
+    candidate_support_weight = config.candidate_support_weight
+    rival_omission_weight = config.rival_omission_weight
+    contrast_weight = config.contrast_weight
+    split_join_weight = config.split_join_weight
+    soft_match_weight = config.soft_match_weight
+    contextual_multiplier = config.contextual_multiplier
+    contextual_cap = config.contextual_cap
+    minimum_support_advantage = config.minimum_support_advantage
+    minimum_candidate_support = config.minimum_candidate_support
+    evidence_sufficiency_target = config.evidence_sufficiency_target
+    soft_match_threshold = config.soft_match_threshold
+    use_split_join = config.use_split_join
+    use_soft_matching = config.use_soft_matching
+    started_at = perf_counter()
+    required_columns = {
+        "unique_id_l",
+        "unique_id_r",
+        "ukam_address_id_l",
+        "ukam_address_id_r",
+        "tokens_l",
+        "tokens_r",
+        "splink_match_weight",
+        "phase1_score",
+    }
+    missing_columns = sorted(required_columns.difference(df_predict.columns))
+    if missing_columns:
+        raise ValueError(
+            "Contextual residual reranking requires columns: "
+            + ", ".join(missing_columns)
+        )
+
+    tables = {
+        "input": "__ukam__contextual_input",
+        "candidate_scope": "__ukam__contextual_candidate_scope",
+        "query_tokens_raw": "__ukam__contextual_query_tokens_raw",
+        "query_tokens": "__ukam__contextual_query_tokens",
+        "candidate_tokens_raw": "__ukam__contextual_candidate_tokens_raw",
+        "candidate_tokens": "__ukam__contextual_candidate_tokens",
+        "query_joined": "__ukam__contextual_query_joined_tokens",
+        "candidate_joined": "__ukam__contextual_candidate_joined_tokens",
+        "exact": "__ukam__contextual_exact_matches",
+        "split_join": "__ukam__contextual_split_join_matches",
+        "soft_candidates": "__ukam__contextual_soft_candidates",
+        "soft_scored": "__ukam__contextual_soft_scored",
+        "soft_qualified": "__ukam__contextual_soft_qualified",
+        "soft": "__ukam__contextual_soft_matches",
+        "matches": "__ukam__contextual_token_matches",
+        "query_statistics": "__ukam__contextual_query_statistics",
+        "candidate_statistics": "__ukam__contextual_candidate_statistics",
+        "pair_strength": "__ukam__contextual_pair_query_strength",
+        "pair_rival": "__ukam__contextual_pair_query_rival_strength",
+        "candidate_support": "__ukam__contextual_candidate_support",
+        "features": "__ukam__contextual_features",
+        "scored": "__ukam__contextual_scored",
+        "diagnostics": "__ukam__contextual_diagnostics",
+        "final": "__ukam__contextual_final",
+    }
+
+    for table_name in tables.values():
+        con.execute(f"DROP TABLE IF EXISTS {table_name}")
+
+    minimum_support_advantage_condition = "TRUE"
+    if minimum_support_advantage is not None:
+        minimum_support_advantage_condition = f"""
+            scored.candidate_id = scored.reference_winner_candidate_id
+            OR scored.candidate_residual_support
+                - scored.reference_winner_residual_support >= {minimum_support_advantage}
+        """
+    minimum_candidate_support_condition = "TRUE"
+    if minimum_candidate_support is not None:
+        minimum_candidate_support_condition = (
+            f"scored.candidate_residual_support >= {minimum_candidate_support}"
+        )
+
+    con.execute(
+        f"CREATE TEMP TABLE {tables['input']} AS "
+        f"SELECT * FROM ({df_predict.sql_query()}) AS predictions"
+    )
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["candidate_scope"]} AS
+        WITH deduplicated AS (
+            SELECT
+                input.*,
+                ROW_NUMBER() OVER (
+                    PARTITION BY ukam_address_id_r, ukam_address_id_l
+                    ORDER BY {contextual_base_score} DESC, unique_id_l, unique_id_r
+                ) AS pair_row_number
+            FROM {tables["input"]} AS input
+        ),
+        raw_scope AS (
+            SELECT
+                * EXCLUDE (pair_row_number),
+                MAX(splink_match_weight) OVER (
+                    PARTITION BY ukam_address_id_r
+                ) AS best_splink_match_weight
+            FROM deduplicated
+            WHERE pair_row_number = 1
+        ),
+        eligibility AS (
+            SELECT
+                *,
+                splink_match_weight - best_splink_match_weight AS splink_gap_from_best,
+                splink_match_weight >= {absolute_splink_floor}
+                    AND splink_match_weight >=
+                        best_splink_match_weight - {maximum_splink_gap}
+                    AS is_contextually_eligible
+            FROM raw_scope
+        )
+        SELECT
+            *,
+            COUNT(*) FILTER (WHERE is_contextually_eligible) OVER (
+                PARTITION BY ukam_address_id_r
+            ) AS eligible_candidate_count
+        FROM eligibility
+    """)
+
+    token_class = """
+        CASE
+            WHEN regexp_full_match(token, '^[A-Z]+$') THEN 'alphabetic'
+            WHEN regexp_full_match(token, '^[0-9]+$') THEN 'numeric'
+            ELSE 'mixed_alphanumeric'
+        END
+    """
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["query_tokens_raw"]} AS
+        WITH source_lists AS (
+            SELECT
+                ukam_address_id_r AS query_id,
+                tokens_r,
+                ROW_NUMBER() OVER (
+                    PARTITION BY ukam_address_id_r
+                    ORDER BY unique_id_r, ukam_address_id_l
+                ) AS source_row_number
+            FROM {tables["candidate_scope"]}
+        )
+        SELECT
+            source_lists.query_id,
+            token AS query_token,
+            token_position AS query_token_position,
+            {token_class.replace("token", "token")} AS query_token_class
+        FROM source_lists,
+            UNNEST(tokens_r) WITH ORDINALITY AS unnested(token, token_position)
+        WHERE source_row_number = 1
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["query_tokens"]} AS
+        SELECT
+            query_id,
+            query_token,
+            MIN(query_token_position) AS query_token_position,
+            ANY_VALUE(query_token_class) AS query_token_class
+        FROM {tables["query_tokens_raw"]}
+        GROUP BY query_id, query_token
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["candidate_tokens_raw"]} AS
+        SELECT
+            ukam_address_id_r AS query_id,
+            ukam_address_id_l AS candidate_id,
+            token AS candidate_token,
+            token_position AS candidate_token_position,
+            {token_class.replace("token", "token")} AS candidate_token_class,
+            is_contextually_eligible
+        FROM {tables["candidate_scope"]},
+            UNNEST(tokens_l) WITH ORDINALITY AS unnested(token, token_position)
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["candidate_tokens"]} AS
+        SELECT
+            query_id,
+            candidate_id,
+            candidate_token,
+            MIN(candidate_token_position) AS candidate_token_position,
+            ANY_VALUE(candidate_token_class) AS candidate_token_class,
+            ANY_VALUE(is_contextually_eligible) AS is_contextually_eligible
+        FROM {tables["candidate_tokens_raw"]}
+        GROUP BY query_id, candidate_id, candidate_token
+    """)
+    joined_class = """
+        CASE
+            WHEN regexp_full_match(joined_token, '^[A-Z]+$') THEN 'alphabetic'
+            WHEN regexp_full_match(joined_token, '^[0-9]+$') THEN 'numeric'
+            ELSE 'mixed_alphanumeric'
+        END
+    """
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["query_joined"]} AS
+        WITH adjacent AS (
+            SELECT
+                query_id,
+                query_token_position AS first_position,
+                LEAD(query_token_position) OVER source_window AS second_position,
+                query_token AS first_token,
+                LEAD(query_token) OVER source_window AS second_token,
+                query_token_class AS first_token_class,
+                LEAD(query_token_class) OVER source_window AS second_token_class
+            FROM {tables["query_tokens_raw"]}
+            WINDOW source_window AS (
+                PARTITION BY query_id ORDER BY query_token_position
+            )
+        )
+        SELECT
+            query_id,
+            first_position,
+            second_position,
+            first_token || second_token AS joined_token,
+            {joined_class} AS joined_token_class,
+            first_token_class,
+            second_token_class
+        FROM adjacent
+        WHERE second_position = first_position + 1
+          AND NOT (
+              first_token_class = 'numeric' AND second_token_class = 'numeric'
+          )
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["candidate_joined"]} AS
+        WITH adjacent AS (
+            SELECT
+                query_id,
+                candidate_id,
+                candidate_token_position AS first_position,
+                LEAD(candidate_token_position) OVER candidate_window AS second_position,
+                candidate_token AS first_token,
+                LEAD(candidate_token) OVER candidate_window AS second_token,
+                candidate_token_class AS first_token_class,
+                LEAD(candidate_token_class) OVER candidate_window AS second_token_class,
+                is_contextually_eligible
+            FROM {tables["candidate_tokens_raw"]}
+            WINDOW candidate_window AS (
+                PARTITION BY query_id, candidate_id ORDER BY candidate_token_position
+            )
+        )
+        SELECT
+            query_id,
+            candidate_id,
+            first_position,
+            second_position,
+            first_token || second_token AS joined_token,
+            {joined_class} AS joined_token_class,
+            first_token_class,
+            second_token_class,
+            is_contextually_eligible
+        FROM adjacent
+        WHERE second_position = first_position + 1
+          AND NOT (
+              first_token_class = 'numeric' AND second_token_class = 'numeric'
+          )
+    """)
+
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["exact"]} AS
+        SELECT
+            query.query_id,
+            candidate.candidate_id,
+            query.query_token,
+            query.query_token_position,
+            candidate.candidate_token,
+            candidate.candidate_token_position,
+            1.0::DOUBLE AS match_strength,
+            'exact' AS match_mechanism,
+            1 AS mechanism_precedence
+        FROM {tables["query_tokens"]} AS query
+        JOIN {tables["candidate_tokens"]} AS candidate
+            ON candidate.query_id = query.query_id
+           AND candidate.candidate_token = query.query_token
+    """)
+
+    if use_split_join:
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["split_join"]} AS
+            WITH proposals AS (
+                SELECT
+                    query.query_id,
+                    joined.candidate_id,
+                    query.query_token,
+                    query.query_token_position,
+                    joined.joined_token AS candidate_token,
+                    joined.first_position AS candidate_token_position,
+                    0.95::DOUBLE AS match_strength,
+                    'split_join' AS match_mechanism,
+                    2 AS mechanism_precedence
+                FROM {tables["query_tokens"]} AS query
+                JOIN {tables["candidate_joined"]} AS joined
+                    ON joined.query_id = query.query_id
+                   AND joined.joined_token = query.query_token
+                   AND (
+                       (query.query_token_class = 'alphabetic'
+                        AND joined.first_token_class = 'alphabetic'
+                        AND joined.second_token_class = 'alphabetic')
+                       OR (query.query_token_class = 'mixed_alphanumeric'
+                           AND (
+                               (joined.first_token_class = 'alphabetic'
+                                AND joined.second_token_class = 'numeric')
+                               OR (joined.first_token_class = 'numeric'
+                                   AND joined.second_token_class = 'alphabetic')
+                           ))
+                   )
+                UNION ALL
+                SELECT
+                    joined.query_id,
+                    candidate.candidate_id,
+                    joined.joined_token AS query_token,
+                    joined.first_position AS query_token_position,
+                    candidate.candidate_token,
+                    candidate.candidate_token_position,
+                    0.95::DOUBLE AS match_strength,
+                    'split_join' AS match_mechanism,
+                    2 AS mechanism_precedence
+                FROM {tables["query_joined"]} AS joined
+                JOIN {tables["candidate_tokens"]} AS candidate
+                    ON candidate.query_id = joined.query_id
+                   AND candidate.candidate_token = joined.joined_token
+                   AND (
+                       (candidate.candidate_token_class = 'alphabetic'
+                        AND joined.first_token_class = 'alphabetic'
+                        AND joined.second_token_class = 'alphabetic')
+                       OR (candidate.candidate_token_class = 'mixed_alphanumeric'
+                           AND (
+                               (joined.first_token_class = 'alphabetic'
+                                AND joined.second_token_class = 'numeric')
+                               OR (joined.first_token_class = 'numeric'
+                                   AND joined.second_token_class = 'alphabetic')
+                           ))
+                   )
+            ),
+            residual_proposals AS (
+                SELECT proposals.*
+                FROM proposals
+                LEFT JOIN {tables["exact"]} AS exact
+                    ON exact.query_id = proposals.query_id
+                   AND exact.candidate_id = proposals.candidate_id
+                   AND exact.query_token_position = proposals.query_token_position
+                WHERE exact.query_id IS NULL
+            )
+            SELECT *
+            FROM residual_proposals
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY query_id, candidate_id, query_token_position
+                ORDER BY candidate_token, candidate_token_position
+            ) = 1
+        """)
+    else:
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["split_join"]} AS
+            SELECT * FROM {tables["exact"]} WHERE FALSE
+        """)
+
+    if use_soft_matching:
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft_candidates"]} AS
+            WITH residual_query_tokens AS (
+                SELECT query.*
+                FROM {tables["query_tokens"]} AS query
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM (
+                        SELECT query_id, query_token_position FROM {tables["exact"]}
+                        UNION
+                        SELECT query_id, query_token_position FROM {tables["split_join"]}
+                    ) AS explained
+                    WHERE explained.query_id = query.query_id
+                      AND explained.query_token_position = query.query_token_position
+                )
+            ),
+            residual_candidate_tokens AS (
+                SELECT candidate.*
+                FROM {tables["candidate_tokens"]} AS candidate
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM (
+                        SELECT query_id, candidate_id, candidate_token_position
+                        FROM {tables["exact"]}
+                        UNION
+                        SELECT query_id, candidate_id, candidate_token_position
+                        FROM {tables["split_join"]}
+                    ) AS explained
+                    WHERE explained.query_id = candidate.query_id
+                      AND explained.candidate_id = candidate.candidate_id
+                                            AND explained.candidate_token_position =
+                                                    candidate.candidate_token_position
+                )
+            )
+            SELECT
+                query.query_id,
+                candidate.candidate_id,
+                query.query_token,
+                query.query_token_position,
+                query.query_token_class,
+                candidate.candidate_token,
+                candidate.candidate_token_position,
+                candidate.candidate_token_class
+            FROM residual_query_tokens AS query
+            JOIN residual_candidate_tokens AS candidate
+                ON candidate.query_id = query.query_id
+               AND query.query_token_class = 'alphabetic'
+               AND candidate.candidate_token_class = 'alphabetic'
+               AND length(query.query_token) >= 5
+               AND length(candidate.candidate_token) >= 5
+               AND abs(
+                   length(query.query_token) - length(candidate.candidate_token)
+               ) <= 3
+        """)
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft_scored"]} AS
+            SELECT
+                query_id,
+                candidate_id,
+                query_token,
+                query_token_position,
+                candidate_token,
+                candidate_token_position,
+                jaro_winkler_similarity(
+                    query_token, candidate_token
+                ) AS match_strength
+            FROM {tables["soft_candidates"]}
+        """)
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft_qualified"]} AS
+            SELECT
+                *,
+                ROW_NUMBER() OVER (
+                    PARTITION BY query_id, candidate_id, query_token_position
+                    ORDER BY match_strength DESC, candidate_token,
+                        candidate_token_position
+                ) AS candidate_token_rank,
+                ROW_NUMBER() OVER (
+                    PARTITION BY query_id, candidate_id, candidate_token_position
+                    ORDER BY match_strength DESC, query_token, query_token_position
+                ) AS query_token_rank
+            FROM {tables["soft_scored"]}
+            WHERE match_strength >= {soft_match_threshold}
+        """)
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft"]} AS
+            SELECT
+                query_id,
+                candidate_id,
+                query_token,
+                query_token_position,
+                candidate_token,
+                candidate_token_position,
+                match_strength,
+                'soft' AS match_mechanism,
+                3 AS mechanism_precedence
+            FROM {tables["soft_qualified"]}
+            WHERE candidate_token_rank = 1
+              AND query_token_rank = 1
+        """)
+    else:
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft_candidates"]} AS
+            SELECT * FROM {tables["exact"]} WHERE FALSE
+        """)
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft_scored"]} AS
+            SELECT * FROM {tables["exact"]} WHERE FALSE
+        """)
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft_qualified"]} AS
+            SELECT * FROM {tables["exact"]} WHERE FALSE
+        """)
+        con.execute(f"""
+            CREATE TEMP TABLE {tables["soft"]} AS
+            SELECT * FROM {tables["exact"]} WHERE FALSE
+        """)
+
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["matches"]} AS
+        SELECT *
+        FROM (
+            SELECT * FROM {tables["exact"]}
+            UNION ALL
+            SELECT * FROM {tables["split_join"]}
+            UNION ALL
+            SELECT * FROM {tables["soft"]}
+        ) AS candidate_matches
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY query_id, candidate_id, query_token_position
+            ORDER BY mechanism_precedence, match_strength DESC,
+                candidate_token, candidate_token_position
+        ) = 1
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["query_statistics"]} AS
+        WITH query_candidate_strength AS (
+            SELECT
+                scope.ukam_address_id_r AS query_id,
+                scope.ukam_address_id_l AS candidate_id,
+                query.query_token,
+                query.query_token_position,
+                COALESCE(matches.match_strength, 0.0) AS candidate_strength,
+                scope.is_contextually_eligible
+            FROM {tables["candidate_scope"]} AS scope
+            JOIN {tables["query_tokens"]} AS query
+                ON query.query_id = scope.ukam_address_id_r
+            LEFT JOIN {tables["matches"]} AS matches
+                ON matches.query_id = scope.ukam_address_id_r
+               AND matches.candidate_id = scope.ukam_address_id_l
+               AND matches.query_token_position = query.query_token_position
+        ),
+        counts AS (
+            SELECT
+                query_id,
+                query_token,
+                query_token_position,
+                MAX(candidate_strength) FILTER (
+                    WHERE is_contextually_eligible
+                ) AS addressability_strength,
+                COUNT(*) FILTER (
+                    WHERE is_contextually_eligible AND candidate_strength > 0
+                ) AS local_candidate_df
+            FROM query_candidate_strength
+            GROUP BY query_id, query_token, query_token_position
+        ),
+        with_group_size AS (
+            SELECT
+                counts.*,
+                MAX(scope.eligible_candidate_count) AS eligible_candidate_count
+            FROM counts
+            JOIN {tables["candidate_scope"]} AS scope
+                ON scope.ukam_address_id_r = counts.query_id
+            GROUP BY ALL
+        )
+        SELECT
+            *,
+            addressability_strength = 0 AS is_unaddressed,
+            local_candidate_df::DOUBLE / NULLIF(eligible_candidate_count, 0)
+                >= {consensus_threshold} AS is_consensus,
+            CASE
+                WHEN addressability_strength = 0 THEN 0.0
+                WHEN local_candidate_df::DOUBLE / NULLIF(eligible_candidate_count, 0)
+                    >= {consensus_threshold} THEN 0.0
+                ELSE ln(
+                    (eligible_candidate_count + {local_frequency_smoothing})
+                    / (local_candidate_df + {local_frequency_smoothing})
+                )
+            END AS local_query_weight
+        FROM with_group_size
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["candidate_statistics"]} AS
+        WITH candidate_document_frequency AS (
+            SELECT
+                candidate.query_id,
+                candidate.candidate_token,
+                COUNT(*) FILTER (WHERE scope.is_contextually_eligible)
+                    AS local_candidate_df,
+                MAX(scope.eligible_candidate_count) AS eligible_candidate_count
+            FROM {tables["candidate_tokens"]} AS candidate
+            JOIN {tables["candidate_scope"]} AS scope
+                ON scope.ukam_address_id_r = candidate.query_id
+               AND scope.ukam_address_id_l = candidate.candidate_id
+            GROUP BY candidate.query_id, candidate.candidate_token
+        )
+        SELECT
+            *,
+            CASE
+                WHEN local_candidate_df::DOUBLE / NULLIF(eligible_candidate_count, 0)
+                    >= {consensus_threshold} THEN 0.0
+                ELSE ln(
+                    (eligible_candidate_count + {local_frequency_smoothing})
+                    / (local_candidate_df + {local_frequency_smoothing})
+                )
+            END AS candidate_residual_weight
+        FROM candidate_document_frequency
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["pair_strength"]} AS
+        SELECT
+            scope.ukam_address_id_r AS query_id,
+            scope.ukam_address_id_l AS candidate_id,
+            query.query_token,
+            query.query_token_position,
+            query.local_query_weight,
+            query.addressability_strength,
+            query.is_unaddressed,
+            query.is_consensus,
+            scope.is_contextually_eligible,
+            COALESCE(matches.match_strength, 0.0) AS candidate_strength,
+            matches.match_mechanism
+        FROM {tables["candidate_scope"]} AS scope
+        JOIN {tables["query_statistics"]} AS query
+            ON query.query_id = scope.ukam_address_id_r
+        LEFT JOIN {tables["matches"]} AS matches
+            ON matches.query_id = scope.ukam_address_id_r
+           AND matches.candidate_id = scope.ukam_address_id_l
+           AND matches.query_token_position = query.query_token_position
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["pair_rival"]} AS
+        WITH eligible_strengths AS (
+            SELECT
+                query_id,
+                query_token_position,
+                candidate_id,
+                candidate_strength,
+                DENSE_RANK() OVER (
+                    PARTITION BY query_id, query_token_position
+                    ORDER BY candidate_strength DESC
+                ) AS strength_rank
+            FROM {tables["pair_strength"]}
+            WHERE is_contextually_eligible
+        ),
+        top_two AS (
+            SELECT
+                query_id,
+                query_token_position,
+                MAX(candidate_strength) FILTER (WHERE strength_rank = 1)
+                    AS highest_strength,
+                COUNT(*) FILTER (WHERE strength_rank = 1)
+                    AS highest_strength_count,
+                MAX(candidate_strength) FILTER (WHERE strength_rank = 2)
+                    AS second_highest_strength
+            FROM eligible_strengths
+            GROUP BY query_id, query_token_position
+        )
+        SELECT
+            current.*,
+            CASE
+                WHEN current.is_contextually_eligible
+                    AND current.candidate_strength = top_two.highest_strength
+                    AND top_two.highest_strength_count = 1
+                    THEN COALESCE(top_two.second_highest_strength, 0.0)
+                ELSE COALESCE(top_two.highest_strength, 0.0)
+            END AS rival_strength
+        FROM {tables["pair_strength"]} AS current
+        LEFT JOIN top_two
+            ON top_two.query_id = current.query_id
+           AND top_two.query_token_position = current.query_token_position
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["candidate_support"]} AS
+        WITH token_support AS (
+            SELECT
+                scope.ukam_address_id_r AS query_id,
+                scope.ukam_address_id_l AS candidate_id,
+                candidate.candidate_token,
+                statistics.candidate_residual_weight,
+                MAX(matches.match_strength) AS best_query_match_strength
+            FROM {tables["candidate_scope"]} AS scope
+            JOIN {tables["candidate_tokens"]} AS candidate
+                ON candidate.query_id = scope.ukam_address_id_r
+               AND candidate.candidate_id = scope.ukam_address_id_l
+            JOIN {tables["candidate_statistics"]} AS statistics
+                ON statistics.query_id = candidate.query_id
+               AND statistics.candidate_token = candidate.candidate_token
+            LEFT JOIN {tables["matches"]} AS matches
+                ON matches.query_id = candidate.query_id
+               AND matches.candidate_id = candidate.candidate_id
+               AND matches.candidate_token = candidate.candidate_token
+            WHERE scope.is_contextually_eligible
+            GROUP BY ALL
+        )
+        SELECT
+            query_id,
+            candidate_id,
+            COALESCE(
+                SUM(candidate_residual_weight * COALESCE(best_query_match_strength, 0.0))
+                / NULLIF(SUM(candidate_residual_weight), 0.0),
+                0.0
+            ) AS candidate_residual_support
+        FROM token_support
+        GROUP BY query_id, candidate_id
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["features"]} AS
+        SELECT
+            scope.ukam_address_id_r AS query_id,
+            scope.ukam_address_id_l AS candidate_id,
+            COALESCE(support.candidate_residual_support, 0.0)
+                AS candidate_residual_support,
+            COALESCE(
+                SUM(pair.local_query_weight * greatest(
+                    pair.rival_strength - pair.candidate_strength, 0.0
+                ))
+                / NULLIF(
+                    SUM(pair.local_query_weight * pair.addressability_strength), 0.0
+                ),
+                0.0
+            ) AS rival_explained_omission,
+            COALESCE(
+                SUM(pair.local_query_weight * (
+                    pair.candidate_strength - pair.rival_strength
+                ))
+                / NULLIF(
+                    SUM(pair.local_query_weight * pair.addressability_strength), 0.0
+                ),
+                0.0
+            ) AS contrast_rate,
+            COALESCE(
+                SUM(pair.local_query_weight * pair.candidate_strength) FILTER (
+                    WHERE pair.match_mechanism = 'split_join'
+                )
+                / NULLIF(
+                    SUM(pair.local_query_weight * pair.addressability_strength), 0.0
+                ),
+                0.0
+            ) AS split_join_rate,
+            COALESCE(
+                SUM(pair.local_query_weight * pair.candidate_strength) FILTER (
+                    WHERE pair.match_mechanism = 'soft'
+                )
+                / NULLIF(
+                    SUM(pair.local_query_weight * pair.addressability_strength), 0.0
+                ),
+                0.0
+            ) AS soft_match_rate,
+            COALESCE(
+                SUM(pair.local_query_weight * pair.addressability_strength), 0.0
+            ) AS addressable_distinguishing_weight
+        FROM {tables["candidate_scope"]} AS scope
+        LEFT JOIN {tables["pair_rival"]} AS pair
+            ON pair.query_id = scope.ukam_address_id_r
+           AND pair.candidate_id = scope.ukam_address_id_l
+        LEFT JOIN {tables["candidate_support"]} AS support
+            ON support.query_id = scope.ukam_address_id_r
+           AND support.candidate_id = scope.ukam_address_id_l
+        GROUP BY ALL
+    """)
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["scored"]} AS
+        WITH raw_scores AS (
+            SELECT
+                scope.ukam_address_id_r AS query_id,
+                scope.ukam_address_id_l AS candidate_id,
+                scope.phase1_score,
+                    scope.{contextual_base_score} AS contextual_base_score,
+                scope.is_contextually_eligible,
+                scope.eligible_candidate_count,
+                features.* EXCLUDE (query_id, candidate_id),
+                least(
+                    1.0,
+                    features.addressable_distinguishing_weight
+                    / {evidence_sufficiency_target}
+                ) AS evidence_scale,
+                {candidate_support_weight} * features.candidate_residual_support
+                    - {rival_omission_weight} * features.rival_explained_omission
+                    + {contrast_weight} * features.contrast_rate
+                    + {split_join_weight} * features.split_join_rate
+                    + {soft_match_weight} * features.soft_match_rate
+                    AS raw_contextual_score
+            FROM {tables["candidate_scope"]} AS scope
+            JOIN {tables["features"]} AS features
+                ON features.query_id = scope.ukam_address_id_r
+               AND features.candidate_id = scope.ukam_address_id_l
+        ),
+        centred AS (
+            SELECT
+                *,
+                AVG(raw_contextual_score) FILTER (WHERE is_contextually_eligible)
+                    OVER (PARTITION BY query_id) AS eligible_group_mean
+            FROM raw_scores
+        ),
+        reference_winner AS (
+            SELECT
+                *,
+                FIRST_VALUE(candidate_id) OVER (
+                    PARTITION BY query_id
+                    ORDER BY contextual_base_score DESC, candidate_id
+                ) AS reference_winner_candidate_id,
+                FIRST_VALUE(candidate_residual_support) OVER (
+                    PARTITION BY query_id
+                    ORDER BY contextual_base_score DESC, candidate_id
+                ) AS reference_winner_residual_support
+            FROM centred
+        )
+        SELECT
+            *,
+            CASE
+                WHEN eligible_candidate_count < 2 THEN 0.0
+                ELSE raw_contextual_score - eligible_group_mean
+            END AS centred_contextual_score,
+            CASE
+                WHEN eligible_candidate_count < 2 THEN 0.0
+                WHEN is_contextually_eligible THEN
+                    CASE
+                        WHEN (
+                            raw_contextual_score - eligible_group_mean
+                        ) > 0.0
+                        AND NOT ({minimum_support_advantage_condition}) THEN 0.0
+                        WHEN (
+                            raw_contextual_score - eligible_group_mean
+                        ) > 0.0
+                        AND NOT ({minimum_candidate_support_condition}) THEN 0.0
+                        ELSE {contextual_multiplier}
+                            * (raw_contextual_score - eligible_group_mean)
+                            * evidence_scale
+                    END
+                ELSE least(
+                    0.0,
+                    {contextual_multiplier}
+                    * (raw_contextual_score - eligible_group_mean)
+                    * evidence_scale
+                )
+            END AS gated_contextual_adjustment
+        FROM reference_winner AS scored
+    """)
+    diagnostic_projection = ""
+    diagnostic_joins = ""
+    if config.include_diagnostics:
+        con.execute(f"""
+                CREATE TEMP TABLE {tables["diagnostics"]} AS
+                SELECT
+                    pair.query_id,
+                    pair.candidate_id,
+                    list(pair.query_token ORDER BY pair.query_token_position) FILTER (
+                        WHERE pair.is_consensus
+                    ) AS consensus_query_tokens,
+                    list(pair.query_token ORDER BY pair.query_token_position) FILTER (
+                        WHERE pair.is_unaddressed
+                    ) AS unaddressed_query_tokens,
+                    list(pair.query_token ORDER BY pair.query_token_position) FILTER (
+                        WHERE pair.local_query_weight > 0
+                            AND pair.candidate_strength > 0
+                    ) AS matched_residual_tokens,
+                    list(pair.query_token ORDER BY pair.query_token_position) FILTER (
+                        WHERE pair.local_query_weight > 0
+                          AND pair.rival_strength > pair.candidate_strength
+                    ) AS rival_explained_tokens,
+                    list(pair.query_token ORDER BY pair.query_token_position) FILTER (
+                        WHERE pair.match_mechanism = 'split_join'
+                    ) AS split_join_matches,
+                    list(pair.query_token ORDER BY pair.query_token_position) FILTER (
+                        WHERE pair.match_mechanism = 'soft'
+                    ) AS soft_matches
+                FROM {tables["pair_rival"]} AS pair
+                GROUP BY pair.query_id, pair.candidate_id
+            """)
+        diagnostic_projection = """,
+                scope.is_contextually_eligible,
+                scope.eligible_candidate_count,
+                scope.best_splink_match_weight,
+                scope.splink_gap_from_best,
+                scored.candidate_residual_support,
+                scored.rival_explained_omission,
+                scored.contrast_rate,
+                scored.split_join_rate,
+                scored.soft_match_rate,
+                scored.addressable_distinguishing_weight,
+                scored.evidence_scale,
+                diagnostics.consensus_query_tokens,
+                diagnostics.unaddressed_query_tokens,
+                diagnostics.matched_residual_tokens,
+                diagnostics.rival_explained_tokens,
+                candidate_tokens.candidate_residual_tokens,
+                diagnostics.split_join_matches,
+                diagnostics.soft_matches"""
+        diagnostic_joins = f"""
+            LEFT JOIN {tables["diagnostics"]} AS diagnostics
+                ON diagnostics.query_id = scope.ukam_address_id_r
+               AND diagnostics.candidate_id = scope.ukam_address_id_l
+            LEFT JOIN (
+                SELECT
+                    candidate.query_id,
+                    candidate.candidate_id,
+                    list(
+                        candidate.candidate_token
+                        ORDER BY candidate.candidate_token_position
+                    ) FILTER (WHERE statistics.candidate_residual_weight > 0)
+                        AS candidate_residual_tokens
+                FROM {tables["candidate_tokens"]} AS candidate
+                JOIN {tables["candidate_statistics"]} AS statistics
+                    ON statistics.query_id = candidate.query_id
+                   AND statistics.candidate_token = candidate.candidate_token
+                GROUP BY candidate.query_id, candidate.candidate_id
+            ) AS candidate_tokens
+                ON candidate_tokens.query_id = scope.ukam_address_id_r
+               AND candidate_tokens.candidate_id = scope.ukam_address_id_l"""
+
+    output_columns = [column for column in df_predict.columns if column != "match_weight"]
+    output_projection = ",\n            ".join(
+        f"scope.{column}" for column in output_columns
+    )
+    con.execute(f"""
+        CREATE TEMP TABLE {tables["final"]} AS
+        SELECT
+            {output_projection},
+            greatest(
+                -{contextual_cap},
+                least({contextual_cap}, scored.gated_contextual_adjustment)
+            ) AS contextual_adjustment,
+            scope.{contextual_base_score} + greatest(
+                -{contextual_cap},
+                least({contextual_cap}, scored.gated_contextual_adjustment)
+            ) AS contextual_match_weight,
+            scope.{contextual_base_score} + greatest(
+                -{contextual_cap},
+                least({contextual_cap}, scored.gated_contextual_adjustment)
+            ) AS match_weight
+            {diagnostic_projection}
+        FROM {tables["candidate_scope"]} AS scope
+        JOIN {tables["scored"]} AS scored
+            ON scored.query_id = scope.ukam_address_id_r
+           AND scored.candidate_id = scope.ukam_address_id_l
+        {diagnostic_joins}
+    """)
+
+    if telemetry is not None:
+        telemetry["contextual_reranker_seconds"] = perf_counter() - started_at
+        telemetry["soft_residual_pairs_considered"] = con.sql(
+            f"SELECT count(*) FROM {tables['soft_candidates']}"
+        ).fetchone()[0]
+        telemetry["soft_jaro_winkler_pairs_evaluated"] = con.sql(
+            f"SELECT count(*) FROM {tables['soft_scored']}"
+        ).fetchone()[0]
+        telemetry["soft_threshold_pairs"] = con.sql(
+            f"SELECT count(*) FROM {tables['soft_qualified']}"
+        ).fetchone()[0]
+    for table_key, table_name in tables.items():
+        if table_key != "final":
+            con.execute(f"DROP TABLE IF EXISTS {table_name}")
+    return con.table(tables["final"])

--- a/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
+++ b/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
@@ -362,6 +362,7 @@ def improve_predictions_using_distinguishing_tokens(
             ukam_address_id_r,
             ukam_address_id_l,
             match_weight AS match_weight_original,
+            match_weight AS splink_match_weight,
             token_reward,
             token_absence_penalty,
             bigram_reward,
@@ -375,6 +376,9 @@ def improve_predictions_using_distinguishing_tokens(
                 - missing_token_penalty
                 - positional_conflict_penalty AS mw_adjustment,
             match_weight + mw_adjustment AS match_weight,
+            match_weight + mw_adjustment AS phase1_score,
+            tokens_l,
+            tokens_r,
             overlapping_tokens_this_l_and_r,
             tokens_elsewhere_in_block_but_not_this,
             hist_all_tokens_in_block_l,


### PR DESCRIPTION
### Contextual reranker summary

The contextual residual reranker is a post-linkage scoring stage that compares each candidate with the other candidates available for the same messy address.

It focuses on the evidence that remains after common or unhelpful tokens have been removed.

It answers:

> Which candidate best explains the distinctive parts of this address, relative to its local alternatives?

## How it differs from the existing reranker

The existing distinguishability reranker asks:

> Does this candidate contain rare or distinguishing address evidence?

It rewards and penalises evidence such as:

- locally rare tokens;
- locally rare bigrams;
- missing distinguishing evidence;
- positional conflicts;
- flat and numeric structure.

The contextual reranker asks:

> Does this candidate explain the residual evidence better than its rivals?

It considers:

- which query tokens are common across the candidate group;
- which tokens can actually distinguish between candidates;
- whether each candidate explains those tokens;
- whether a rival better explains missing evidence;
- whether split and joined tokens represent the same text;
- whether a conservative fuzzy token match is present.

The existing reranker evaluates candidate evidence directly. The contextual reranker evaluates it comparatively.

### Why it is useful

Several candidates may share the same postcode, street and building name. These shared tokens provide little help when choosing between them.

The contextual reranker removes this consensus and concentrates on the remaining evidence.

It is designed to complement the existing reranker, not replace it. The existing stage provides strong structural protection, while the contextual stage helps resolve close local competition.

<details>
<summary><strong>Worked example</strong></summary>

### Messy address

```text
DELAB FARMHOUSE MONYMUSK INVERURIE
```

### Candidate A

```text
DELAB FARM HOUSE MONYMUSK INVERURIE
```

### Candidate B

```text
DELAB FARM COTTAGE MONYMUSK INVERURIE
```

Both candidates share:

```text
DELAB
FARM
MONYMUSK
INVERURIE
```

These are consensus tokens and do not clearly distinguish the candidates.

The important residual evidence is:

```text
FARMHOUSE
```

Candidate A contains:

```text
FARM HOUSE
```

The contextual reranker recognises the split/join relationship:

```text
FARMHOUSE ↔ FARM HOUSE
```

Candidate B does not explain the residual token.

The reranker therefore:

1. removes the shared consensus evidence;
2. identifies `FARMHOUSE` as distinguishing;
3. rewards Candidate A for explaining it;
4. penalises Candidate B because its rival explains the evidence better;
5. increases Candidate A's relative score.

</details>
