### PR TITLE
feat: add Google Maps link to messy input record review

### DIFF
--- a/tests/labelling/test_canonical_search.py
+++ b/tests/labelling/test_canonical_search.py
@@ -109,7 +109,7 @@ def test_rejects_missing_cleaned_address_column(tmp_path: Path) -> None:
         load_canonical_source(path)
 
 
-def test_search_returns_stable_unique_pages_and_literal_substrings(
+def test_search_returns_stable_pages_and_literal_substrings(
     tmp_path: Path,
 ) -> None:
     path = tmp_path / "canonical.parquet"
@@ -123,19 +123,40 @@ def test_search_returns_stable_unique_pages_and_literal_substrings(
     page_two = search_canonical_data(
         source, postcode="E5 8RY", address_query="STREET", page=2
     )
-    page_one_ids = [row["canonical_id"] for row in page_one.rows]
-    page_two_ids = [row["canonical_id"] for row in page_two.rows]
+    page_four = search_canonical_data(
+        source, postcode="E5 8RY", address_query="STREET", page=4
+    )
 
     assert len(page_one.rows) == CANONICAL_PAGE_SIZE
     assert len(page_two.rows) == CANONICAL_PAGE_SIZE
-    assert len(set(page_one_ids)) == CANONICAL_PAGE_SIZE
-    assert len(set(page_two_ids)) == CANONICAL_PAGE_SIZE
-    assert set(page_one_ids).isdisjoint(page_two_ids)
-    assert len(set(page_one_ids) | set(page_two_ids)) == 200
+    assert len(page_four.rows) == CANONICAL_PAGE_SIZE
+    assert (
+        len(
+            {
+                (row["canonical_id"], row["cleaned_address"])
+                for page in (page_one, page_two, page_four)
+                for row in page.rows
+            }
+        )
+        == CANONICAL_PAGE_SIZE * 3
+    )
     assert page_one.has_previous is False
     assert page_one.has_next is True
     assert page_two.has_previous is True
-    assert page_two.has_next is False
+    assert page_two.has_next is True
+    assert page_four.has_previous is True
+    assert page_four.has_next is False
+    duplicate_id_rows = search_canonical_data(
+        source, postcode="E5 8RY", address_query="199 TEST STREET", page=1
+    ).rows
+    assert [row["canonical_id"] for row in duplicate_id_rows] == [
+        "CANON_0199",
+        "CANON_0199",
+    ]
+    assert [row["cleaned_address"] for row in duplicate_id_rows] == [
+        "199 TEST STREET HACKNEY LONDON",
+        "FLAT 199 TEST STREET HACKNEY LONDON",
+    ]
     assert (
         search_canonical_data(
             source, postcode="E5 8RY", address_query="street", page=1

--- a/tests/labelling/test_canonical_search.py
+++ b/tests/labelling/test_canonical_search.py
@@ -157,6 +157,11 @@ def test_search_returns_stable_pages_and_literal_substrings(
         "199 TEST STREET HACKNEY LONDON",
         "FLAT 199 TEST STREET HACKNEY LONDON",
     ]
+    filtered_by_id = search_canonical_data(
+        source, unique_id_query="percent", postcode=None, address_query=None, page=1
+    )
+    assert filtered_by_id.unique_id_query == "percent"
+    assert [row["canonical_id"] for row in filtered_by_id.rows] == ["PERCENT"]
     assert (
         search_canonical_data(
             source, postcode="E5 8RY", address_query="street", page=1
@@ -187,7 +192,7 @@ def test_search_validation_lookup_and_parquet_plan(tmp_path: Path) -> None:
     assert normalise_postcode_search("n165fd") == "N16 5FD"
     assert find_canonical_record(source, "PERCENT")["canonical_postcode"] == "N16 5FD"
     assert find_canonical_record(source, "missing") is None
-    with pytest.raises(ValueError, match="postcode or an address"):
+    with pytest.raises(ValueError, match="unique ID"):
         search_canonical_data(source, postcode=None, address_query=None, page=1)
     with pytest.raises(ValueError, match="at least 1"):
         search_canonical_data(source, postcode="E5 8RY", address_query=None, page=0)

--- a/tests/labelling/test_server.py
+++ b/tests/labelling/test_server.py
@@ -85,7 +85,8 @@ def create_api_test_bundle(root: Path, *, include_unmatched: bool = False) -> Pa
                     FALSE, 'canonical-2', 'label-3', '2 TEST ROAD LONDON',
                     'E1 1AB', 'exact: full match', 'exact', TRUE,
                     NULL::DOUBLE, NULL::DOUBLE, 1,
-                                        [{'rank': 1::BIGINT, 'label_id': 'label-3'::VARCHAR,
+                                        [{'rank': 1::BIGINT,
+                                            'label_id': 'label-3'::VARCHAR,
                                             'splink_match_weight': 8.0::DOUBLE}]
 """
                 + unmatched_record

--- a/tests/labelling/test_server.py
+++ b/tests/labelling/test_server.py
@@ -29,13 +29,29 @@ from uk_address_matcher.labelling.server import (
 )
 
 
-def create_api_test_bundle(root: Path) -> Path:
+def create_api_test_bundle(root: Path, *, include_unmatched: bool = False) -> Path:
     root.mkdir()
     data_file = root / "review_data.parquet"
+    first_imported_label = "'label-imported'" if include_unmatched else "NULL::VARCHAR"
+    first_has_existing_label = "TRUE" if include_unmatched else "FALSE"
+    unmatched_record = (
+        """
+                UNION ALL
+                SELECT
+                    'bundle-1', '1.2.3', CURRENT_TIMESTAMP, 'messy-unmatched',
+                    'UNMATCHED TEST ROAD', 'UNMATCHED TEST ROAD', 'E1 1AC',
+                    'label-unmatched', TRUE, NULL::VARCHAR, NULL::VARCHAR,
+                    NULL::VARCHAR, NULL::VARCHAR, 'No candidate match', 'unmatched',
+                    FALSE, NULL::DOUBLE, NULL::DOUBLE, 0, []
+        """
+        if include_unmatched
+        else ""
+    )
     connection = duckdb.connect()
     try:
         connection.execute(
-            """COPY (
+            (
+                """COPY (
                 SELECT
                     'bundle-1' AS bundle_id,
                     '1.2.3' AS uk_address_matcher_version,
@@ -44,8 +60,8 @@ def create_api_test_bundle(root: Path) -> Path:
                     '1 TEST ROAD' AS messy_address,
                     '1 TEST ROAD' AS messy_cleaned_address,
                     'E1 1AA' AS messy_postcode,
-                    NULL::VARCHAR AS ukam_label,
-                    FALSE AS has_existing_label,
+                    __FIRST_IMPORTED_LABEL__ AS ukam_label,
+                    __FIRST_HAS_EXISTING_LABEL__ AS has_existing_label,
                     'canonical-1' AS resolved_canonical_id,
                     'label-1' AS resolved_label_id,
                     '1 TEST ROAD LONDON' AS resolved_canonical_address,
@@ -57,8 +73,10 @@ def create_api_test_bundle(root: Path) -> Path:
                     2.1 AS distinguishability,
                     2 AS candidate_count,
                     [
-                        {'rank': 1::BIGINT, 'label_id': 'label-1'::VARCHAR},
-                        {'rank': 2::BIGINT, 'label_id': 'label-2'::VARCHAR}
+                        {'rank': 1::BIGINT, 'label_id': 'label-1'::VARCHAR,
+                         'splink_match_weight': 10.0::DOUBLE},
+                        {'rank': 2::BIGINT, 'label_id': 'label-2'::VARCHAR,
+                         'splink_match_weight': 8.0::DOUBLE}
                     ] AS top_candidates
                 UNION ALL
                 SELECT
@@ -67,8 +85,15 @@ def create_api_test_bundle(root: Path) -> Path:
                     FALSE, 'canonical-2', 'label-3', '2 TEST ROAD LONDON',
                     'E1 1AB', 'exact: full match', 'exact', TRUE,
                     NULL::DOUBLE, NULL::DOUBLE, 1,
-                    [{'rank': 1::BIGINT, 'label_id': 'label-3'::VARCHAR}]
-            ) TO ? (FORMAT PARQUET)""",
+                                        [{'rank': 1::BIGINT, 'label_id': 'label-3'::VARCHAR,
+                                            'splink_match_weight': 8.0::DOUBLE}]
+"""
+                + unmatched_record
+                + """
+                ) TO ? (FORMAT PARQUET)"""
+            )
+            .replace("__FIRST_IMPORTED_LABEL__", first_imported_label)
+            .replace("__FIRST_HAS_EXISTING_LABEL__", first_has_existing_label),
             [str(data_file)],
         )
     finally:
@@ -143,6 +168,7 @@ def test_server_requires_token_and_serves_application_shell(
     assert status == 200
     assert isinstance(payload, str)
     assert 'id="score-range-min"' in payload
+    assert 'id="review-current-label-value"' in payload
     assert 'id="review-content"' in payload
 
     status, payload = request(base_url, "/api/bootstrap", token=session.token)
@@ -184,7 +210,6 @@ def test_records_and_review_share_score_and_stage_filters(
         "previous_unique_id": None,
         "next_unique_id": None,
     }
-
     status, payload = request(
         base_url,
         "/api/review-record?unique_id=messy-2&stage=splink",
@@ -194,6 +219,74 @@ def test_records_and_review_share_score_and_stage_filters(
     assert payload == {
         "error": "The requested record does not exist in the current filtered review set"
     }
+
+
+def test_records_support_score_sorting_and_mismatch_filter(tmp_path: Path) -> None:
+    api_bundle = _load_bundle(create_api_test_bundle(tmp_path / "api-bundle"))
+    _ensure_state_database(api_bundle)
+
+    descending = _records_payload(
+        api_bundle,
+        {"sort_by": ["splink_score"], "sort_order": ["desc"]},
+    )
+    ascending = _records_payload(
+        api_bundle,
+        {"sort_by": ["splink_score"], "sort_order": ["asc"]},
+    )
+    assert [row["unique_id"] for row in descending["rows"]] == [
+        "messy-1",
+        "messy-2",
+    ]
+    assert [row["unique_id"] for row in ascending["rows"]] == [
+        "messy-2",
+        "messy-1",
+    ]
+    assert descending["rows"][0]["splink_match_weight"] == 10.0
+
+    mismatch_bundle = _load_bundle(create_test_bundle(tmp_path / "mismatch-bundle"))
+    _ensure_state_database(mismatch_bundle)
+    mismatches = _records_payload(mismatch_bundle, {"mismatches_only": ["true"]})
+    assert mismatches["total_filtered"] == 1
+    assert mismatches["rows"][0]["unique_id"] == "messy-1"
+    assert (
+        _records_payload(
+            mismatch_bundle,
+            {"mismatches_only": ["true"], "show_labelled": ["false"]},
+        )["total_filtered"]
+        == 1
+    )
+
+    unmatched_bundle = _load_bundle(
+        create_api_test_bundle(tmp_path / "unmatched-bundle", include_unmatched=True)
+    )
+    _ensure_state_database(unmatched_bundle)
+    mismatches = _records_payload(unmatched_bundle, {"mismatches_only": ["true"]})
+    assert mismatches["total_filtered"] == 1
+    assert mismatches["rows"][0]["unique_id"] == "messy-1"
+
+    filtered_mismatches = _records_payload(
+        unmatched_bundle,
+        {
+            "mismatches_only": ["true"],
+            "address_query": ["unmatched"],
+        },
+    )
+    assert filtered_mismatches["total_filtered"] == 0
+
+
+def test_record_text_filters_are_grouped_with_other_filters(tmp_path: Path) -> None:
+    bundle = _load_bundle(create_api_test_bundle(tmp_path / "filter-bundle"))
+    _ensure_state_database(bundle)
+
+    records = _records_payload(
+        bundle,
+        {
+            "address_query": ["road"],
+            "stage": ["splink"],
+        },
+    )
+
+    assert [row["unique_id"] for row in records["rows"]] == ["messy-1"]
 
 
 def test_labels_endpoint_validates_candidates_and_writes_csv(
@@ -604,6 +697,15 @@ def test_canonical_search_api_and_selection_validation(tmp_path: Path) -> None:
             "canonical-1",
             "canonical-2",
         ]
+
+        status, payload = request(
+            base_url,
+            "/api/canonical-search?unique_id_query=canonical-2",
+            token=session.token,
+        )
+        assert status == 200
+        assert payload["unique_id_query"] == "canonical-2"
+        assert [row["canonical_id"] for row in payload["rows"]] == ["canonical-2"]
 
         status, payload = request(
             base_url,

--- a/uk_address_matcher/labelling/app/app.css
+++ b/uk_address_matcher/labelling/app/app.css
@@ -1134,6 +1134,16 @@ tbody tr:hover td {
   padding: 15px 18px;
   font-size: 16px;
 }
+.review-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 14px 10px 18px;
+}
+.review-card-header h2 {
+  padding: 5px 0;
+}
 .messy-card {
   background: linear-gradient(
     135deg,
@@ -1142,9 +1152,35 @@ tbody tr:hover td {
   );
   border-color: #bfd4ff;
 }
+.messy-card-header {
+  background: rgba(219, 233, 255, 0.72);
+}
 .messy-card h2 {
   color: #175cd3;
-  background: rgba(219, 233, 255, 0.72);
+}
+.map-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border: 1px solid #8db6f5;
+  border-radius: 5px;
+  background: #fff;
+  color: #175cd3;
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.map-link:hover,
+.map-link:focus-visible {
+  border-color: #175cd3;
+  background: #eaf2ff;
+}
+.map-link-icon {
+  font-size: 14px;
+  line-height: 1;
 }
 .canonical-card {
   background: linear-gradient(

--- a/uk_address_matcher/labelling/app/app.css
+++ b/uk_address_matcher/labelling/app/app.css
@@ -107,6 +107,48 @@ nav {
 .toggle {
   font-size: 13px;
 }
+.toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.toggle input {
+  position: relative;
+  flex: 0 0 auto;
+  width: 36px;
+  height: 20px;
+  margin: 0;
+  appearance: none;
+  border: 1px solid #98a2b3;
+  border-radius: 999px;
+  background: #eaecf0;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.toggle input::after {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px #10182833;
+  content: "";
+  transition: transform 0.15s ease;
+}
+.toggle input:checked {
+  border-color: #175cd3;
+  background: #175cd3;
+}
+.toggle input:checked::after {
+  transform: translateX(16px);
+}
+.toggle input:focus-visible {
+  outline: 2px solid #84adf5;
+  outline-offset: 2px;
+}
 .range-scale,
 .range-labels,
 .sidebar-toggle,
@@ -157,6 +199,32 @@ th {
   color: #475467;
   font-size: 11px;
   text-transform: uppercase;
+}
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-transform: inherit;
+}
+.sort-button:hover,
+.sort-button:focus-visible {
+  color: #175cd3;
+}
+.sort-button:focus-visible {
+  outline: 2px solid #84adf5;
+  outline-offset: 3px;
+}
+.sort-arrow {
+  min-width: 14px;
+  color: #98a2b3;
+  font-size: 14px;
+  line-height: 1;
 }
 .messy {
   background: linear-gradient(
@@ -360,7 +428,7 @@ th {
 }
 .canonical-search-panel {
   display: grid;
-  grid-template-columns: minmax(180px, 0.55fr) minmax(300px, 1.5fr) auto;
+  grid-template-columns: minmax(180px, 0.55fr) minmax(180px, 0.55fr) minmax(260px, 1.5fr) auto;
   align-items: end;
   gap: 14px;
   padding: 18px;
@@ -776,6 +844,38 @@ nav {
   font-weight: 800;
   text-transform: uppercase;
   color: #475467;
+}
+.search-card {
+  gap: 9px;
+}
+.search-field {
+  display: grid;
+  gap: 5px;
+  color: #475467;
+  font-size: 11px;
+  font-weight: 700;
+}
+.search-field input {
+  min-height: 34px;
+  padding: 7px 9px;
+  border: 1px solid #d0d5dd;
+  border-radius: 5px;
+  background: #fff;
+  color: #101828;
+}
+.search-field input::placeholder {
+  color: #98a2b3;
+}
+.search-field input:focus {
+  outline: 0;
+  border-color: #175cd3;
+  box-shadow: 0 0 0 3px #175cd31f;
+}
+.search-card p {
+  margin: 0 2px;
+  color: #667085;
+  font-size: 11px;
+  line-height: 1.4;
 }
 .stage-options {
   display: grid;
@@ -1339,6 +1439,38 @@ tbody tr:hover td {
   display: flex;
   gap: 10px;
 }
+.review-current-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 240px;
+  padding: 8px 12px;
+  border: 1px solid #b8dfc6;
+  border-radius: 6px;
+  background: #f0faf3;
+  color: #344054;
+}
+.review-current-label-icon {
+  color: #18794e;
+  font-size: 20px;
+  line-height: 1;
+}
+.review-current-label-heading,
+.review-current-label strong {
+  display: block;
+}
+.review-current-label-heading {
+  color: #667085;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.review-current-label strong {
+  margin-top: 2px;
+  color: #101828;
+  font-size: 14px;
+  overflow-wrap: anywhere;
+}
 .review-actions .accept {
   color: #18794e;
   border-color: #a9d9b8;
@@ -1400,7 +1532,11 @@ tbody tr:hover td {
   line-height: 1.3;
 }
 .canonical-search-panel {
-  grid-template-columns: minmax(150px, 220px) minmax(240px, 460px) auto;
+  grid-template-columns:
+    minmax(150px, 220px)
+    minmax(150px, 220px)
+    minmax(240px, 460px)
+    auto;
   justify-content: center;
   gap: 10px;
   padding: 12px 14px;

--- a/uk_address_matcher/labelling/app/app.js
+++ b/uk_address_matcher/labelling/app/app.js
@@ -634,7 +634,16 @@ function renderReview() {
   reviewElements.previous.disabled = !navigation.previous_unique_id;
   reviewElements.next.disabled = !navigation.next_unique_id;
   $("review-messy-id").textContent = display(record.unique_id);
-  $("review-messy-address").textContent = display(record.messy_address);
+  const messyAddress = String(record.messy_address || "").trim(),
+    messyPostcode = String(record.messy_postcode || "").trim(),
+    mapQuery = [messyAddress, messyPostcode].filter(Boolean).join(", ");
+  $("review-messy-address").textContent = display(messyAddress);
+  const mapLink = $("review-open-map");
+  mapLink.hidden = !messyAddress;
+  mapLink.href = `https://www.google.com/maps/search/?${new URLSearchParams({
+    api: "1",
+    query: mapQuery,
+  })}`;
   $("review-messy-cleaned").textContent = display(record.messy_cleaned_address);
   $("review-messy-postcode").textContent = display(record.messy_postcode);
   const matched = Boolean(
@@ -1011,20 +1020,14 @@ if (location.hash.startsWith("#review")) loadReview();
     c.table.hidden = false;
     const first = (state.canonical.page - 1) * 100 + 1,
       last = first + state.canonical.rows.length - 1;
-    c.status.textContent = `Showing unique canonical records ${format(first)}-${format(last)}`;
+    c.status.textContent = `Showing canonical records ${format(first)}-${format(last)}`;
     state.canonical.rows.forEach((record) => {
       const row = document.createElement("tr"),
         id = text("td", record.canonical_id, "primary"),
-        address = document.createElement("td"),
         cleaned = document.createElement("td"),
         postcode = text("td", record.canonical_postcode || "-"),
         action = document.createElement("td"),
         button = text("button", "Use this record", "use-canonical-button");
-      appendHighlight(
-        address,
-        record.canonical_address,
-        state.canonical.addressQuery,
-      );
       appendHighlight(
         cleaned,
         record.cleaned_address,
@@ -1033,7 +1036,7 @@ if (location.hash.startsWith("#review")) loadReview();
       button.type = "button";
       button.onclick = () => selectResult(record);
       action.append(button);
-      row.append(id, address, cleaned, postcode, action);
+      row.append(id, cleaned, postcode, action);
       row.ondblclick = () => selectResult(record);
       c.body.append(row);
     });
@@ -1100,7 +1103,7 @@ if (location.hash.startsWith("#review")) loadReview();
     if (!selection) return;
     c.selectionId.textContent = selection.canonical_id;
     c.selectionAddress.textContent = [
-      selection.canonical_address,
+      selection.cleaned_address,
       selection.canonical_postcode,
     ]
       .filter(Boolean)

--- a/uk_address_matcher/labelling/app/app.js
+++ b/uk_address_matcher/labelling/app/app.js
@@ -9,6 +9,8 @@ const state = {
   bootstrap: null,
   deadline: 0,
   lastActivity: 0,
+  sortBy: "unique_id",
+  sortOrder: "asc",
 };
 const $ = (id) => document.getElementById(id);
 const el = {
@@ -97,6 +99,15 @@ function query() {
     page: state.page,
     page_size: state.pageSize,
     show_labelled: $("show-labelled").checked,
+    mismatches_only: $("mismatches-only").checked,
+    sort_by: state.sortBy,
+    sort_order: state.sortOrder,
+  });
+  [
+    ["unique_id_query", "record-unique-id"],
+    ["address_query", "record-address-query"],
+  ].forEach(([key, id]) => {
+    if ($(id).value.trim()) p.set(key, $(id).value.trim());
   });
   stages().forEach((stage) => p.append("stage", stage));
   [
@@ -125,6 +136,23 @@ function matchWeightClass(value) {
   if (weight < 12) return "match-weight weight-yellow-green";
   if (weight < 20) return "match-weight weight-green";
   return "match-weight weight-strong-green";
+}
+const sortDescriptions = {
+  reranked_score: "Final score after reranking candidates",
+  splink_score: "Raw Splink match weight before reranking",
+  distinguishability: "Difference between this match and the next-best candidate",
+};
+function updateSortControls() {
+  document.querySelectorAll(".sort-button").forEach((button) => {
+    const active = button.dataset.sort === state.sortBy,
+      direction = active ? state.sortOrder : "asc",
+      arrow = button.querySelector(".sort-arrow");
+    arrow.textContent = active ? (direction === "asc" ? "↑" : "↓") : "↕";
+    button.setAttribute(
+      "aria-label",
+      `${sortDescriptions[button.dataset.sort]}. Sort ${direction === "asc" ? "descending" : "ascending"} next`,
+    );
+  });
 }
 let hoverCard = null;
 function hideHoverCard() {
@@ -265,7 +293,7 @@ function render() {
   if (!state.rows.length) {
     const row = document.createElement("tr"),
       cell = text("td", "No records match the selected filters.");
-    cell.colSpan = 8;
+    cell.colSpan = 9;
     row.append(cell);
     el.body.append(row);
     return;
@@ -354,6 +382,13 @@ function render() {
       suggestion,
       stageCell,
       text("td", weightText, matchWeightClass(record.match_weight)),
+      text(
+        "td",
+        record.splink_match_weight == null
+          ? "-"
+          : Number(record.splink_match_weight).toFixed(2),
+        matchWeightClass(record.splink_match_weight),
+      ),
       text(
         "td",
         record.distinguishability == null
@@ -490,8 +525,14 @@ async function initialise() {
     ["score-min", "score-max", "dist-min", "dist-max"].forEach(
       (id) => ($(id).value = ""),
     );
+    $("record-unique-id").value = "";
+    $("record-address-query").value = "";
     resetRanges();
     $("show-labelled").checked = true;
+    $("mismatches-only").checked = false;
+    state.sortBy = "unique_id";
+    state.sortOrder = "asc";
+    updateSortControls();
     state.page = 1;
     load();
   };
@@ -506,6 +547,28 @@ async function initialise() {
     $("expand-filters").hidden = true;
   };
   $("show-labelled").onchange = applyFilter;
+  $("mismatches-only").onchange = applyFilter;
+  ["record-unique-id", "record-address-query"].forEach((id) =>
+    $(id).addEventListener("input", () => {
+      state.page = 1;
+      clearTimeout(window.searchTimer);
+      window.searchTimer = setTimeout(load, 250);
+    }),
+  );
+  document.querySelectorAll(".sort-button").forEach((button) => {
+    button.onclick = () => {
+      if (state.sortBy === button.dataset.sort)
+        state.sortOrder = state.sortOrder === "asc" ? "desc" : "asc";
+      else {
+        state.sortBy = button.dataset.sort;
+        state.sortOrder = "desc";
+      }
+      state.page = 1;
+      updateSortControls();
+      load();
+    };
+  });
+  updateSortControls();
   $("page-size").onchange = () => {
     state.page = 1;
     state.pageSize = Number($("page-size").value);
@@ -702,11 +765,11 @@ function renderReview() {
       ...list.map((candidate) => candidateRow(candidate)),
     );
   }
-  $("review-current-label").textContent = record.current_label
-    ? `Current label: ${record.current_label}`
+  $("review-current-label-value").textContent = record.current_label
+    ? record.current_label
     : record.is_labelled
-      ? "A decision has been recorded."
-      : "This record has not been labelled.";
+      ? "Decision recorded without a canonical label."
+      : "Not labelled yet.";
   updateReviewAccept();
 }
 function candidateRow(candidate) {
@@ -884,6 +947,7 @@ if (location.hash.startsWith("#review")) loadReview();
   const c = {
     unavailable: $("canonical-unavailable"),
     content: $("canonical-content"),
+    uniqueId: $("canonical-unique-id"),
     postcode: $("canonical-postcode"),
     address: $("canonical-address-query"),
     usePostcode: $("canonical-use-review-postcode"),
@@ -944,7 +1008,7 @@ if (location.hash.startsWith("#review")) loadReview();
     c.message.hidden = false;
     c.message.textContent = "Search results will appear here.";
     c.status.textContent =
-      "Enter a postcode or address value to begin searching.";
+      "Enter a unique ID, postcode, or address value to begin searching.";
     c.page.textContent = "Page 1";
     c.summary.textContent = "Page 1";
     c.previous.disabled = true;
@@ -1044,10 +1108,11 @@ if (location.hash.startsWith("#review")) loadReview();
   };
   const load = async () => {
     if (!state.canonical.available) return;
-    const postcode = c.postcode.value.trim(),
+    const uniqueIdQuery = c.uniqueId.value.trim(),
+      postcode = c.postcode.value.trim(),
       addressQuery = c.address.value.trim();
-    if (!postcode && !addressQuery) {
-      toast("Enter a postcode or address value.");
+    if (!uniqueIdQuery && !postcode && !addressQuery) {
+      toast("Enter a unique ID, postcode, or address value.");
       return;
     }
     state.canonical.loading = true;
@@ -1060,6 +1125,7 @@ if (location.hash.startsWith("#review")) loadReview();
       const parameters = new URLSearchParams({
         page: String(state.canonical.page),
       });
+      if (uniqueIdQuery) parameters.set("unique_id_query", uniqueIdQuery);
       if (postcode) parameters.set("postcode", postcode);
       if (addressQuery) parameters.set("address_query", addressQuery);
       const payload = await api(`/api/canonical-search?${parameters}`);

--- a/uk_address_matcher/labelling/app/index.html
+++ b/uk_address_matcher/labelling/app/index.html
@@ -212,7 +212,20 @@
           </div>
           <div class="review-cards">
             <article class="review-card messy-card">
-              <h2>Messy input record</h2>
+              <div class="review-card-header messy-card-header">
+                <h2>Messy input record</h2>
+                <a
+                  id="review-open-map"
+                  class="map-link"
+                  href="#"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="Open the exact messy address in Google Maps"
+                  aria-label="Open the exact messy address in Google Maps"
+                  ><span class="map-link-icon" aria-hidden="true">&#128205;</span
+                  >Open in Maps</a
+                >
+              </div>
               <dl>
                 <dt>Unique ID</dt>
                 <dd id="review-messy-id"></dd>
@@ -388,7 +401,6 @@
                   <thead>
                     <tr>
                       <th>Canonical ID</th>
-                      <th>Address</th>
                       <th>Cleaned address</th>
                       <th>Postcode</th>
                       <th>Action</th>

--- a/uk_address_matcher/labelling/app/index.html
+++ b/uk_address_matcher/labelling/app/index.html
@@ -49,6 +49,26 @@
               <legend>Match stage</legend>
               <div id="stage-options" class="stage-options"></div>
             </fieldset>
+            <fieldset class="filter-card search-card">
+              <legend>Search records</legend>
+              <label class="search-field"
+                ><span>Unique ID</span><input
+                  id="record-unique-id"
+                  type="search"
+                  maxlength="100"
+                  placeholder="Contains..."
+                  autocomplete="off"
+              /></label>
+              <label class="search-field"
+                ><span>Address or postcode</span><input
+                  id="record-address-query"
+                  type="search"
+                  maxlength="100"
+                  placeholder="Contains..."
+                  autocomplete="off"
+              /></label>
+              <p>Matches raw and cleaned addresses or postcode.</p>
+            </fieldset>
             <fieldset class="filter-card range-card">
               <legend>Splink reranked score</legend>
               <div class="range-scale">
@@ -139,6 +159,15 @@
                 >Show labelled records
                 <input id="show-labelled" type="checkbox" checked
               /></label>
+              <label
+                class="toggle"
+                title="Show records where an existing label differs from the model suggestion"
+                >Model mismatches only
+                <input
+                  id="mismatches-only"
+                  type="checkbox"
+                  aria-label="Show model mismatches only"
+              /></label>
             </fieldset>
             <div class="label-progress">
               <span>Labels created</span
@@ -175,15 +204,40 @@
                     <th>Messy address</th>
                     <th>Model suggestion</th>
                     <th>Match stage</th>
-                    <th>Reranked score</th>
-                    <th>Dist.</th>
+                    <th>
+                      <button
+                        class="sort-button"
+                        data-sort="reranked_score"
+                        title="Final score after reranking candidates"
+                      >
+                        Reranked score <span class="sort-arrow">&#8597;</span>
+                      </button>
+                    </th>
+                    <th>
+                      <button
+                        class="sort-button"
+                        data-sort="splink_score"
+                        title="Raw Splink match weight before reranking"
+                      >
+                        Splink score <span class="sort-arrow">&#8597;</span>
+                      </button>
+                    </th>
+                    <th>
+                      <button
+                        class="sort-button"
+                        data-sort="distinguishability"
+                        title="Difference between this match and the next-best candidate"
+                      >
+                        Dist. <span class="sort-arrow">&#8597;</span>
+                      </button>
+                    </th>
                     <th>Label</th>
                     <th>Action</th>
                   </tr>
                 </thead>
                 <tbody id="records-body">
                   <tr>
-                    <td colspan="8">Loading...</td>
+                    <td colspan="9">Loading...</td>
                   </tr>
                 </tbody>
               </table>
@@ -350,6 +404,13 @@
             </div>
             <section class="canonical-search-panel">
               <label
+                >Unique ID contains<input
+                  id="canonical-unique-id"
+                  type="text"
+                  maxlength="100"
+                  placeholder="For example, 12345"
+                  autocomplete="off" /></label
+              ><label
                 >Postcode<input
                   id="canonical-postcode"
                   type="text"
@@ -377,8 +438,8 @@
               </div>
             </section>
             <p class="canonical-help">
-              Enter a postcode, an address value, or both. Address searching is
-              a case-insensitive literal substring check.
+              Enter a unique ID, postcode, address value, or any combination.
+              Searches are case-insensitive literal substring checks.
             </p>
             <section class="canonical-results">
               <header>
@@ -420,7 +481,13 @@
             </section>
           </section>
           <footer class="review-actions">
-            <span id="review-current-label"></span>
+            <span id="review-current-label" class="review-current-label">
+              <span class="review-current-label-icon" aria-hidden="true"
+                >&#127991;</span
+              ><span>
+                <span class="review-current-label-heading">Current label</span
+                ><strong id="review-current-label-value"></strong> </span
+            ></span>
             <div>
               <button id="review-undo" class="review-button" type="button">
                 Undo

--- a/uk_address_matcher/labelling/canonical.py
+++ b/uk_address_matcher/labelling/canonical.py
@@ -42,6 +42,7 @@ class CanonicalSearchPage:
     page_size: int
     has_previous: bool
     has_next: bool
+    unique_id_query: str
     postcode: str | None
     address_query: str
     rows: list[dict[str, Any]]
@@ -165,25 +166,36 @@ def _row_dicts(cursor: duckdb.DuckDBPyConnection) -> list[dict[str, Any]]:
 def search_canonical_data(
     source: CanonicalSource,
     *,
-    postcode: str | None,
-    address_query: str | None,
-    page: int,
+    unique_id_query: str | None = None,
+    postcode: str | None = None,
+    address_query: str | None = None,
+    page: int = 1,
 ) -> CanonicalSearchPage:
     if not isinstance(page, int):
         raise TypeError("Canonical search page must be an integer.")
     if page < 1:
         raise ValueError("Canonical search page must be at least 1.")
     normalised_postcode = normalise_postcode_search(postcode)
+    cleaned_unique_id_query = (
+        "" if unique_id_query is None else str(unique_id_query).strip()
+    )
+    if len(cleaned_unique_id_query) > 100:
+        raise ValueError("Unique ID search must contain no more than 100 characters.")
     cleaned_query = "" if address_query is None else str(address_query).strip()
     if len(cleaned_query) > 100:
         raise ValueError("Address search must contain no more than 100 characters.")
-    if normalised_postcode is None and not cleaned_query:
-        raise ValueError("Enter a postcode or an address value before searching.")
+    if normalised_postcode is None and not cleaned_query and not cleaned_unique_id_query:
+        raise ValueError(
+            "Enter a unique ID, postcode, or address value before searching."
+        )
     unique_id, postcode_column, cleaned_address, display_address = _canonical_columns(
         source
     )
     conditions = [f"{unique_id} IS NOT NULL"]
     parameters: list[Any] = []
+    if cleaned_unique_id_query:
+        conditions.append(f"contains(upper(CAST({unique_id} AS VARCHAR)), upper(?))")
+        parameters.append(cleaned_unique_id_query)
     if normalised_postcode is not None:
         conditions.append(f"{postcode_column} = ?")
         parameters.append(normalised_postcode)
@@ -213,6 +225,7 @@ def search_canonical_data(
         page_size=CANONICAL_PAGE_SIZE,
         has_previous=page > 1,
         has_next=len(rows) > CANONICAL_PAGE_SIZE,
+        unique_id_query=cleaned_unique_id_query,
         postcode=normalised_postcode,
         address_query=cleaned_query,
         rows=rows[:CANONICAL_PAGE_SIZE],

--- a/uk_address_matcher/labelling/canonical.py
+++ b/uk_address_matcher/labelling/canonical.py
@@ -192,26 +192,14 @@ def search_canonical_data(
         parameters.append(cleaned_query)
     offset = (page - 1) * CANONICAL_PAGE_SIZE
     query = f"""
-        WITH matching_rows AS (
-            SELECT
-                CAST({unique_id} AS VARCHAR) AS canonical_id,
-                CAST({display_address} AS VARCHAR) AS canonical_address,
-                CAST({cleaned_address} AS VARCHAR) AS cleaned_address,
-                CAST({postcode_column} AS VARCHAR) AS canonical_postcode,
-                ROW_NUMBER() OVER (
-                    PARTITION BY CAST({unique_id} AS VARCHAR)
-                    ORDER BY {postcode_column}, {cleaned_address}, {display_address},
-                        CAST({unique_id} AS VARCHAR)
-                ) AS identity_rank
-            FROM {canonical_scan_sql(source)}
-            WHERE {" AND ".join(conditions)}
-        ), unique_results AS (
-            SELECT canonical_id, canonical_address, cleaned_address, canonical_postcode
-            FROM matching_rows WHERE identity_rank = 1
-        )
-        SELECT canonical_id, canonical_address, cleaned_address, canonical_postcode
-        FROM unique_results
-        ORDER BY canonical_postcode, cleaned_address, canonical_id
+        SELECT
+            CAST({unique_id} AS VARCHAR) AS canonical_id,
+            CAST({display_address} AS VARCHAR) AS canonical_address,
+            CAST({cleaned_address} AS VARCHAR) AS cleaned_address,
+            CAST({postcode_column} AS VARCHAR) AS canonical_postcode
+        FROM {canonical_scan_sql(source)}
+        WHERE {" AND ".join(conditions)}
+        ORDER BY canonical_postcode, cleaned_address, canonical_address, canonical_id
         LIMIT ? OFFSET ?
     """
     connection = duckdb.connect()

--- a/uk_address_matcher/labelling/server.py
+++ b/uk_address_matcher/labelling/server.py
@@ -447,7 +447,8 @@ def _record_filter_sql(filters: RecordFilters) -> tuple[str, list[Any]]:
     if filters.address_query:
         conditions.append(
             "(contains(upper(COALESCE(CAST(messy_address AS VARCHAR), '')), upper(?)) "
-            "OR contains(upper(COALESCE(CAST(messy_cleaned_address AS VARCHAR), '')), upper(?)) "
+            "OR contains(upper(COALESCE(CAST(messy_cleaned_address AS VARCHAR), '')), "
+            "upper(?)) "
             "OR contains(upper(COALESCE(CAST(messy_postcode AS VARCHAR), '')), upper(?)))"
         )
         parameters.extend([filters.address_query] * 3)

--- a/uk_address_matcher/labelling/server.py
+++ b/uk_address_matcher/labelling/server.py
@@ -30,6 +30,12 @@ from uk_address_matcher.labelling.canonical import (
 DEFAULT_PAGE_SIZE = 20
 ALLOWED_PAGE_SIZES = {10, 20, 50, 100}
 ALLOWED_MATCH_STAGES = {"exact", "peeled", "splink", "unique_trigram", "unmatched"}
+RECORD_SORT_COLUMNS = {
+    "unique_id": "unique_id",
+    "reranked_score": "match_weight",
+    "splink_score": "splink_match_weight",
+    "distinguishability": "distinguishability",
+}
 ALLOWED_DECISIONS = {
     "accept_model",
     "select_candidate",
@@ -83,12 +89,17 @@ class InputDataset:
 
 @dataclass(frozen=True)
 class RecordFilters:
+    unique_id_query: str
+    address_query: str
     stages: tuple[str, ...]
     score_min: float | None
     score_max: float | None
     distinguishability_min: float | None
     distinguishability_max: float | None
     show_labelled: bool
+    mismatches_only: bool
+    sort_by: str
+    sort_order: str
 
 
 class SessionState:
@@ -298,7 +309,11 @@ def _base_review_cte(bundle: Bundle) -> str:
                 CAST(r.resolved_label_id AS VARCHAR) AS resolved_label_id,
                 r.resolved_canonical_address, r.resolved_canonical_postcode,
                 r.match_reason, r.match_stage, r.is_matched, r.match_weight,
-                r.distinguishability, r.candidate_count, r.top_candidates,
+                r.distinguishability,
+                TRY_CAST(json_extract_string(
+                    CAST(r.top_candidates AS JSON), '$[0].splink_match_weight'
+                ) AS DOUBLE) AS splink_match_weight,
+                r.candidate_count, r.top_candidates,
                 l.decision AS saved_decision,
                 l.selected_candidate_rank,
                 CASE WHEN l.decision = 'clear' THEN FALSE
@@ -387,11 +402,28 @@ def _optional_float(query: dict[str, list[str]], name: str) -> float | None:
         raise ValueError(f"Query parameter {name!r} must be numeric") from error
 
 
+def _optional_text(query: dict[str, list[str]], name: str) -> str:
+    value = query.get(name, [""])[0].strip()
+    if len(value) > 100:
+        raise ValueError(
+            f"Query parameter {name!r} must contain no more than 100 characters"
+        )
+    return value
+
+
 def _parse_record_filters(query: dict[str, list[str]]) -> RecordFilters:
     stages = tuple(query.get("stage", []))
     if set(stages) - ALLOWED_MATCH_STAGES:
         raise ValueError("Unsupported match stage")
+    sort_by = query.get("sort_by", ["unique_id"])[0]
+    if sort_by not in RECORD_SORT_COLUMNS:
+        raise ValueError("Unsupported record sort")
+    sort_order = query.get("sort_order", ["asc"])[0].lower()
+    if sort_order not in {"asc", "desc"}:
+        raise ValueError("Record sort order must be asc or desc")
     return RecordFilters(
+        unique_id_query=_optional_text(query, "unique_id_query"),
+        address_query=_optional_text(query, "address_query"),
         stages=stages,
         score_min=_optional_float(query, "score_min"),
         score_max=_optional_float(query, "score_max"),
@@ -399,12 +431,26 @@ def _parse_record_filters(query: dict[str, list[str]]) -> RecordFilters:
         distinguishability_max=_optional_float(query, "distinguishability_max"),
         show_labelled=query.get("show_labelled", ["true"])[0].lower()
         in {"1", "true", "yes", "on"},
+        mismatches_only=query.get("mismatches_only", ["false"])[0].lower()
+        in {"1", "true", "yes", "on"},
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
 
 
 def _record_filter_sql(filters: RecordFilters) -> tuple[str, list[Any]]:
     conditions: list[str] = []
     parameters: list[Any] = []
+    if filters.unique_id_query:
+        conditions.append("contains(upper(unique_id), upper(?))")
+        parameters.append(filters.unique_id_query)
+    if filters.address_query:
+        conditions.append(
+            "(contains(upper(COALESCE(CAST(messy_address AS VARCHAR), '')), upper(?)) "
+            "OR contains(upper(COALESCE(CAST(messy_cleaned_address AS VARCHAR), '')), upper(?)) "
+            "OR contains(upper(COALESCE(CAST(messy_postcode AS VARCHAR), '')), upper(?)))"
+        )
+        parameters.extend([filters.address_query] * 3)
     if filters.stages:
         conditions.append(
             "match_stage IN (" + ", ".join("?" for _ in filters.stages) + ")"
@@ -419,9 +465,21 @@ def _record_filter_sql(filters: RecordFilters) -> tuple[str, list[Any]]:
         if value is not None:
             conditions.append(f"(match_stage != 'splink' OR {column} {operator} ?)")
             parameters.append(value)
-    if not filters.show_labelled:
+    if not filters.show_labelled and not filters.mismatches_only:
         conditions.append("is_labelled = FALSE")
+    if filters.mismatches_only:
+        conditions.append(
+            "match_stage <> 'unmatched' AND has_existing_label AND is_matched AND "
+            "imported_label IS NOT NULL AND resolved_label_id IS NOT NULL AND "
+            "resolved_label_id IS DISTINCT FROM imported_label"
+        )
     return ("WHERE " + " AND ".join(conditions) if conditions else "", parameters)
+
+
+def _record_order_sql(filters: RecordFilters) -> str:
+    column = RECORD_SORT_COLUMNS[filters.sort_by]
+    direction = filters.sort_order.upper()
+    return f"{column} {direction} NULLS LAST, unique_id ASC"
 
 
 def _records_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[str, Any]:
@@ -432,7 +490,8 @@ def _records_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[str, A
         raise ValueError("page and page_size must be integers") from error
     if page_size not in ALLOWED_PAGE_SIZES:
         raise ValueError(f"page_size must be one of {sorted(ALLOWED_PAGE_SIZES)}")
-    where_clause, parameters = _record_filter_sql(_parse_record_filters(query))
+    filters = _parse_record_filters(query)
+    where_clause, parameters = _record_filter_sql(filters)
     connection = duckdb.connect(str(bundle.state_file))
     try:
         total = connection.execute(
@@ -448,9 +507,10 @@ def _records_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[str, A
                 has_existing_label, resolved_label_id,
                 resolved_canonical_address, resolved_canonical_postcode,
                 match_reason, match_stage, is_matched, match_weight, distinguishability,
-                candidate_count, top_candidates, current_decision,
+                splink_match_weight, candidate_count, top_candidates, current_decision,
                 current_label, selected_candidate_rank, is_labelled
-            FROM base {where_clause} ORDER BY unique_id LIMIT ? OFFSET ?""",
+            FROM base {where_clause} ORDER BY {_record_order_sql(filters)}
+            LIMIT ? OFFSET ?""",
             [str(bundle.data_file), *parameters, page_size, (page - 1) * page_size],
         )
         names = [column[0] for column in cursor.description]
@@ -472,7 +532,8 @@ def _review_record_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[
     unique_id = query.get("unique_id", [""])[0]
     if not unique_id:
         raise ValueError("unique_id is required")
-    where_clause, parameters = _record_filter_sql(_parse_record_filters(query))
+    filters = _parse_record_filters(query)
+    where_clause, parameters = _record_filter_sql(filters)
     cleaned_address = (
         "messy_cleaned_address"
         if "messy_cleaned_address" in bundle.review_columns
@@ -482,10 +543,16 @@ def _review_record_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[
     try:
         cursor = connection.execute(
             f"""{_base_review_cte(bundle)}, filtered AS (
-                SELECT *, ROW_NUMBER() OVER (ORDER BY unique_id) AS review_position,
+                SELECT *, ROW_NUMBER() OVER (
+                        ORDER BY {_record_order_sql(filters)}
+                    ) AS review_position,
                     COUNT(*) OVER () AS review_total,
-                    LAG(unique_id) OVER (ORDER BY unique_id) AS previous_unique_id,
-                    LEAD(unique_id) OVER (ORDER BY unique_id) AS next_unique_id
+                    LAG(unique_id) OVER (
+                        ORDER BY {_record_order_sql(filters)}
+                    ) AS previous_unique_id,
+                    LEAD(unique_id) OVER (
+                        ORDER BY {_record_order_sql(filters)}
+                    ) AS next_unique_id
                 FROM base {where_clause}
             )
             SELECT unique_id, messy_address, {cleaned_address} AS messy_cleaned_address,
@@ -843,6 +910,7 @@ def _handler_factory(
                         raise ValueError("Canonical page must be an integer.") from error
                     result = search_canonical_data(
                         canonical_source,
+                        unique_id_query=query.get("unique_id_query", [None])[0],
                         postcode=query.get("postcode", [None])[0],
                         address_query=query.get("address_query", [None])[0],
                         page=page,
@@ -854,6 +922,7 @@ def _handler_factory(
                             "page_size": result.page_size,
                             "has_previous": result.has_previous,
                             "has_next": result.has_next,
+                            "unique_id_query": result.unique_id_query,
                             "postcode": result.postcode,
                             "address_query": result.address_query,
                             "rows": result.rows,


### PR DESCRIPTION
## PR Summary

Adds a click-through button for opening google maps for a given messy record. Also fixes an issue with our canonical filter deduping and not displaying all permutations of a record for a given property.

<img width="626" height="59" alt="Screenshot 2026-08-04 at 08 50 28" src="https://github.com/user-attachments/assets/967e3f59-5295-4f83-969a-5aa5bc194079" />
