### PR TITLE
fix: Next steps heading in documentation

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -100,7 +100,7 @@ Here is a list of some of our known users and their use cases:
 
 This project is free and open source and is released under the MIT licence.
 
-****## Next steps
+## Next steps
 
 - [Overview](index.md)
 - [Getting started](get_started.md)


### PR DESCRIPTION
Removes four asterisks before the Next steps heading, restoring valid Markdown formatting. This ensures the section renders correctly. 

Validation: git diff --check.