### PR TITLE
fix: make sequential matching exception-safe and add MatchResult.close

### DIFF
--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -337,6 +337,217 @@ def test_match_with_custom_splink_stage(con, canonical_data, messy_data):
     assert isinstance(result.matches(), duckdb.DuckDBPyRelation)
 
 
+def test_sequential_matchers_share_connection_with_splink(
+    con, canonical_data, messy_data
+):
+    stages = [ExactMatchStage(), SplinkStage()]
+    first_result = AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=messy_data,
+        con=con,
+        stages=stages,
+    ).match()
+
+    second_messy_data = _make_addresses(
+        con,
+        [
+            {
+                "unique_id": "M3",
+                "address_concat": "3 middle boulevard birmingham",
+                "postcode": "B1 1AA",
+            }
+        ],
+    )
+    second_result = AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=second_messy_data,
+        con=con,
+        stages=stages,
+    ).match()
+
+    assert first_result.matches().count("*").fetchone()[0] == 2
+    assert second_result.matches().count("*").fetchone()[0] == 1
+    reranker_intermediates = con.execute(
+        """
+        SELECT table_name
+        FROM duckdb_tables()
+        WHERE table_name SIMILAR TO
+            '__ukam__tmp_(good_matches|top_n_matches|token_addresses|block_statistics)_%'
+        """
+    ).fetchall()
+    assert reranker_intermediates == []
+
+
+def _catalogue_snapshot(con):
+    tables = {name for (name,) in con.execute(
+        "SELECT table_name FROM duckdb_tables()"
+    ).fetchall()}
+    views = {name for (name,) in con.execute(
+        "SELECT view_name FROM duckdb_views() WHERE NOT internal"
+    ).fetchall()}
+    return tables | views
+
+
+def test_splink_matching_preserves_user_tables_with_legacy_internal_names(
+    con, canonical_data, messy_data
+):
+    user_table_names = (
+        "m_",
+        "c_",
+        "good_matches",
+        "top_n_matches",
+        "token_addresses",
+        "block_statistics",
+        "__ukam__distinguishability_matches",
+    )
+    for table_name in user_table_names:
+        con.execute(f"CREATE TABLE \"{table_name}\" AS SELECT 'user data' AS marker")
+
+    result = AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=messy_data,
+        con=con,
+        stages=[SplinkStage(final_match_weight_threshold=-20.0)],
+    ).match()
+
+    assert result.matches().count("*").fetchone()[0] == 2
+    for table_name in user_table_names:
+        assert con.table(table_name).fetchall() == [("user data",)]
+
+
+def test_splink_stage_failure_restores_user_tables_and_leaves_no_leftovers(
+    con, canonical_data, messy_data, monkeypatch
+):
+    """A mid-Splink exception must not leave m_/c_ shadowed or leak objects."""
+    import uk_address_matcher.post_linkage.analyse_results as analyse_results
+
+    con.execute("CREATE TABLE m_ AS SELECT 'user data' AS marker")
+    con.execute("CREATE TABLE c_ AS SELECT 'user data' AS marker")
+    baseline = _catalogue_snapshot(con)
+
+    def boom(**kwargs):
+        raise RuntimeError("simulated failure mid-splink")
+
+    monkeypatch.setattr(
+        analyse_results, "best_matches_with_distinguishability", boom
+    )
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        AddressMatcher(
+            canonical_addresses=canonical_data,
+            addresses_to_match=messy_data,
+            con=con,
+            stages=[SplinkStage(final_match_weight_threshold=-20.0)],
+        ).match()
+
+    # User tables must resolve to user data again, not the matcher's relations
+    assert con.sql("SELECT * FROM m_").fetchall() == [("user data",)]
+    assert con.sql("SELECT * FROM c_").fetchall() == [("user data",)]
+
+    leftovers = {
+        name
+        for name in _catalogue_snapshot(con) - baseline
+        if name.startswith(("__splink__", "__ukam__tmp_", "__ukam__splink__"))
+    }
+    assert leftovers == set()
+
+
+def test_match_result_close_is_scoped_and_idempotent(con, canonical_data, messy_data):
+    baseline = _catalogue_snapshot(con)
+
+    first_result = AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=messy_data,
+        con=con,
+        stages=[SplinkStage(final_match_weight_threshold=-20.0)],
+    ).match()
+
+    second_messy = _make_addresses(
+        con,
+        [
+            {
+                "unique_id": "M3",
+                "address_concat": "3 middle boulevard birmingham",
+                "postcode": "B1 1AA",
+            }
+        ],
+    )
+    second_result = AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=second_messy,
+        con=con,
+        stages=[SplinkStage(final_match_weight_threshold=-20.0)],
+    ).match()
+
+    # Closing the earlier result must not break the later live one
+    first_result.close()
+    assert second_result.matches().count("*").fetchone()[0] == 1
+
+    second_result.close()
+    second_result.close()  # idempotent
+
+    leftovers = {
+        name
+        for name in _catalogue_snapshot(con) - baseline
+        if name.startswith(
+            ("__splink__", "__ukam__splink__", "__ukam__processed_",
+             "__ukam_final_matches_", "__ukam__inverted_index_",
+             "__ukam_derived_inverted_index_")
+        )
+    }
+    assert leftovers == set()
+
+
+def test_match_result_is_a_context_manager(con, canonical_data, messy_data):
+    with AddressMatcher(
+        canonical_addresses=canonical_data,
+        addresses_to_match=messy_data,
+        con=con,
+        stages=[ExactMatchStage()],
+    ).match() as result:
+        assert result.matches().count("*").fetchone()[0] == 2
+    assert result._owned_table_names == ()
+
+
+def test_file_backed_database_is_clean_after_close(
+    canonical_data, con, tmp_path
+):
+    database_path = tmp_path / "matcher.duckdb"
+    file_con = duckdb.connect(str(database_path))
+    try:
+        baseline = _catalogue_snapshot(file_con)
+        canonical = _make_addresses(file_con, CANONICAL_RECORDS)
+        messy = _make_addresses(file_con, MESSY_RECORDS)
+        result = AddressMatcher(
+            canonical_addresses=canonical,
+            addresses_to_match=messy,
+            con=file_con,
+            stages=[ExactMatchStage(), SplinkStage(final_match_weight_threshold=-20.0)],
+        ).match()
+        result.matches().fetchall()
+        result.close()
+        leftovers = _catalogue_snapshot(file_con) - baseline
+    finally:
+        file_con.close()
+
+    # Known pre-existing exceptions: fixed-name derived TF / index-meta tables
+    # are outside the ownership model (tracked separately — see review H3).
+    allowed = {"__ukam_derived_term_frequencies", "__ukam_index_meta"}
+    assert leftovers <= allowed
+
+    reopened = duckdb.connect(str(database_path))
+    try:
+        persisted = {
+            name
+            for (name,) in reopened.execute(
+                "SELECT table_name FROM duckdb_tables()"
+            ).fetchall()
+        }
+    finally:
+        reopened.close()
+    assert persisted <= allowed
+
+
 def test_match_from_prepared_folder(con, canonical_data, messy_data):
     """Loading canonical data from a prepared folder should work end-to-end."""
     with tempfile.TemporaryDirectory() as tmp:

--- a/uk_address_matcher/address_matcher.py
+++ b/uk_address_matcher/address_matcher.py
@@ -192,6 +192,7 @@ class AddressMatcher:
         if self._inverted_index_table_name is not None:
             _drop_table_and_registered_aliases(self.con, self._inverted_index_table_name)
 
+        source_name = getattr(inverted_index, "alias", None)
         source_relation = _register_input_relation_once(
             inverted_index,
             con=self.con,
@@ -206,6 +207,11 @@ class AddressMatcher:
             + source_relation.sql_query()
             + ")"
         )
