### PR TITLE
feat: add overview page for labelling tool

### DIFF
--- a/benchmarking/hackney_labelling_examples.py
+++ b/benchmarking/hackney_labelling_examples.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import time
+
+import duckdb
+import pyarrow as pa
+
+from benchmarking.config.datasets import get_dataset_definition, load_dataset
+from benchmarking.config.sources import resolve_data_source
+from benchmarking.settings import CANONICAL_PATH
+from uk_address_matcher import AddressMatcher, ExactMatchStage, SplinkStage
+from uk_address_matcher.labelling import launch_labelling_app
+
+HACKNEY_GSS_CODE = "E09000012"
+CLASSIFICATION_CODE_PREFIX = "R"
+HACKNEY_DATASET = get_dataset_definition("hackney")
+HACKNEY_INPUT_PATH = resolve_data_source(
+    HACKNEY_DATASET["data_path_env"],
+    HACKNEY_DATASET["file_name"],
+)
+
+
+start_time = time.time()
+con = duckdb.connect(database=":memory:")
+hackney_addresses = load_dataset(con, dataset_key="hackney")
+
+canonical_address_filter = (
+    f"lowertierlocalauthoritygsscode = '{HACKNEY_GSS_CODE}' "
+    f"AND substr(classificationcode, 1, 1) = '{CLASSIFICATION_CODE_PREFIX}'"
+)
+
+matcher = AddressMatcher(
+    canonical_addresses=CANONICAL_PATH,
+    canonical_address_filter=canonical_address_filter,
+    addresses_to_match=hackney_addresses,
+    con=con,
+    stages=[
+        ExactMatchStage(),
+        SplinkStage(),
+    ],
+)
+
+result = matcher.match()
+bundle_path = result.export_labelling_bundle(overwrite=True)
+accuracy_table = result.accuracy_analysis(
+    output_type="table",
+    add_metrics=["f1"],
+    match_weight_round_to_nearest=1,
+)
+accuracy_relation = con.from_arrow(pa.Table.from_pylist(accuracy_table))
+
+print(f"Labelling bundle written to: {bundle_path}")
+print(f"Execution time: {time.time() - start_time:.1f} seconds")
+accuracy_relation.show(max_width=100_000, max_rows=100_000)
+con.sql(f"""
+    select * from
+    read_parquet('{bundle_path}/review_data.parquet')
+""").show(max_width=10000, max_rows=1)
+
+launch_labelling_app(
+    labelling_bundle_path=bundle_path,
+    input_dataset_path=HACKNEY_INPUT_PATH,
+    input_dataset_label_column="UPRN",
+)


### PR DESCRIPTION
I had intended to split these two pages up, but Git commits got crossed and now we have both bundled together.

<img width="1488" height="824" alt="Screenshot 2026-07-30 at 14 46 51" src="https://github.com/user-attachments/assets/3d46ce93-e870-4a98-8df2-33751078b739" />

<img width="1591" height="799" alt="Screenshot 2026-07-30 at 16 10 29" src="https://github.com/user-attachments/assets/413de6dd-588a-46d0-a1ae-14a4045a0019" />

