### PR TITLE
DistinguishingTokenStage

### DIFF
--- a/docs/site/optimising_accuracy.md
+++ b/docs/site/optimising_accuracy.md
@@ -159,6 +159,7 @@ The available stages are as follows:
 | Stage | Type | What it is good at | Accuracy implication |
 |---|---|---|---|
 | `ExactMatchStage` | Deterministic | Cleaned address text is already the same on both sides | Very high precision, should usually run first |
+| `DistinguishingTokenStage` | Deterministic | A locally unique canonical prefix is followed by two ordered address tokens, allowing up to two safe gaps | Substantially higher recall than peeled matching, with a small reduction in precision overall; requires an opt-in prepared canonical |
 | `PeeledAddressStage` | Deterministic | One side has extra trailing locality words such as `LONDON` or `HACKNEY` | High precision, useful before probabilistic matching |
 | `UniqueTrigramStage` | Deterministic | A distinctive phrase identifies one canonical address within the postcode | High precision, removes clear fuzzy cases before Splink |
 | `SplinkStage` | Scored | Typos, abbreviations, partial matches, and other fuzzy cases | Precision and recall depend on threshold choice |
@@ -166,7 +167,26 @@ The available stages are as follows:
 
 ##### Summary recommendation
 
-You almost always want to use the `ExactMatchStage`.  The `PeeledAddressStage` and `UniqueTrigramStage` produce high, but not perfect precision (i.e. there's a chance of a small number of false positives).
+You almost always want to use the `ExactMatchStage`.  The `DistinguishingTokenStage`, `PeeledAddressStage` and `UniqueTrigramStage` produce high, but not perfect precision (i.e. there's a chance of a small number of false positives).
+
+`DistinguishingTokenStage` requires additional canonical preparation. Enable it
+when building the prepared canonical:
+
+Across four benchmark areas, `ExactMatchStage` followed by
+`DistinguishingTokenStage` achieved 76.1465% weighted recall, compared with
+60.0428% for `ExactMatchStage` followed by `PeeledAddressStage`. Weighted
+precision remained high but was slightly lower: 99.6010% compared with
+99.6855%. The recall improvement was substantial in every benchmark area,
+while the precision difference was small and varied slightly by area.
+
+```python
+prepare_canonical_folder(
+    df_canonical,
+    output_folder=output_folder,
+    con=con,
+    derive_distinguishing_wrt_adjacent_records=True,
+)
+```
 
 You almost always want to use the `SplinkStage` last, to attempt to find any matches missed by the previous stages.  In some cases, it may produce higher accuracy than the `PeeledAddressStage` and `UniqueTrigramStage`, which is why you do not always want to use these stages.
 
@@ -176,6 +196,7 @@ You almost always want to use the `SplinkStage` last, to attempt to find any mat
 ```python
 from uk_address_matcher import (
     AddressMatcher,
+    DistinguishingTokenStage,
     ExactMatchStage,
     PeeledAddressStage,
     UniqueTrigramStage,
@@ -188,6 +209,7 @@ matcher = AddressMatcher(
     con=con,
     stages=[
         ExactMatchStage(),
+        DistinguishingTokenStage(),
         PeeledAddressStage(),
         UniqueTrigramStage(),
         SplinkStage(
@@ -208,6 +230,10 @@ For guidance on choosing Splink thresholds, see [here](choosing_a_matching_thres
 ### ExactMatchStage
 
 ::: uk_address_matcher.ExactMatchStage
+
+### DistinguishingTokenStage
+
+::: uk_address_matcher.DistinguishingTokenStage
 
 ### PeeledAddressStage
 

--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -600,6 +600,7 @@ def test_available_stages_prints_human_guidance():
     text = str(AddressMatcher.available_stages())
 
     assert text.startswith("Available matching stages (import from uk_address_matcher):")
+    assert "DistinguishingTokenStage" in text
     assert "ExactMatchStage" in text
     assert "PeeledAddressStage" in text
     assert "SplinkStage" in text

--- a/tests/test_distinguishing_token_stage.py
+++ b/tests/test_distinguishing_token_stage.py
@@ -1,0 +1,104 @@
+import pytest
+
+from uk_address_matcher import DistinguishingTokenStage
+from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
+
+
+def test_distinguishing_token_stage_applies_safe_gap_rules(duck_con):
+    messy = duck_con.sql("""
+        SELECT * FROM (VALUES
+            (1, 'A B C', 'AA1 1AA'),
+            (2, 'A X Y B C', 'AA1 1AA'),
+            (3, 'A X B Y C', 'AA1 1AA'),
+            (4, 'A B X Y C', 'AA1 1AA'),
+            (5, 'A X Y Z B C', 'AA1 1AA'),
+            (6, 'A 7 B C', 'AA1 1AA'),
+            (7, 'A HOUSE B C', 'AA1 1AA'),
+            (8, 'A C B', 'AA1 1AA'),
+            (9, 'A B C', 'AA1 1AB'),
+            (10, 'OTHER A B C', 'AA1 1AA')
+        ) AS rows(ukam_address_id, clean_full_address, postcode)
+    """)
+    canonical = duck_con.sql("""
+        SELECT * FROM (VALUES
+            (101, 'canonical-a', 'A B C', 'AA1 1AA', ['A']::VARCHAR[])
+        ) AS rows(
+            ukam_address_id,
+            unique_id,
+            clean_full_address,
+            postcode,
+            distinguishing_adj_start_tokens
+        )
+    """)
+
+    matches = DistinguishingTokenStage().find_matches(
+        con=duck_con,
+        stage_name="distinguishingtokenstage",
+        df_unmatched=messy,
+        df_canonical=canonical,
+    )
+
+    assert matches is not None
+    assert matches.order("ukam_address_id").fetchall() == [
+        (1, 101, "canonical-a", MatchReason.DISTINGUISHING_TOKEN.value),
+        (2, 101, "canonical-a", MatchReason.DISTINGUISHING_TOKEN.value),
+        (3, 101, "canonical-a", MatchReason.DISTINGUISHING_TOKEN.value),
+        (4, 101, "canonical-a", MatchReason.DISTINGUISHING_TOKEN.value),
+    ]
+
+
+def test_distinguishing_token_stage_rejects_ambiguous_canonical_ids(duck_con):
+    messy = duck_con.sql("""
+        SELECT * FROM (VALUES
+            (1, 'A B C', 'AA1 1AA'),
+            (2, 'D E F', 'DD1 1DD')
+        ) AS rows(ukam_address_id, clean_full_address, postcode)
+    """)
+    canonical = duck_con.sql("""
+        SELECT * FROM (VALUES
+            (101, 'canonical-a', 'A B C', 'AA1 1AA', ['A']::VARCHAR[]),
+            (102, 'canonical-b', 'A B C', 'AA1 1AA', ['A']::VARCHAR[]),
+            (103, 'canonical-d', 'D E F', 'DD1 1DD', ['D']::VARCHAR[]),
+            (104, 'canonical-d', 'D E F', 'DD1 1DD', ['D']::VARCHAR[])
+        ) AS rows(
+            ukam_address_id,
+            unique_id,
+            clean_full_address,
+            postcode,
+            distinguishing_adj_start_tokens
+        )
+    """)
+
+    matches = DistinguishingTokenStage().find_matches(
+        con=duck_con,
+        stage_name="distinguishingtokenstage",
+        df_unmatched=messy,
+        df_canonical=canonical,
+    )
+
+    assert matches is not None
+    assert matches.fetchall() == [
+        (2, 103, "canonical-d", MatchReason.DISTINGUISHING_TOKEN.value)
+    ]
+
+
+def test_distinguishing_token_stage_requires_prepared_prefix(duck_con):
+    messy = duck_con.sql("""
+        SELECT 1 AS ukam_address_id, 'A B C' AS clean_full_address,
+            'AA1 1AA' AS postcode
+    """)
+    canonical = duck_con.sql("""
+        SELECT 101 AS ukam_address_id, 'canonical-a' AS unique_id,
+            'A B C' AS clean_full_address, 'AA1 1AA' AS postcode
+    """)
+
+    with pytest.raises(
+        ValueError,
+        match="derive_distinguishing_wrt_adjacent_records=True",
+    ):
+        DistinguishingTokenStage().find_matches(
+            con=duck_con,
+            stage_name="distinguishingtokenstage",
+            df_unmatched=messy,
+            df_canonical=canonical,
+        )

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -645,9 +645,7 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
-            clean_relation
-        ),
+        lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
@@ -721,9 +719,7 @@ def test_prepare_remote_output_writes_chunked_paths(monkeypatch):
     monkeypatch.setattr(
         chunking_strategies,
         "prepare_data_for_matching",
-        lambda data, con, num_of_chunks, term_frequency_lookup, show_progress=True: (
-            clean_relation
-        ),
+        lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
@@ -847,6 +843,50 @@ def test_load_prepared_data_has_expected_row_counts(con, prepared_folder):
     assert result.addresses.count("*").fetchone()[0] == 3
     assert result.term_frequencies.count("*").fetchone()[0] > 0
     assert result.inverted_index.count("*").fetchone()[0] > 0
+
+
+@pytest.mark.parametrize("output_chunk_count", [1, 2])
+def test_prepare_persists_distinguishing_tokens(
+    con,
+    tmp_path,
+    output_chunk_count,
+):
+    canonical = con.sql("""
+        SELECT * FROM (VALUES
+            ('C1', 'FLAT A 1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            ('C2', '1 HIGH STREET CAMDEN LONDON', 'N1 1AA'),
+            ('C3', '9 SOLO ROAD YORK', 'Y1 1AA')
+        ) AS rows(unique_id, address_concat, postcode)
+    """)
+
+    prepare_canonical_folder(
+        canonical,
+        output_folder=tmp_path,
+        con=con,
+        num_of_chunks=2,
+        output_chunk_count=output_chunk_count,
+        derive_distinguishing_wrt_adjacent_records=True,
+        overwrite=True,
+        show_progress=False,
+    )
+
+    loaded = load_prepared_canonical_data(tmp_path, con=con).addresses
+    actual = {
+        unique_id: (distinguishing, common)
+        for unique_id, distinguishing, common in loaded.project(
+            """
+            unique_id,
+            distinguishing_adj_start_tokens,
+            common_adj_start_tokens
+            """
+        ).fetchall()
+    }
+
+    assert actual == {
+        "C1": (["A"], ["1", "HIGH", "STREET", "CAMDEN", "LONDON"]),
+        "C2": ([], ["1", "HIGH", "STREET", "CAMDEN", "LONDON"]),
+        "C3": (["9", "SOLO", "ROAD"], ["YORK"]),
+    }
 
 
 def test_chunked_canonical_manifest_row_audit(con, canonical_data, tmp_path):

--- a/uk_address_matcher/__init__.py
+++ b/uk_address_matcher/__init__.py
@@ -12,6 +12,7 @@ from uk_address_matcher.linking_model.address_record import AddressRecord
 
 # === Matching stages and runner ===
 from uk_address_matcher.linking_model.matching import (
+    DistinguishingTokenStage,
     ExactMatchStage,
     PeeledAddressStage,
     SplinkStage,
@@ -30,6 +31,7 @@ __all__ = [
     "prepare_data_for_matching",
     "ukam_datasets",
     # Matching stages and runner
+    "DistinguishingTokenStage",
     "ExactMatchStage",
     "UniqueTrigramStage",
     "PeeledAddressStage",

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -25,6 +25,9 @@ from uk_address_matcher.cleaning.steps.inverted_index import (
     _derive_keys_for_strategy,
     _lookup_keys_in_inverted_index,
 )
+from uk_address_matcher.cleaning.steps.token_parsing import (
+    _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records,
+)
 from uk_address_matcher.logging.chunking import (
     log_chunk_progress,
     log_stage_complete,
@@ -653,6 +656,7 @@ def prepare_data_for_matching(
     """
     progress_mode = resolve_progress_mode(show_progress)
     uid = _uid()
+    distinguishing_table_name = None
 
     # Clean data in chunks (without term frequencies)
     cleaned_address_table = clean_data_pre_term_frequencies(
@@ -662,6 +666,32 @@ def prepare_data_for_matching(
         debug_options=debug_options,
         show_progress=progress_mode,
     )
+
+    if derive_distinguishing_wrt_adjacent_records:
+        distinguishing_pipeline = create_sql_pipeline(
+            con,
+            input_rel=cleaned_address_table,
+            stage_specs=[
+                _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records()
+            ],
+            pipeline_name="Derive locally distinguishing canonical tokens",
+            pipeline_description=(
+                "Compare each canonical address with nearby suffix-similar records"
+            ),
+        )
+        distinguishing_tokens = distinguishing_pipeline.run(debug_options).project(
+            """
+            ukam_address_id,
+            distinguishing_adj_start_tokens,
+            common_adj_start_tokens
+            """
+        )
+        distinguishing_table_name = f"__ukam_distinguishing_tokens_{uid}"
+        _materialise_relation(
+            con,
+            distinguishing_tokens,
+            distinguishing_table_name,
+        )
 
     total_rows = cleaned_address_table.count("*").fetchone()[0]
     _create_term_frequency_tables(con, term_frequency_lookup=term_frequency_lookup)
@@ -700,6 +730,17 @@ def prepare_data_for_matching(
 
     # Get the underlying table name for direct access
     cleaned_table_name = cleaned_address_table.alias
+    if distinguishing_table_name is None:
+        distinguishing_select_sql = ""
+        distinguishing_join_sql = ""
+    else:
+        distinguishing_select_sql = """,
+                distinguishing.distinguishing_adj_start_tokens,
+                distinguishing.common_adj_start_tokens"""
+        distinguishing_join_sql = f"""
+            LEFT JOIN {distinguishing_table_name} AS distinguishing
+              ON cleaned.ukam_address_id = distinguishing.ukam_address_id
+        """
 
     if dataset_role == "canonical":
         processed_table = f"__ukam__processed_canonical_{uid}"
@@ -722,10 +763,11 @@ def prepare_data_for_matching(
         for chunk_index in range(total_chunks):
             chunk_started_at = time.perf_counter()
             chunk_query = con.sql(f"""
-            SELECT *
-                FROM {cleaned_table_name}
+            SELECT cleaned.*{distinguishing_select_sql}
+                FROM {cleaned_table_name} AS cleaned
+                {distinguishing_join_sql}
                 WHERE
-                    (abs(hash(original_address_concat)) % {total_chunks})
+                    (abs(hash(cleaned.original_address_concat)) % {total_chunks})
                     = {chunk_index}
             """)
             chunk_table = f"__ukam_post_tf_chunk_input_{uid}_{chunk_index}"
@@ -736,9 +778,6 @@ def prepare_data_for_matching(
                 chunk,
                 con=con,
                 pre_cleaned_addresses=True,
-                derive_distinguishing_wrt_adjacent_records=(
-                    derive_distinguishing_wrt_adjacent_records
-                ),
                 additional_stages=inverted_index_stages,
                 debug_options=debug_options if chunk_index == 0 else None,
             )

--- a/uk_address_matcher/linking_model/matching/__init__.py
+++ b/uk_address_matcher/linking_model/matching/__init__.py
@@ -1,5 +1,6 @@
 from uk_address_matcher.linking_model.matching.runner import _run_matching
 from uk_address_matcher.linking_model.matching.stages import (
+    DistinguishingTokenStage,
     ExactMatchStage,
     MatchingStage,
     PeeledAddressStage,
@@ -9,6 +10,7 @@ from uk_address_matcher.linking_model.matching.stages import (
 
 __all__ = [
     "MatchingStage",
+    "DistinguishingTokenStage",
     "ExactMatchStage",
     "UniqueTrigramStage",
     "PeeledAddressStage",

--- a/uk_address_matcher/linking_model/matching/stages/__init__.py
+++ b/uk_address_matcher/linking_model/matching/stages/__init__.py
@@ -1,4 +1,7 @@
 from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
+from uk_address_matcher.linking_model.matching.stages.distinguishing_token import (
+    DistinguishingTokenStage,
+)
 from uk_address_matcher.linking_model.matching.stages.exact_match import ExactMatchStage
 from uk_address_matcher.linking_model.matching.stages.peeled import PeeledAddressStage
 from uk_address_matcher.linking_model.matching.stages.splink import SplinkStage
@@ -6,6 +9,7 @@ from uk_address_matcher.linking_model.matching.stages.trigram import UniqueTrigr
 
 __all__ = [
     "MatchingStage",
+    "DistinguishingTokenStage",
     "ExactMatchStage",
     "UniqueTrigramStage",
     "PeeledAddressStage",

--- a/uk_address_matcher/linking_model/matching/stages/distinguishing_token.py
+++ b/uk_address_matcher/linking_model/matching/stages/distinguishing_token.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
+from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
+from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
+
+if TYPE_CHECKING:
+    import duckdb
+
+    from uk_address_matcher.sql_pipeline.runner import DebugOptions
+
+
+_PREMISE_GAP_TOKENS = (
+    "APARTMENT",
+    "BLOCK",
+    "BUILDING",
+    "COTTAGE",
+    "FLAT",
+    "HOUSE",
+    "MAISONETTE",
+    "OFFICE",
+    "STEADING",
+    "STUDIO",
+    "SUITE",
+    "UNIT",
+    "WAREHOUSE",
+    "WORKSHOP",
+)
+
+
+@dataclass(frozen=True, repr=False)
+class DistinguishingTokenStage(MatchingStage):
+    """Match an address using its local prefix and two ordered evidence tokens.
+
+    Canonical addresses must be prepared with
+    ``derive_distinguishing_wrt_adjacent_records=True``. The distinguishing
+    prefix must occur at the start of the messy address, followed by the next
+    two canonical tokens in order. Up to two intervening tokens are allowed,
+    provided they contain no digits and are not premise types such as ``FLAT``,
+    ``HOUSE``, or ``UNIT``. Postcodes must be identical and the evidence must
+    identify exactly one canonical ID.
+
+    Use this optional deterministic stage before ``SplinkStage``.
+    """
+
+    def find_matches(
+        self,
+        con: duckdb.DuckDBPyConnection,
+        stage_name: str,
+        df_unmatched: duckdb.DuckDBPyRelation,
+        df_canonical: duckdb.DuckDBPyRelation,
+        debug_options: Optional[DebugOptions] = None,
+        explain: bool = False,
+    ) -> Optional[duckdb.DuckDBPyRelation]:
+        if "distinguishing_adj_start_tokens" not in df_canonical.columns:
+            raise ValueError(
+                "DistinguishingTokenStage requires canonical addresses prepared "
+                "with derive_distinguishing_wrt_adjacent_records=True."
+            )
+
+        from uk_address_matcher.linking_model.matching.stages._sql_helpers import (
+            run_sql_pipeline,
+        )
+
+        return run_sql_pipeline(
+            con=con,
+            pipeline_stages=[_distinguishing_token_matches()],
+            stage_name=stage_name,
+            df_unmatched=df_unmatched,
+            df_canonical=df_canonical,
+            debug_options=debug_options,
+            explain=explain,
+        )
+
+
+def _safe_gap_token(token_sql: str) -> str:
+    premise_tokens = ", ".join(f"'{token}'" for token in _PREMISE_GAP_TOKENS)
+    return (
+        f"(NOT regexp_matches({token_sql}, '[0-9]') "
+        f"AND {token_sql} NOT IN ({premise_tokens}))"
+    )
+
+
+def _ordered_evidence_condition() -> str:
+    prefix_length = "canonical.prefix_length"
+    evidence_1 = f"split_part(canonical.clean_full_address, ' ', {prefix_length} + 1)"
+    evidence_2 = f"split_part(canonical.clean_full_address, ' ', {prefix_length} + 2)"
+    offsets = {
+        offset: (f"split_part(messy.clean_full_address, ' ', {prefix_length} + {offset})")
+        for offset in range(1, 5)
+    }
+    offset_1, offset_2, offset_3, offset_4 = offsets.values()
+
+    return f"""
+        (
+            (
+                {offset_1} = {evidence_1}
+                AND (
+                    {offset_2} = {evidence_2}
+                    OR (
+                        {_safe_gap_token(offset_2)}
+                        AND (
+                            {offset_3} = {evidence_2}
+                            OR (
+                                {_safe_gap_token(offset_3)}
+                                AND {offset_4} = {evidence_2}
+                            )
+                        )
+                    )
+                )
+            )
+            OR (
+                {_safe_gap_token(offset_1)}
+                AND (
+                    (
+                        {offset_2} = {evidence_1}
+                        AND (
+                            {offset_3} = {evidence_2}
+                            OR (
+                                {_safe_gap_token(offset_3)}
+                                AND {offset_4} = {evidence_2}
+                            )
+                        )
+                    )
+                    OR (
+                        {_safe_gap_token(offset_2)}
+                        AND {offset_3} = {evidence_1}
+                        AND {offset_4} = {evidence_2}
+                    )
+                )
+            )
+        )
+    """
+
+
+@pipeline_stage(
+    name="distinguishing_token_matching",
+    description=(
+        "Resolve addresses using a locally distinguishing prefix and two ordered "
+        "tokens separated by at most two safe gaps."
+    ),
+    tags=["phase_1", "matching"],
+)
+def _distinguishing_token_matches() -> list[CTEStep]:
+    match_reason = MatchReason.DISTINGUISHING_TOKEN.value
+    enum_values = str(MatchReason.enum_values())
+    evidence_condition = _ordered_evidence_condition()
+
+    canonical_signatures_sql = """
+        SELECT
+            canonical.ukam_address_id AS canonical_ukam_address_id,
+            canonical.unique_id AS resolved_canonical_id,
+            canonical.clean_full_address,
+            canonical.postcode,
+            canonical.distinguishing_adj_start_tokens,
+            len(canonical.distinguishing_adj_start_tokens) AS prefix_length
+        FROM {__ukam__tmp_canonical_addresses} AS canonical
+        INNER JOIN (
+            SELECT DISTINCT postcode
+            FROM {__ukam__tmp_messy_addresses}
+            WHERE postcode IS NOT NULL
+        ) AS messy_postcodes
+            ON canonical.postcode = messy_postcodes.postcode
+        WHERE canonical.unique_id IS NOT NULL
+          AND len(canonical.distinguishing_adj_start_tokens) > 0
+          AND len(string_split(canonical.clean_full_address, ' '))
+              >= len(canonical.distinguishing_adj_start_tokens) + 2
+    """
+    candidates_sql = f"""
+        SELECT
+            messy.ukam_address_id,
+            canonical.canonical_ukam_address_id,
+            canonical.resolved_canonical_id
+        FROM {{__ukam__tmp_messy_addresses}} AS messy
+        INNER JOIN {{canonical_distinguishing_signatures}} AS canonical
+            ON messy.postcode = canonical.postcode
+        WHERE starts_with(
+            messy.clean_full_address,
+            array_to_string(canonical.distinguishing_adj_start_tokens, ' ') || ' '
+        )
+          AND {evidence_condition}
+    """
+    distinct_ids_sql = """
+        SELECT
+            ukam_address_id,
+            resolved_canonical_id,
+            min(canonical_ukam_address_id) AS canonical_ukam_address_id
+        FROM {distinguishing_token_candidates}
+        GROUP BY ukam_address_id, resolved_canonical_id
+    """
+    unambiguous_matches_sql = f"""
+        SELECT
+            ukam_address_id,
+            canonical_ukam_address_id,
+            resolved_canonical_id,
+            '{match_reason}'::ENUM {enum_values} AS match_reason
+        FROM {{distinct_distinguishing_token_ids}}
+        QUALIFY count(*) OVER (PARTITION BY ukam_address_id) = 1
+    """
+
+    return [
+        CTEStep("canonical_distinguishing_signatures", canonical_signatures_sql),
+        CTEStep("distinguishing_token_candidates", candidates_sql),
+        CTEStep("distinct_distinguishing_token_ids", distinct_ids_sql),
+        CTEStep("unambiguous_distinguishing_token_matches", unambiguous_matches_sql),
+    ]

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -444,6 +444,7 @@ def prepare_canonical_folder(
     con: duckdb.DuckDBPyConnection,
     num_of_chunks: int = 10,
     output_chunk_count: int = 1,
+    derive_distinguishing_wrt_adjacent_records: bool = False,
     overwrite: bool = False,
     show_progress: ShowProgress = True,
 ) -> None:
@@ -473,6 +474,8 @@ def prepare_canonical_folder(
             addresses. Set to 1 to write `ukam_canonical_addresses.parquet`.
             Set above 1 to write hash-partitioned chunks under
             `ukam_canonical_addresses_chunks/`.
+        derive_distinguishing_wrt_adjacent_records: Derive the locally
+            distinguishing prefix required by ``DistinguishingTokenStage``.
         overwrite: Whether to overwrite existing files in the folder. When
             `True`, all known artefacts are removed before writing to ensure
             the folder ends up in a consistent state.
@@ -543,6 +546,10 @@ def prepare_canonical_folder(
         con=con,
         num_of_chunks=num_of_chunks,
         term_frequency_lookup=tf_table,
+        derive_distinguishing_wrt_adjacent_records=(
+            derive_distinguishing_wrt_adjacent_records
+        ),
+        dataset_role="canonical",
         show_progress=progress_mode,
     )
 

--- a/uk_address_matcher/sql_pipeline/match_reasons.py
+++ b/uk_address_matcher/sql_pipeline/match_reasons.py
@@ -14,6 +14,7 @@ class MatchReason(Enum):
         "peeled_address_stripped: match after peeling and removing whitespace "
         "and punctuation"
     )
+    DISTINGUISHING_TOKEN = "distinguishing_token: local prefix and ordered token match"
     SPLINK = "splink: probabilistic match"
     UNIQUE_TRIGRAM = "unique_trigram: unique trigram match"
 
@@ -33,6 +34,8 @@ class MatchReason(Enum):
             return "peeled_address"
         if self is MatchReason.PEELED_ADDRESS_STRIPPED:
             return "peeled_address_stripped"
+        if self is MatchReason.DISTINGUISHING_TOKEN:
+            return "distinguishing_token"
         if self is MatchReason.SPLINK:
             return "splink"
         if self is MatchReason.UNIQUE_TRIGRAM:


### PR DESCRIPTION
This extends the local distinguishing-token work in #444 by exposing the same
signal as an optional deterministic `DistinguishingTokenStage`.

The stage matches a non-empty, locally distinguishing canonical prefix at the
start of an address, followed by the next two canonical tokens in order. It
allows at most two safe gap tokens, requires an exact postcode, and only emits
a match when one distinct canonical ID qualifies.

Canonical preparation is opt-in via
`derive_distinguishing_wrt_adjacent_records=True`; existing defaults are
unchanged. This PR does not modify the packaged Splink model.

## Results

Both arms independently process records left unmatched by `ExactMatchStage`.

| Area | Peeled precision | Peeled recall | Distinguishing-token precision | Distinguishing-token recall | Precision delta | Recall delta |
|---|---:|---:|---:|---:|---:|---:|
| Hackney | 99.9699% | 35.0459% | 99.9422% | 57.7591% | -0.0277 pp | +22.7132 pp |
| Rhondda | 99.7506% | 65.4609% | 99.6680% | 83.4219% | -0.0826 pp | +17.9610 pp |
| Aberdeenshire | 99.5392% | 80.0353% | 99.3932% | 88.2785% | -0.1461 pp | +8.2432 pp |
| Mid Sussex | 92.9688% | 6.3365% | 93.0108% | 23.0298% | +0.0420 pp | +16.6933 pp |
| **Weighted total** | **99.6855%** | **60.0428%** | **99.6010%** | **76.1465%** | **-0.0845 pp** | **+16.1037 pp** |

This gives substantially higher recall than peeled matching, while retaining
high precision with a small overall reduction.

## Validation

- Packaged and experimental implementations produced identical matched
  `(messy ID, canonical ID)` pairs across all four benchmark areas.
- Tests cover safe-gap rules, ambiguity handling, canonical preparation across
  chunks, public stage discovery, and missing-preparation errors.
- Full suite: `304 passed`.