+        # The derived source table has been copied; it has no further use.
+        if isinstance(source_name, str) and source_name.startswith(
+            "__ukam_derived_inverted_index_"
+        ):
+            _drop_table_and_registered_aliases(self.con, source_name)
         self._inverted_index_table_name = table_name
 
     @property
@@ -345,13 +351,27 @@ class AddressMatcher:
         self._resolve_canonical_data()
         self._resolve_messy_data()
 
-        result, stage_diagnostics = _run_matching(
-            con=self.con,
-            df_messy_clean=self._messy_clean,
-            df_canonical_clean=self._canonical_clean,
-            stages=self.stages,
-            debug_options=self.debug_options,
-        )
+        # The inverted index is only consumed while cleaning the messy data,
+        # which has now happened. Drop it so it does not accumulate.
+        if self._inverted_index_table_name is not None:
+            _drop_table_and_registered_aliases(
+                self.con, self._inverted_index_table_name
+            )
+            self._inverted_index_table_name = None
+
+        try:
+            result, stage_diagnostics = _run_matching(
+                con=self.con,
+                df_messy_clean=self._messy_clean,
+                df_canonical_clean=self._canonical_clean,
+                stages=self.stages,
+                debug_options=self.debug_options,
+            )
+        except BaseException:
+            # Failed matching must not strand transient objects: run the same
+            # sweep the success path runs (there is no result to keep).
+            self._cleanup_intermediate_tables(None)
+            raise
 
         splink_stage = next(
             (stage for stage in self.stages if isinstance(stage, SplinkStage)),
@@ -360,6 +380,28 @@ class AddressMatcher:
 
         self._cleanup_intermediate_tables(result)
 
+        # Objects retained for this result's inspection APIs. Snapshot the
+        # names/handles now: if the caller reuses the same stage objects for a
+        # later run, this result must still clean up ITS run, not the newer one.
+        owned_tables = [
+            getattr(result, "alias", None),
+            getattr(self._messy_clean, "alias", None),
+        ]
+        if not isinstance(self._raw_canonical, (str, Path)):
+            # Raw canonical input was cleaned into a run-scoped table.
+            # (Prepared-folder canonical relations read parquet directly and
+            # own no catalogue objects.)
+            owned_tables.append(getattr(self._canonical_clean, "alias", None))
+        owned_splink_frames: tuple = ()
+        if splink_stage is not None:
+            owned_tables.extend(
+                (
+                    splink_stage.predictions_table,
+                    splink_stage.best_matches_table,
+                )
+            )
+            owned_splink_frames = splink_stage._owned_splink_frames
+
         return MatchResult(
             result,
             con=self.con,
@@ -367,9 +409,17 @@ class AddressMatcher:
             _canonical_relation=self._canonical_clean,
             _messy_relation=self._messy_clean,
             _stage_diagnostics=stage_diagnostics,
+            _owned_table_names=tuple(
+                dict.fromkeys(
+                    name for name in owned_tables if isinstance(name, str)
+                )
+            ),
+            _owned_splink_frames=owned_splink_frames,
         )
 
-    def _cleanup_intermediate_tables(self, result: duckdb.DuckDBPyRelation) -> None:
+    def _cleanup_intermediate_tables(
+        self, result: duckdb.DuckDBPyRelation | None
+    ) -> None:
         """A simple cleaning utility to drop transient tables created during
         matching, while keeping the final result and canonical/messy tables."""
         keep_names = {

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -7,7 +7,6 @@
     "common_end_tokens_hist"
   ],
   "sql_dialect": "duckdb",
-  "linker_uid": "e5bphl9c",
   "em_convergence": 0.0001,
   "max_iterations": 25,
   "bayes_factor_column_prefix": "bf_",

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -93,6 +93,22 @@ class SplinkStage(MatchingStage):
     predictions_table: str | None = field(default=None, init=False, repr=False)
     improved_predictions_table: str | None = field(default=None, init=False, repr=False)
     best_matches_table: str | None = field(default=None, init=False, repr=False)
+    # SplinkDataFrame handles for tables this stage registered/created via
+    # Splink. Held so they can be dropped through Splink's public API.
+    _owned_splink_frames: tuple = field(default=(), init=False, repr=False)
+
+    def _release_splink_tables(self) -> None:
+        """Drop this run's Splink tables via Splink's public API."""
+        for frame in self._owned_splink_frames:
+            try:
+                frame.drop_table_from_database_and_remove_from_cache(
+                    force_non_splink_table=True
+                )
+            except Exception:
+                # Best-effort: the table may already be gone (idempotent
+                # cleanup) or the connection may be closing.
+                pass
+        self._owned_splink_frames = ()
 
     def find_matches(
         self,
@@ -113,7 +129,10 @@ class SplinkStage(MatchingStage):
         from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
             improve_predictions_using_distinguishing_tokens,
         )
-        from uk_address_matcher.sql_pipeline.helpers import _uid
+        from uk_address_matcher.sql_pipeline.helpers import (
+            _drop_table_and_registered_aliases,
+            _uid,
+        )
         from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
 
         if explain:
@@ -123,65 +142,92 @@ class SplinkStage(MatchingStage):
         if unmatched_count == 0:
             return None
 
-        # Step 1: Build linker
-        linker = _get_linker(
-            df_addresses_to_match=df_unmatched,
-            df_addresses_to_search_within=df_canonical,
-            con=con,
-            include_full_postcode_block=self.include_full_postcode_block,
-            include_outside_postcode_block=self.include_outside_postcode_block,
-            additional_columns_to_retain=self.additional_columns_to_retain,
-            retain_intermediate_calculation_columns=(
-                self.retain_intermediate_calculation_columns
-            ),
-            settings=self.settings,
-        )
+        # Splink reads its two inputs through relations registered on the
+        # connection as `m_` and `c_` (see _get_linker). Any user table with
+        # either name is shadowed by that registration, so the registrations
+        # MUST be removed on every exit path — including exceptions —
+        # otherwise later reads of `m_`/`c_` silently return matcher data
+        # instead of the user's table. Hence the try/finally.
+        reranker_matches_table: str | None = None
+        try:
+            # Step 1: Build linker (registers m_/c_ and the tf/concat tables)
+            owned_frames: list = []
+            linker = _get_linker(
+                df_addresses_to_match=df_unmatched,
+                df_addresses_to_search_within=df_canonical,
+                con=con,
+                include_full_postcode_block=self.include_full_postcode_block,
+                include_outside_postcode_block=self.include_outside_postcode_block,
+                additional_columns_to_retain=self.additional_columns_to_retain,
+                retain_intermediate_calculation_columns=(
+                    self.retain_intermediate_calculation_columns
+                ),
+                settings=self.settings,
+                owned_splink_frames=owned_frames,
+            )
 
-        self.linker = linker
+            self.linker = linker
 
-        # Step 2: Predict
-        df_predict = linker.inference.predict(
-            threshold_match_weight=self.predict_threshold_match_weight
-        )
-        df_predict_ddb = df_predict.as_duckdbpyrelation()
+            # Step 2: Predict
+            df_predict = linker.inference.predict(
+                threshold_match_weight=self.predict_threshold_match_weight
+            )
+            owned_frames.append(df_predict)
+            self._owned_splink_frames = tuple(owned_frames)
+            df_predict_ddb = df_predict.as_duckdbpyrelation()
 
-        table_name = f"__ukam__splink__predictions__{_uid()}"
-        con.execute(
-            "CREATE OR REPLACE TEMP VIEW "
-            + table_name
-            + " AS SELECT * FROM ("
-            + df_predict_ddb.sql_query()
-            + ")"
-        )
-        self.predictions_table = table_name
+            table_name = f"__ukam__splink__predictions__{_uid()}"
+            con.execute(
+                "CREATE OR REPLACE TEMP VIEW "
+                + table_name
+                + " AS SELECT * FROM ("
+                + df_predict_ddb.sql_query()
+                + ")"
+            )
+            self.predictions_table = table_name
 
-        # Step 3: Improve predictions using distinguishing tokens
-        df_improved = improve_predictions_using_distinguishing_tokens(
-            df_predict=df_predict_ddb,
-            con=con,
-            match_weight_threshold=self.improve_threshold_match_weight,
-            top_n_matches=self.improve_top_n_matches,
-            use_bigrams=self.improve_use_bigrams,
-            additional_columns_to_retain=self.additional_columns_to_retain,
-        )
-        df_improved = relation_markers.improve_predictions_using_relation_markers(
-            df_predict=df_improved,
-            con=con,
-        )
-        self.improved_predictions_table = getattr(df_improved, "alias", None)
+            # Step 3: Improve predictions using distinguishing tokens
+            df_improved = improve_predictions_using_distinguishing_tokens(
+                df_predict=df_predict_ddb,
+                con=con,
+                match_weight_threshold=self.improve_threshold_match_weight,
+                top_n_matches=self.improve_top_n_matches,
+                use_bigrams=self.improve_use_bigrams,
+                additional_columns_to_retain=self.additional_columns_to_retain,
+            )
+            reranker_matches_table = getattr(df_improved, "alias", None)
+            df_improved = relation_markers.improve_predictions_using_relation_markers(
+                df_predict=df_improved,
+                con=con,
+            )
+            self.improved_predictions_table = getattr(df_improved, "alias", None)
 
-        # Step 4: Compute distinguishability and select best match per record
-        # This returns an unmaterialised relation
-        df_best = best_matches_with_distinguishability(
-            df_predict=df_improved,
-            df_addresses_to_match=df_unmatched,
-            con=con,
-            best_match_only=False,
-        )
+            # Step 4: Compute distinguishability and select best match per
+            # record. This returns an unmaterialised relation.
+            df_best = best_matches_with_distinguishability(
+                df_predict=df_improved,
+                df_addresses_to_match=df_unmatched,
+                con=con,
+                best_match_only=False,
+            )
 
-        df_best_name = f"__ukam__splink__best_matches__{_uid()}"
-        df_best.create(df_best_name)
-        self.best_matches_table = df_best_name
+            df_best_name = f"__ukam__splink__best_matches__{_uid()}"
+            df_best.create(df_best_name)
+            self.best_matches_table = df_best_name
+        except BaseException:
+            # Failed part-way: drop everything this run created so a failed
+            # match leaves no run-scoped objects behind.
+            self._release_splink_tables()
+            for orphan in (reranker_matches_table, self.predictions_table):
+                if isinstance(orphan, str):
+                    _drop_table_and_registered_aliases(con, orphan)
+            self.predictions_table = None
+            raise
+        finally:
+            # Restore any user tables named m_/c_ that the registration
+            # shadowed. unregister of an unknown name is a no-op.
+            con.unregister("m_")
+            con.unregister("c_")
 
         # Step 5: Apply thresholds and project to standard columns
         splink_label = MatchReason.SPLINK.value

--- a/uk_address_matcher/linking_model/splink_model.py
+++ b/uk_address_matcher/linking_model/splink_model.py
@@ -3,7 +3,7 @@ import json
 import logging
 from contextlib import contextmanager
 
-from duckdb import DuckDBPyConnection, DuckDBPyRelation
+from duckdb import DuckDBPyConnection, DuckDBPyRelation, InvalidInputException
 from splink import DuckDBAPI, Linker, SettingsCreator
 
 from uk_address_matcher.sql_pipeline.helpers import package_resource_read_sql
@@ -88,7 +88,16 @@ def _get_linker(
     retain_intermediate_calculation_columns=False,
     retain_matching_columns=True,
     settings: SettingsCreator | None = None,
+    owned_splink_frames: list | None = None,
 ) -> Linker:
+    """Build a configured Splink linker for the given relations.
+
+    If ``owned_splink_frames`` is provided, every ``SplinkDataFrame`` this
+    function registers on the connection (the three numeric-token term
+    frequency lookups and the concat-with-tf input) is appended to it so the
+    caller can later drop them via Splink's public
+    ``drop_table_from_database_and_remove_from_cache`` API.
+    """
     # Check if either input dataset contains a source_dataset column
     if (
         "source_dataset" in df_addresses_to_match.columns
@@ -136,6 +145,7 @@ def _get_linker(
     else:
         settings_as_dict = settings.create_settings_dict("duckdb")
 
+    settings_as_dict["linker_uid"] = None
     settings_as_dict = _sanitise_null_comparison_levels(settings_as_dict)
 
     if additional_columns_to_retain:
@@ -233,19 +243,27 @@ def _get_linker(
     # df_addresses_to_search_within_fix = con.table("df_addresses_to_search_within_fix")
     df_addresses_to_search_within_fix = df_addresses_to_search_within
 
-    # Drop stale Splink views/tables from any prior linker on this connection.
-    messy_name, canonical_name = (
-        "m_",
-        "c_",
-    )
-
-    for tbl in (messy_name, canonical_name):
-        con.execute(f"DROP VIEW IF EXISTS {tbl}")
-        con.execute(f"DROP TABLE IF EXISTS {tbl}")
+    # Splink expects the prediction-side dataset labels to be `m_` and `c_`.
+    # Register the matching relations under those names for the duration of the
+    # Splink run instead of dropping any user table that happens to share the
+    # name. The caller (SplinkStage) is responsible for unregistering both
+    # names once Splink has materialised its outputs, restoring any shadowed
+    # user tables. Registration order: unregister first so a stale
+    # registration from a previous (possibly failed) run is replaced.
+    messy_name, canonical_name = "m_", "c_"
+    for table_name, relation in (
+        (messy_name, df_addresses_to_match_fix),
+        (canonical_name, df_addresses_to_search_within_fix),
+    ):
+        try:
+            con.unregister(table_name)
+        except InvalidInputException:
+            pass
+        con.register(table_name, relation)
 
     with _suppress_known_splink_warnings():
         linker = Linker(
-            [df_addresses_to_match_fix, df_addresses_to_search_within_fix],
+            [messy_name, canonical_name],
             settings=settings,
             db_api=db_api,
             input_table_aliases=[messy_name, canonical_name],
@@ -263,9 +281,11 @@ def _get_linker(
             from precomputed_numeric_tf_table"""
 
         df = con.sql(df_sql)
-        linker.table_management.register_term_frequency_lookup(
+        tf_frame = linker.table_management.register_term_frequency_lookup(
             df, f"numeric_token_{i}", overwrite=True
         )
+        if owned_splink_frames is not None:
+            owned_splink_frames.append(tf_frame)
 
     cols_to_select = df_addresses_to_match.columns
     select_expr = ", ".join(cols_to_select)
@@ -282,6 +302,10 @@ def _get_linker(
     """
 
     concat_with_tf = con.sql(sql)
-    linker.table_management.register_table_input_nodes_concat_with_tf(concat_with_tf)
+    concat_frame = linker.table_management.register_table_input_nodes_concat_with_tf(
+        concat_with_tf
+    )
+    if owned_splink_frames is not None:
+        owned_splink_frames.append(concat_frame)
 
     return linker

--- a/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
+++ b/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from duckdb import DuckDBPyConnection, DuckDBPyRelation
 
+from uk_address_matcher.sql_pipeline.helpers import (
+    _drop_table_and_registered_aliases,
+    _uid,
+)
+
 _POSITIONAL_TOKENS_SQL = "('LEFT', 'RIGHT', 'CENTRE', 'FRONT')"
 
 
@@ -21,398 +26,437 @@ def improve_predictions_using_distinguishing_tokens(
     MISSING_TOKEN_PENALTY: float = 0.0,
     POSITIONAL_CONFLICT_PENALTY: float = 6.0,
 ) -> DuckDBPyRelation:
-    matches_table = "__ukam__distinguishability_matches"
+    table_suffix = _uid()
+    matches_table = f"__ukam__tmp_distinguishability_matches_{table_suffix}"
+    good_matches_table = f"__ukam__tmp_good_matches_{table_suffix}"
+    top_n_matches_table = f"__ukam__tmp_top_n_matches_{table_suffix}"
+    token_addresses_table = f"__ukam__tmp_token_addresses_{table_suffix}"
+    block_statistics_table = f"__ukam__tmp_block_statistics_{table_suffix}"
+    intermediate_tables = (
+        good_matches_table,
+        top_n_matches_table,
+        token_addresses_table,
+        block_statistics_table,
+    )
 
-    retained_columns = ""
-    if additional_columns_to_retain:
-        retained_columns = "".join(
-            f"{column}_l, {column}_r, " for column in additional_columns_to_retain
-        )
-    if "ukam_label_r" in df_predict.columns:
-        retained_columns += "ukam_label_r, "
+    # The four intermediates are consumed only inside this function, so they
+    # are dropped on every exit path (finally). The matches table is this
+    # function's output — the caller owns it on success — so it is dropped
+    # only if we fail part-way through building it.
+    try:
 
-    eligibility_filter = ""
-    if histogram_eligibility_column is not None:
-        if histogram_eligibility_column not in df_predict.columns:
-            raise ValueError(
-                "histogram_eligibility_column must exist in df_predict: "
-                f"{histogram_eligibility_column}"
+        retained_columns = ""
+        if additional_columns_to_retain:
+            retained_columns = "".join(
+                f"{column}_l, {column}_r, " for column in additional_columns_to_retain
             )
-        eligibility_filter = f"WHERE COALESCE({histogram_eligibility_column}, FALSE)"
+        if "ukam_label_r" in df_predict.columns:
+            retained_columns += "ukam_label_r, "
 
-    candidate_token_lists_sql = """
-        array_agg(candidate_tokens).
-        list_transform(candidate_tokens -> list_distinct(candidate_tokens))
-    """
-    canonical_bigrams_sql = """
-        list_transform(
-            array_agg(candidate_tokens),
-            candidate_tokens -> list_distinct(
-                list_transform(
-                    list_zip(
-                        list_slice(candidate_tokens, 1, length(candidate_tokens) - 1),
-                        list_slice(candidate_tokens, 2, length(candidate_tokens))
-                    ),
-                    pair -> ARRAY[pair[1], pair[2]]
+        eligibility_filter = ""
+        if histogram_eligibility_column is not None:
+            if histogram_eligibility_column not in df_predict.columns:
+                raise ValueError(
+                    "histogram_eligibility_column must exist in df_predict: "
+                    f"{histogram_eligibility_column}"
                 )
-            )
-        ).flatten() AS bigrams_in_block_l,
+            eligibility_filter = f"WHERE COALESCE({histogram_eligibility_column}, FALSE)"
+
+        candidate_token_lists_sql = """
+            array_agg(candidate_tokens).
+            list_transform(candidate_tokens -> list_distinct(candidate_tokens))
         """
-
-    con.sql(f"""
-        SELECT *
-        FROM df_predict
-        WHERE match_weight > {match_weight_threshold}
-        QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY unique_id_r, unique_id_l
-            ORDER BY match_weight DESC, ukam_address_id_r DESC, ukam_address_id_l DESC
-        ) = 1
-    """).create("good_matches")
-
-    con.sql(f"""
-        SELECT *
-        FROM good_matches
-        QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY unique_id_r
-            ORDER BY match_weight DESC, unique_id_l DESC
-        ) <= {top_n_matches}
-    """).create("top_n_matches")
-
-    con.sql("""
-        WITH intermediate AS (
-            SELECT *, map_keys(common_end_tokens_hist_r) AS common_end_tokens_r
-            FROM top_n_matches
-        ),
-        enriched AS (
-            SELECT
-                *,
-                COALESCE(
-                    common_end_tokens_r.list_transform(
-                        value -> COALESCE(
-                            struct_extract(
-                                TRY_CAST(value AS STRUCT(tok VARCHAR, rel_freq DOUBLE)),
-                                'tok'
-                            ),
-                            TRY_CAST(value AS VARCHAR)
-                        )
-                    ),
-                    CAST([] AS VARCHAR[])
-                ) AS common_end_tokens_tok
-            FROM intermediate
-        )
-        SELECT
-            *,
-            clean_full_address_l
-                .trim()
-                .upper()
-                .regexp_split_to_array('\\s+')
-                .list_reverse()
-                .list_filter((token, position) -> NOT (
-                    position = 1 AND common_end_tokens_tok.list_contains(token)
-                ))
-                .list_filter((token, position) -> NOT (
-                    position = 1 AND common_end_tokens_tok.list_contains(token)
-                ))
-                .list_reverse()
-                .array_to_string(' ') AS __token_address_l,
-            clean_full_address_r
-                .trim()
-                .upper()
-                .regexp_split_to_array('\\s+')
-                .list_reverse()
-                .list_filter((token, position) -> NOT (
-                    position = 1 AND common_end_tokens_tok.list_contains(token)
-                ))
-                .list_filter((token, position) -> NOT (
-                    position = 1 AND common_end_tokens_tok.list_contains(token)
-                ))
-                .list_reverse()
-                .array_to_string(' ') AS __token_address_r
-        FROM enriched
-    """).create("token_addresses")
-
-    con.sql(f"""
-        WITH source_tokens AS (
-            SELECT DISTINCT
-                ukam_address_id_r,
-                concat_ws(' ', __token_address_r, postcode_r)
-                    .trim()
-                    .upper()
-                    .regexp_split_to_array('\\s+') AS tokens_r
-            FROM token_addresses
-        ),
-        block_tokens AS (
-            SELECT
-                source.ukam_address_id_r,
-                source.tokens_r,
-                concat_ws(' ', candidate.__token_address_l, candidate.postcode_l)
-                    .trim()
-                    .upper()
-                    .regexp_split_to_array('\\s+') AS candidate_tokens
-            FROM token_addresses AS candidate
-            JOIN source_tokens AS source USING (ukam_address_id_r)
-            {eligibility_filter}
-        ),
-        block_histograms AS (
-            SELECT
-                ukam_address_id_r,
-                ANY_VALUE(tokens_r) AS tokens_r,
-                list_aggregate(
-                    {candidate_token_lists_sql}.flatten(),
-                    'histogram'
-                ) AS hist_all_tokens_in_block_l,
-                {canonical_bigrams_sql}
-            FROM block_tokens
-            GROUP BY ukam_address_id_r
-        )
-        SELECT
-            *,
-            map_from_entries(
-                list_filter(
-                    map_entries(hist_all_tokens_in_block_l),
-                    entry -> list_contains(tokens_r, entry.key)
-                )
-            ) AS hist_overlapping_tokens_r_block_l,
-            list_aggregate(bigrams_in_block_l, 'histogram')
-                AS hist_all_bigrams_in_block_l,
+        canonical_bigrams_sql = """
             list_transform(
-                list_zip(
-                    list_slice(tokens_r, 1, length(tokens_r) - 1),
-                    list_slice(tokens_r, 2, length(tokens_r))
-                ),
-                pair -> ARRAY[pair[1], pair[2]]
-            ) AS bigrams_r
-        FROM block_histograms
-    """).create("block_statistics")
+                array_agg(candidate_tokens),
+                candidate_tokens -> list_distinct(
+                    list_transform(
+                        list_zip(
+                            list_slice(candidate_tokens, 1, length(candidate_tokens) - 1),
+                            list_slice(candidate_tokens, 2, length(candidate_tokens))
+                        ),
+                        pair -> ARRAY[pair[1], pair[2]]
+                    )
+                )
+            ).flatten() AS bigrams_in_block_l,
+            """
 
-    con.sql(f"""
-        WITH intermediate AS (
-            SELECT
-                candidate.match_weight,
-                candidate.match_probability,
-                candidate.unique_id_l,
-                candidate.unique_id_r,
-                candidate.original_address_concat_l,
-                candidate.original_address_concat_r,
-                candidate.ukam_address_id_l,
-                candidate.ukam_address_id_r,
-                candidate.postcode_l,
-                candidate.postcode_r,
-                concat_ws(' ', candidate.__token_address_l, candidate.postcode_l)
-                    .trim()
-                    .upper()
-                    .regexp_split_to_array('\\s+') AS tokens_l,
-                statistics.tokens_r,
-                statistics.hist_all_tokens_in_block_l,
-                statistics.hist_overlapping_tokens_r_block_l,
-                statistics.hist_all_bigrams_in_block_l,
-                statistics.bigrams_r,
-                {retained_columns}
-                list_distinct(
-                    list_filter(
-                        concat_ws(' ', candidate.__token_address_l, candidate.postcode_l)
-                            .trim()
-                            .upper()
-                            .regexp_split_to_array('\\s+'),
-                            token -> token IN {_POSITIONAL_TOKENS_SQL}
-                    )
-                ) AS positional_tokens_l,
-                list_distinct(
-                    list_filter(
-                        statistics.tokens_r,
-                            token -> token IN {_POSITIONAL_TOKENS_SQL}
-                    )
-                ) AS positional_tokens_r
-            FROM token_addresses AS candidate
-            LEFT JOIN block_statistics AS statistics USING (ukam_address_id_r)
-        ),
-        candidate_features AS (
+        con.sql(f"""
+            SELECT *
+            FROM df_predict
+            WHERE match_weight > {match_weight_threshold}
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY unique_id_r, unique_id_l
+                ORDER BY match_weight DESC, ukam_address_id_r DESC, ukam_address_id_l DESC
+            ) = 1
+        """).create(good_matches_table)
+
+        con.sql(f"""
+            SELECT *
+            FROM {good_matches_table}
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY unique_id_r
+                ORDER BY match_weight DESC, unique_id_l DESC
+            ) <= {top_n_matches}
+        """).create(top_n_matches_table)
+
+        con.sql(f"""
+            WITH intermediate AS (
+                SELECT *, map_keys(common_end_tokens_hist_r) AS common_end_tokens_r
+                FROM {top_n_matches_table}
+            ),
+            enriched AS (
+                SELECT
+                    *,
+                    COALESCE(
+                        common_end_tokens_r.list_transform(
+                            value -> COALESCE(
+                                struct_extract(
+                                    TRY_CAST(
+                                    value AS STRUCT(tok VARCHAR, rel_freq DOUBLE)
+                                ),
+                                    'tok'
+                                ),
+                                TRY_CAST(value AS VARCHAR)
+                            )
+                        ),
+                        CAST([] AS VARCHAR[])
+                    ) AS common_end_tokens_tok
+                FROM intermediate
+            )
             SELECT
                 *,
-                map_from_entries(
-                    list_filter(
-                        map_entries(hist_overlapping_tokens_r_block_l),
-                        entry -> list_contains(tokens_l, entry.key)
-                    )
-                ) AS overlapping_tokens_this_l_and_r,
-                map_from_entries(list_distinct(list_transform(
-                    list_filter(tokens_r, token -> token NOT IN tokens_l),
-                    token -> {{'key': token, 'value': true}}
-                ))) AS tokens_r_not_in_l_map,
-                list_filter(tokens_l, token -> token NOT IN tokens_r) AS missing_tokens,
-                list_transform(
-                    list_zip(
-                        list_slice(tokens_l, 1, length(tokens_l) - 1),
-                        list_slice(tokens_l, 2, length(tokens_l))
-                    ),
-                    pair -> ARRAY[pair[1], pair[2]]
-                ) AS bigrams_l
-            FROM intermediate
-        ),
-        evidence AS (
+                clean_full_address_l
+                    .trim()
+                    .upper()
+                    .regexp_split_to_array('\\s+')
+                    .list_reverse()
+                    .list_filter((token, position) -> NOT (
+                        position = 1 AND common_end_tokens_tok.list_contains(token)
+                    ))
+                    .list_filter((token, position) -> NOT (
+                        position = 1 AND common_end_tokens_tok.list_contains(token)
+                    ))
+                    .list_reverse()
+                    .array_to_string(' ') AS __token_address_l,
+                clean_full_address_r
+                    .trim()
+                    .upper()
+                    .regexp_split_to_array('\\s+')
+                    .list_reverse()
+                    .list_filter((token, position) -> NOT (
+                        position = 1 AND common_end_tokens_tok.list_contains(token)
+                    ))
+                    .list_filter((token, position) -> NOT (
+                        position = 1 AND common_end_tokens_tok.list_contains(token)
+                    ))
+                    .list_reverse()
+                    .array_to_string(' ') AS __token_address_r
+            FROM enriched
+        """).create(token_addresses_table)
+
+        con.sql(f"""
+            WITH source_tokens AS (
+                SELECT DISTINCT
+                    ukam_address_id_r,
+                    concat_ws(' ', __token_address_r, postcode_r)
+                        .trim()
+                        .upper()
+                        .regexp_split_to_array('\\s+') AS tokens_r
+                FROM {token_addresses_table}
+            ),
+            block_tokens AS (
+                SELECT
+                    source.ukam_address_id_r,
+                    source.tokens_r,
+                    concat_ws(
+                                ' ', candidate.__token_address_l, candidate.postcode_l
+                            )
+                        .trim()
+                        .upper()
+                        .regexp_split_to_array('\\s+') AS candidate_tokens
+                FROM {token_addresses_table} AS candidate
+                JOIN source_tokens AS source USING (ukam_address_id_r)
+                {eligibility_filter}
+            ),
+            block_histograms AS (
+                SELECT
+                    ukam_address_id_r,
+                    ANY_VALUE(tokens_r) AS tokens_r,
+                    list_aggregate(
+                        {candidate_token_lists_sql}.flatten(),
+                        'histogram'
+                    ) AS hist_all_tokens_in_block_l,
+                    {canonical_bigrams_sql}
+                FROM block_tokens
+                GROUP BY ukam_address_id_r
+            )
             SELECT
                 *,
                 map_from_entries(
                     list_filter(
                         map_entries(hist_all_tokens_in_block_l),
-                        entry -> map_contains(tokens_r_not_in_l_map, entry.key)
+                        entry -> list_contains(tokens_r, entry.key)
                     )
-                ) AS tokens_elsewhere_in_block_but_not_this,
-                map_from_entries(list_distinct(list_transform(
-                    list_filter(bigrams_r, bigram -> bigram NOT IN bigrams_l),
-                    bigram -> {{'key': bigram, 'value': true}}
-                ))) AS bigrams_r_not_in_l_map,
-                map_from_entries(
-                    list_filter(
-                        map_entries(hist_overlapping_tokens_r_block_l),
-                        entry -> list_contains(tokens_l, entry.key)
-                    )
-                ) AS overlapping_tokens_this_l_and_r_again
-            FROM candidate_features
-        ),
-        adjusted_evidence AS (
-            SELECT
-                *,
-                overlapping_tokens_this_l_and_r_again
-                    AS overlapping_tokens_this_l_and_r,
-                map_from_entries(
-                    list_filter(
-                        map_entries(hist_all_bigrams_in_block_l),
-                        entry -> list_contains(bigrams_r, entry.key)
-                    )
-                ) AS hist_overlapping_bigrams_r_block_l,
-                map_from_entries(
-                    list_filter(
-                        map_entries(hist_all_bigrams_in_block_l),
-                        entry -> map_contains(bigrams_r_not_in_l_map, entry.key)
-                    )
-                ) AS bigrams_elsewhere_in_block_but_not_this
-            FROM evidence
-        ),
-        components AS (
-            SELECT
-                *,
-                map_from_entries(
-                    list_filter(
-                        map_entries(hist_overlapping_bigrams_r_block_l),
-                        entry -> list_contains(bigrams_l, entry.key)
-                    )
-                ) AS overlapping_bigrams_this_l_and_r,
-                COALESCE(list_sum(list_transform(
-                    map_values(overlapping_tokens_this_l_and_r),
-                    value -> 1.0 / (value * value)
-                )), 0.0) * {REWARD_MULTIPLIER} AS token_reward,
-                COALESCE(len(map_entries(
-                    tokens_elsewhere_in_block_but_not_this
-                )), 0)::DOUBLE
-                    * {PUNISHMENT_MULTIPLIER} AS token_absence_penalty,
-                COALESCE(len(missing_tokens), 0)::DOUBLE * {MISSING_TOKEN_PENALTY}
-                    AS missing_token_penalty,
-                CASE
-                    WHEN COALESCE(len(positional_tokens_l), 0) > 0
-                        AND COALESCE(len(positional_tokens_r), 0) > 0
-                        AND COALESCE(
-                            len(list_intersect(positional_tokens_l, positional_tokens_r)),
-                            0
-                        ) = 0
-                    THEN {POSITIONAL_CONFLICT_PENALTY}
-                    ELSE 0.0
-                END AS positional_conflict_penalty
-            FROM adjusted_evidence
-        ),
-        scored_components AS (
-            SELECT
-                *,
-                map_from_entries(
-                    list_filter(
-                        map_entries(overlapping_bigrams_this_l_and_r),
-                        entry -> NOT (
-                            map_contains(
-                                overlapping_tokens_this_l_and_r, entry.key[1]
+                ) AS hist_overlapping_tokens_r_block_l,
+                list_aggregate(bigrams_in_block_l, 'histogram')
+                    AS hist_all_bigrams_in_block_l,
+                list_transform(
+                    list_zip(
+                        list_slice(tokens_r, 1, length(tokens_r) - 1),
+                        list_slice(tokens_r, 2, length(tokens_r))
+                    ),
+                    pair -> ARRAY[pair[1], pair[2]]
+                ) AS bigrams_r
+            FROM block_histograms
+        """).create(block_statistics_table)
+
+        con.sql(f"""
+            WITH intermediate AS (
+                SELECT
+                    candidate.match_weight,
+                    candidate.match_probability,
+                    candidate.unique_id_l,
+                    candidate.unique_id_r,
+                    candidate.original_address_concat_l,
+                    candidate.original_address_concat_r,
+                    candidate.ukam_address_id_l,
+                    candidate.ukam_address_id_r,
+                    candidate.postcode_l,
+                    candidate.postcode_r,
+                    concat_ws(
+                                ' ', candidate.__token_address_l, candidate.postcode_l
                             )
-                            AND overlapping_tokens_this_l_and_r[entry.key[1]]
-                                <= entry.value
-                            AND map_contains(
-                                overlapping_tokens_this_l_and_r, entry.key[2]
+                        .trim()
+                        .upper()
+                        .regexp_split_to_array('\\s+') AS tokens_l,
+                    statistics.tokens_r,
+                    statistics.hist_all_tokens_in_block_l,
+                    statistics.hist_overlapping_tokens_r_block_l,
+                    statistics.hist_all_bigrams_in_block_l,
+                    statistics.bigrams_r,
+                    {retained_columns}
+                    list_distinct(
+                        list_filter(
+                            concat_ws(
+                                ' ', candidate.__token_address_l, candidate.postcode_l
                             )
-                            AND overlapping_tokens_this_l_and_r[entry.key[2]]
-                                <= entry.value
+                                .trim()
+                                .upper()
+                                .regexp_split_to_array('\\s+'),
+                                token -> token IN {_POSITIONAL_TOKENS_SQL}
                         )
-                    )
-                ) AS overlapping_bigrams_this_l_and_r_filtered,
-                map_from_entries(
-                    list_filter(
-                        map_entries(bigrams_elsewhere_in_block_but_not_this),
-                        entry -> NOT (
-                            map_contains(
-                                tokens_elsewhere_in_block_but_not_this,
-                                entry.key[1]
-                            )
-                            AND tokens_elsewhere_in_block_but_not_this[entry.key[1]]
-                                <= entry.value
-                            AND map_contains(
-                                tokens_elsewhere_in_block_but_not_this,
-                                entry.key[2]
-                            )
-                            AND tokens_elsewhere_in_block_but_not_this[entry.key[2]]
-                                <= entry.value
+                    ) AS positional_tokens_l,
+                    list_distinct(
+                        list_filter(
+                            statistics.tokens_r,
+                                token -> token IN {_POSITIONAL_TOKENS_SQL}
                         )
-                    )
-                ) AS bigrams_elsewhere_in_block_but_not_this_filtered
-            FROM components
-        ),
-        scored_candidates AS (
+                    ) AS positional_tokens_r
+                FROM {token_addresses_table} AS candidate
+                LEFT JOIN {block_statistics_table} AS statistics USING (ukam_address_id_r)
+            ),
+            candidate_features AS (
+                SELECT
+                    *,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(hist_overlapping_tokens_r_block_l),
+                            entry -> list_contains(tokens_l, entry.key)
+                        )
+                    ) AS overlapping_tokens_this_l_and_r,
+                    map_from_entries(list_distinct(list_transform(
+                        list_filter(tokens_r, token -> token NOT IN tokens_l),
+                        token -> {{'key': token, 'value': true}}
+                    ))) AS tokens_r_not_in_l_map,
+                    list_filter(tokens_l, token -> token NOT IN tokens_r)
+                        AS missing_tokens,
+                    list_transform(
+                        list_zip(
+                            list_slice(tokens_l, 1, length(tokens_l) - 1),
+                            list_slice(tokens_l, 2, length(tokens_l))
+                        ),
+                        pair -> ARRAY[pair[1], pair[2]]
+                    ) AS bigrams_l
+                FROM intermediate
+            ),
+            evidence AS (
+                SELECT
+                    *,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(hist_all_tokens_in_block_l),
+                            entry -> map_contains(tokens_r_not_in_l_map, entry.key)
+                        )
+                    ) AS tokens_elsewhere_in_block_but_not_this,
+                    map_from_entries(list_distinct(list_transform(
+                        list_filter(bigrams_r, bigram -> bigram NOT IN bigrams_l),
+                        bigram -> {{'key': bigram, 'value': true}}
+                    ))) AS bigrams_r_not_in_l_map,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(hist_overlapping_tokens_r_block_l),
+                            entry -> list_contains(tokens_l, entry.key)
+                        )
+                    ) AS overlapping_tokens_this_l_and_r_again
+                FROM candidate_features
+            ),
+            adjusted_evidence AS (
+                SELECT
+                    *,
+                    overlapping_tokens_this_l_and_r_again
+                        AS overlapping_tokens_this_l_and_r,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(hist_all_bigrams_in_block_l),
+                            entry -> list_contains(bigrams_r, entry.key)
+                        )
+                    ) AS hist_overlapping_bigrams_r_block_l,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(hist_all_bigrams_in_block_l),
+                            entry -> map_contains(bigrams_r_not_in_l_map, entry.key)
+                        )
+                    ) AS bigrams_elsewhere_in_block_but_not_this
+                FROM evidence
+            ),
+            components AS (
+                SELECT
+                    *,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(hist_overlapping_bigrams_r_block_l),
+                            entry -> list_contains(bigrams_l, entry.key)
+                        )
+                    ) AS overlapping_bigrams_this_l_and_r,
+                    COALESCE(list_sum(list_transform(
+                        map_values(overlapping_tokens_this_l_and_r),
+                        value -> 1.0 / (value * value)
+                    )), 0.0) * {REWARD_MULTIPLIER} AS token_reward,
+                    COALESCE(len(map_entries(
+                        tokens_elsewhere_in_block_but_not_this
+                    )), 0)::DOUBLE
+                        * {PUNISHMENT_MULTIPLIER} AS token_absence_penalty,
+                    COALESCE(len(missing_tokens), 0)::DOUBLE * {MISSING_TOKEN_PENALTY}
+                        AS missing_token_penalty,
+                    CASE
+                        WHEN COALESCE(len(positional_tokens_l), 0) > 0
+                            AND COALESCE(len(positional_tokens_r), 0) > 0
+                            AND COALESCE(
+                                len(
+                                list_intersect(positional_tokens_l, positional_tokens_r)
+                            ),
+                                0
+                            ) = 0
+                        THEN {POSITIONAL_CONFLICT_PENALTY}
+                        ELSE 0.0
+                    END AS positional_conflict_penalty
+                FROM adjusted_evidence
+            ),
+            scored_components AS (
+                SELECT
+                    *,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(overlapping_bigrams_this_l_and_r),
+                            entry -> NOT (
+                                map_contains(
+                                    overlapping_tokens_this_l_and_r, entry.key[1]
+                                )
+                                AND overlapping_tokens_this_l_and_r[entry.key[1]]
+                                    <= entry.value
+                                AND map_contains(
+                                    overlapping_tokens_this_l_and_r, entry.key[2]
+                                )
+                                AND overlapping_tokens_this_l_and_r[entry.key[2]]
+                                    <= entry.value
+                            )
+                        )
+                    ) AS overlapping_bigrams_this_l_and_r_filtered,
+                    map_from_entries(
+                        list_filter(
+                            map_entries(bigrams_elsewhere_in_block_but_not_this),
+                            entry -> NOT (
+                                map_contains(
+                                    tokens_elsewhere_in_block_but_not_this,
+                                    entry.key[1]
+                                )
+                                AND tokens_elsewhere_in_block_but_not_this[entry.key[1]]
+                                    <= entry.value
+                                AND map_contains(
+                                    tokens_elsewhere_in_block_but_not_this,
+                                    entry.key[2]
+                                )
+                                AND tokens_elsewhere_in_block_but_not_this[entry.key[2]]
+                                    <= entry.value
+                            )
+                        )
+                    ) AS bigrams_elsewhere_in_block_but_not_this_filtered
+                FROM components
+            ),
+            scored_candidates AS (
+                SELECT
+                    *,
+                    COALESCE(list_sum(list_transform(
+                        map_values(overlapping_bigrams_this_l_and_r_filtered),
+                        value -> 1.0 / (value * value)
+                    )), 0.0) * {BIGRAM_REWARD_MULTIPLIER} AS bigram_reward,
+                    COALESCE(len(map_entries(
+                        bigrams_elsewhere_in_block_but_not_this_filtered
+                    )), 0)::DOUBLE
+                        * {BIGRAM_PUNISHMENT_MULTIPLIER} AS bigram_absence_penalty
+                FROM scored_components
+            )
             SELECT
-                *,
-                COALESCE(list_sum(list_transform(
-                    map_values(overlapping_bigrams_this_l_and_r_filtered),
-                    value -> 1.0 / (value * value)
-                )), 0.0) * {BIGRAM_REWARD_MULTIPLIER} AS bigram_reward,
-                COALESCE(len(map_entries(
-                    bigrams_elsewhere_in_block_but_not_this_filtered
-                )), 0)::DOUBLE
-                    * {BIGRAM_PUNISHMENT_MULTIPLIER} AS bigram_absence_penalty
-            FROM scored_components
-        )
-        SELECT
-            unique_id_l,
-            unique_id_r,
-            ukam_address_id_r,
-            ukam_address_id_l,
-            match_weight AS match_weight_original,
-            token_reward,
-            token_absence_penalty,
-            bigram_reward,
-            bigram_absence_penalty,
-            missing_token_penalty,
-            positional_conflict_penalty,
-            token_reward
-                - token_absence_penalty
-                + bigram_reward
-                - bigram_absence_penalty
-                - missing_token_penalty
-                - positional_conflict_penalty AS mw_adjustment,
-            match_weight + mw_adjustment AS match_weight,
-            overlapping_tokens_this_l_and_r,
-            tokens_elsewhere_in_block_but_not_this,
-            hist_all_tokens_in_block_l,
-            hist_overlapping_tokens_r_block_l,
-            missing_tokens,
-            positional_tokens_l,
-            positional_tokens_r,
-            {"bigrams_l, bigrams_r, " if use_bigrams else ""}
-            {"overlapping_bigrams_this_l_and_r, " if use_bigrams else ""}
-            {"bigrams_elsewhere_in_block_but_not_this, " if use_bigrams else ""}
-            {"hist_all_bigrams_in_block_l, " if use_bigrams else ""}
-            {"hist_overlapping_bigrams_r_block_l, " if use_bigrams else ""}
-            {"overlapping_bigrams_this_l_and_r_filtered, " if use_bigrams else ""}
-            {"bigrams_elsewhere_in_block_but_not_this_filtered, " if use_bigrams else ""}
-            original_address_concat_l,
-            postcode_l,
-            original_address_concat_r,
-            postcode_r,
-            {retained_columns}
-        FROM scored_candidates
-    """).create(matches_table)
+                unique_id_l,
+                unique_id_r,
+                ukam_address_id_r,
+                ukam_address_id_l,
+                match_weight AS match_weight_original,
+                token_reward,
+                token_absence_penalty,
+                bigram_reward,
+                bigram_absence_penalty,
+                missing_token_penalty,
+                positional_conflict_penalty,
+                token_reward
+                    - token_absence_penalty
+                    + bigram_reward
+                    - bigram_absence_penalty
+                    - missing_token_penalty
+                    - positional_conflict_penalty AS mw_adjustment,
+                match_weight + mw_adjustment AS match_weight,
+                overlapping_tokens_this_l_and_r,
+                tokens_elsewhere_in_block_but_not_this,
+                hist_all_tokens_in_block_l,
+                hist_overlapping_tokens_r_block_l,
+                missing_tokens,
+                positional_tokens_l,
+                positional_tokens_r,
+                {"bigrams_l, bigrams_r, " if use_bigrams else ""}
+                {"overlapping_bigrams_this_l_and_r, " if use_bigrams else ""}
+                {"bigrams_elsewhere_in_block_but_not_this, " if use_bigrams else ""}
+                {"hist_all_bigrams_in_block_l, " if use_bigrams else ""}
+                {"hist_overlapping_bigrams_r_block_l, " if use_bigrams else ""}
+                {"overlapping_bigrams_this_l_and_r_filtered, " if use_bigrams else ""}
+                {
+                    "bigrams_elsewhere_in_block_but_not_this_filtered, "
+                    if use_bigrams
+                    else ""
+                }
+                original_address_concat_l,
+                postcode_l,
+                original_address_concat_r,
+                postcode_r,
+                {retained_columns}
+            FROM scored_candidates
+        """).create(matches_table)
+
+    except BaseException:
+        _drop_table_and_registered_aliases(con, matches_table)
+        raise
+    finally:
+        for intermediate_table in intermediate_tables:
+            _drop_table_and_registered_aliases(con, intermediate_table)
 
     return con.table(matches_table)

--- a/uk_address_matcher/post_linkage/match_result/result.py
+++ b/uk_address_matcher/post_linkage/match_result/result.py
@@ -27,6 +27,7 @@ from uk_address_matcher.post_linkage.match_result.debug_tools import (
     _MatchResultDebugTools,
 )
 from uk_address_matcher.post_linkage.match_result.splink_inspector import _SplinkInspector
+from uk_address_matcher.sql_pipeline.helpers import _drop_table_and_registered_aliases
 
 if TYPE_CHECKING:
     from uk_address_matcher.linking_model.matching.stages.splink import SplinkStage
@@ -46,6 +47,10 @@ class MatchResult:
     Key methods:
         match_metrics      - match-reason breakdown with counts and percentages.
         match_reasons      - distinct match-reason values.
+        close              - drop every table/view retained for this result,
+                             including the result table itself. After close(),
+                             `.matches()` and the inspection methods no longer
+                             work. Also usable as a context manager.
         _splink_predictions - raw Splink predictions table (requires `SplinkStage`).
     """
 
@@ -55,6 +60,13 @@ class MatchResult:
     _canonical_relation: DuckDBPyRelation | None = None
     _messy_relation: DuckDBPyRelation | None = None
     _stage_diagnostics: StageDiagnostics | None = None
+    # Catalogue objects this result owns and drops on close(). Snapshotted at
+    # construction time, so reusing the same stage objects for a later run
+    # cannot repoint an earlier result's cleanup at the newer run's tables.
+    _owned_table_names: tuple[str, ...] = ()
+    # SplinkDataFrame handles for Splink-side tables, dropped via Splink's
+    # public API on close().
+    _owned_splink_frames: tuple = ()
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
@@ -98,6 +110,33 @@ class MatchResult:
             FROM ({base_relation_sql}) AS match_result
             """
         )
+
+    def close(self) -> None:
+        """Release every table/view retained for this result.
+
+        Idempotent. Drops only objects owned by this result, so closing an
+        earlier result never invalidates a later live result on the same
+        connection. After close(), `.matches()` and inspection methods raise.
+        """
+        for frame in self._owned_splink_frames:
+            try:
+                frame.drop_table_from_database_and_remove_from_cache(
+                    force_non_splink_table=True
+                )
+            except Exception:
+                # Best-effort: already dropped, or connection closing.
+                pass
+        self._owned_splink_frames = ()
+        for table_name in self._owned_table_names:
+            _drop_table_and_registered_aliases(self.con, table_name)
+        self._owned_table_names = ()
+
+    def __enter__(self) -> "MatchResult":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.close()
+        return False
 
     def match_metrics(
         self,

--- a/uk_address_matcher/sql_pipeline/helpers.py
+++ b/uk_address_matcher/sql_pipeline/helpers.py
@@ -183,16 +183,15 @@ def _drop_table_and_registered_aliases(
     con: duckdb.DuckDBPyConnection,
     table_name: str,
 ) -> None:
-    object_row = con.execute(
-        "SELECT table_type FROM information_schema.tables WHERE table_name = ?",
+    # information_schema.tables reports temporary tables AND temporary views
+    # as 'LOCAL TEMPORARY', so table_type cannot distinguish them. Check
+    # duckdb_views() (which covers regular views, temp views, and relations
+    # registered via con.register) and fall back to DROP TABLE IF EXISTS.
+    view_exists = con.execute(
+        "SELECT 1 FROM duckdb_views() WHERE view_name = ?",
         [table_name],
     ).fetchone()
-
-    if object_row is None:
-        return
-
-    object_type = object_row[0]
-    if object_type == "VIEW":
+    if view_exists is not None:
         con.execute(f"DROP VIEW IF EXISTS {_quote_identifier(table_name)}")
         return
 


### PR DESCRIPTION
Fixes #461.

Calling `AddressMatcher.match()` more than once on the same DuckDB connection failed on the second call:

```
ValueError: Table(s): __splink__df_concat_with_tf_e5bphl9c already exists in database
```

This builds directly on @ThomasHepworth's WIP branch `fix/resolve-issue-with-sequential-matching` .

## What changed

**Fixed Splink linker ID.** `linker_uid` is set to `None` so Splink generates a fresh uid per linker, and the stale `"linker_uid": "e5bphl9c"` entry is removed from the bundled `splink_model.json`.

**Post-linkage table names.** The five reranker tables (`good_matches`, `top_n_matches`, `token_addresses`, `block_statistics`, `__ukam__distinguishability_matches`) now get run-unique `__ukam__tmp_*_{uid}` names. The four intermediates are dropped on **every** exit path (`try/finally`), and the output table is dropped if the reranker fails part-way through building it.

**User tables named `m_` / `c_` are no longer touched.** Previously these were dropped outright to make room for Splink's dataset labels. The matching relations are now *registered* under those names only for the duration of the Splink run and unregistered in a `finally`, so persistent user tables with those names reappear unchanged, including when the run raises an exception partway through. There's a regression test that creates user tables under all seven legacy internal names and asserts their contents survive a full Splink match.

**Splink table cleanup uses Splink's public API.** The `SplinkDataFrame` handles returned by `register_term_frequency_lookup` / `register_table_input_nodes_concat_with_tf` / `predict()` are retained and dropped via `drop_table_from_database_and_remove_from_cache(force_non_splink_table=True)`. No reliance on `linker._cache_uid` or reconstructed internal table names.

**`MatchResult.close()`.** Each result now owns the run-scoped objects backing its inspection APIs (final matches, processed relations, Splink predictions/best-matches) and releases them via `close()`, which is idempotent and also available as a context manager (`with matcher.match() as result:`). Ownership is snapshotted at construction, so closing an earlier result never invalidates a later live result on the same connection, even when stage objects are reused. Calling `close()` is optional — without it, behaviour matches previous releases except that objects are uniquely named.

**Failure paths.** A failed `match()` now runs the same transient-table sweep as the success path; a failed Splink stage drops its predict/tf/concat/reranker objects. A test simulates a mid-Splink exception and asserts user `m_`/`c_` tables resolve to user data again and no run-scoped catalogue objects remain.

**Cleanup helper fix.** DuckDB's `information_schema.tables` reports temporary tables *and* temporary views as `LOCAL TEMPORARY`, so `table_type` couldn't distinguish them; the helper now checks `duckdb_views()` first (covers regular views, temp views, and `con.register` relations) and falls back to `DROP TABLE IF EXISTS`.

**Inverted-index lifecycle.** The two disposable derived inverted-index objects are dropped as soon as messy-address preparation finishes rather than accumulating per run.

## In the next PR as it's a slightly different issue

- **Prepared-canonical caching** (reusing prepared canonical data across sequential runs on one connection), will need to create a follow-up PR with a benchmark.
- **`__ukam_derived_term_frequencies` / `__ukam_index_meta`** are pre-existing fixed-name tables recreated per run and not covered by the ownership model. Tracked separately; the file-backed-database test documents them as known exceptions.

## Validation

- Full suite: **305 passed**; ruff clean.
- New behavioural tests: two sequential Splink matches on one connection; preservation of user tables under all legacy internal names; exception mid-Splink restores user tables and leaves no run-scoped objects; two live results closed out of order (later result unaffected); idempotent `close()`; context-manager usage; file-backed database contains no run-scoped tables after `close()` and reopen.