### PR TITLE
Improve precision recall overlay charts

### DIFF
--- a/.github/instructions/benchmark-experiments.instructions.md
+++ b/.github/instructions/benchmark-experiments.instructions.md
@@ -97,7 +97,8 @@ applyTo:
   - whether the comparison curve is generally above or below the baseline,
   - whether gains are concentrated at particular recall bands,
   - whether the comparison increases false positives materially,
-  - whether the lower panel shows mostly positive or negative precision gaps.
+  - whether the lower panel shows mostly positive or negative reductions in false
+    positives.
 - If the overlay chart contradicts a simple headline-metric story, say so explicitly.
 - Include the overlay chart path in the experiment artefact list whenever it exists.
 

--- a/benchmarking/insights/run_persistence.py
+++ b/benchmarking/insights/run_persistence.py
@@ -96,7 +96,7 @@ def _vega_lite_html(*, title: str, chart_definition: dict[str, Any]) -> str:
 <body>
     <div class=\"card\">
         <h1>{title}</h1>
-        <p>Overlayed precision-recall curves with recall-aligned precision deltas.</p>
+        <p>Overlayed precision-recall curves with recall-aligned reductions in false positives.</p>
         <div id=\"chart\"></div>
     </div>
     <script>

--- a/benchmarking/insights/run_persistence.py
+++ b/benchmarking/insights/run_persistence.py
@@ -96,7 +96,8 @@ def _vega_lite_html(*, title: str, chart_definition: dict[str, Any]) -> str:
 <body>
     <div class=\"card\">
         <h1>{title}</h1>
-        <p>Overlayed precision-recall curves with recall-aligned reductions in false positives.</p>
+        <p>Overlayed precision-recall curves with recall-aligned reductions in
+            false positives.</p>
         <div id=\"chart\"></div>
     </div>
     <script>

--- a/tests/test_overlay_precision_recall_charts.py
+++ b/tests/test_overlay_precision_recall_charts.py
@@ -181,6 +181,7 @@ def test_overlay_chart_definition_uses_translucent_comparisons_and_hover_guides(
     }
     assert baseline_line_layer["encoding"]["x"]["scale"]["domain"] == [0.84, 0.96]
     assert baseline_line_layer["encoding"]["y"]["scale"]["domain"] == [0.955, 1.0]
+    assert baseline_line_layer["encoding"]["y"]["axis"]["format"] == ".2%"
     assert "params" not in baseline_line_layer
     assert chart_definition["resolve"]["scale"]["x"] == "shared"
 
@@ -306,7 +307,7 @@ def test_overlay_chart_uses_one_ordered_colour_mapping() -> None:
         chart_definition["vconcat"][1]["layer"][1]["encoding"]["x"]["field"] == "recall"
     )
     assert chart_definition["vconcat"][1]["layer"][1]["encoding"]["y"]["scale"] == {
-        "domain": [-0.2, 0.2],
+        "domain": [-1.0, 1.0],
         "nice": False,
     }
 
@@ -321,7 +322,7 @@ def test_overlay_chart_rejects_more_curves_than_palette_colours() -> None:
         )
 
 
-def test_overlay_chart_preserves_curve_data_and_precision_gaps() -> None:
+def test_overlay_chart_preserves_curve_data_and_false_positive_reductions() -> None:
     baseline_values = _curve_values()
     comparison_values = [
         {**baseline_values[0], "precision": 0.91, "fp": 9},
@@ -381,12 +382,42 @@ def test_overlay_chart_preserves_curve_data_and_precision_gaps() -> None:
     ]
 
     diff_records = chart_definition["vconcat"][1]["data"]["values"]
-    precision_gaps = [
-        record["precision_gap_percentage_points"] for record in diff_records
+    false_positive_reductions = [
+        record["false_positive_reduction_percent"] for record in diff_records
     ]
-    assert precision_gaps == pytest.approx([1.0, 1.0])
+    assert false_positive_reductions == pytest.approx([10.0, 20.0])
+    assert [record["false_positive_reduction"] for record in diff_records] == [
+        1.0,
+        1.0,
+    ]
     assert [record["comparison_fp"] for record in diff_records] == [9.0, 4.0]
+    bottom_tooltips = chart_definition["vconcat"][1]["layer"][1]["encoding"][
+        "tooltip"
+    ]
+    assert [tooltip["field"] for tooltip in bottom_tooltips] == [
+        "comparison_label",
+        "baseline_recall",
+        "baseline_fp",
+        "comparison_fp",
+        "false_positive_reduction",
+        "false_positive_reduction_percent",
+    ]
     json.dumps(chart_definition, allow_nan=False)
+
+
+def test_overlay_chart_omits_reduction_when_baseline_has_no_false_positives() -> None:
+    baseline_values = [
+        {**_curve_values()[0], "precision": 1.0, "fp": 0},
+        _curve_values()[1],
+    ]
+
+    chart_definition = _overlay_precision_recall_charts(
+        _chart(baseline_values),
+        _chart(_curve_values(precision_offset=0.01)),
+    )
+
+    diff_records = chart_definition["vconcat"][1]["data"]["values"]
+    assert [record["recall"] for record in diff_records] == [0.8]
 
 
 @pytest.mark.parametrize("input_kind", ["dict", "json", "html", "object", "named"])

--- a/tests/test_overlay_precision_recall_charts.py
+++ b/tests/test_overlay_precision_recall_charts.py
@@ -391,9 +391,7 @@ def test_overlay_chart_preserves_curve_data_and_false_positive_reductions() -> N
         1.0,
     ]
     assert [record["comparison_fp"] for record in diff_records] == [9.0, 4.0]
-    bottom_tooltips = chart_definition["vconcat"][1]["layer"][1]["encoding"][
-        "tooltip"
-    ]
+    bottom_tooltips = chart_definition["vconcat"][1]["layer"][1]["encoding"]["tooltip"]
     assert [tooltip["field"] for tooltip in bottom_tooltips] == [
         "comparison_label",
         "baseline_recall",

--- a/uk_address_matcher/analysis/chart_defs/precision_recall.json
+++ b/uk_address_matcher/analysis/chart_defs/precision_recall.json
@@ -56,7 +56,7 @@
       "type": "quantitative",
       "title": "Precision",
       "axis": {
-        "format": ".1%"
+        "format": ".2%"
       },
       "scale": {
         "zero": false

--- a/uk_address_matcher/analysis/chart_defs/precision_recall_diff.json
+++ b/uk_address_matcher/analysis/chart_defs/precision_recall_diff.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
-  "description": "Recall-aligned precision gap chart",
+  "description": "Recall-aligned false-positive reduction chart",
   "width": 620,
   "height": 180,
   "data": {
@@ -47,11 +47,11 @@
           }
         },
         "y": {
-          "field": "precision_gap_percentage_points",
+          "field": "false_positive_reduction_percent",
           "type": "quantitative",
-          "title": "Precision gap (percentage points)",
+          "title": "Reduction in false positives (%)",
           "axis": {
-            "format": "+.2f"
+            "format": "+.1f"
           }
         },
         "order": {
@@ -81,40 +81,34 @@
             "title": "Comparison"
           },
           {
-            "field": "baseline_precision",
-            "type": "quantitative",
-            "title": "Baseline precision",
-            "format": ".2%"
-          },
-          {
-            "field": "baseline_fp",
-            "type": "quantitative",
-            "title": "Baseline false positives",
-            "format": ".0f"
-          },
-          {
             "field": "baseline_recall",
             "type": "quantitative",
             "title": "Baseline recall",
             "format": ".2%"
           },
           {
-            "field": "comparison_precision",
+            "field": "baseline_fp",
             "type": "quantitative",
-            "title": "Interpolated comparison precision",
-            "format": ".2%"
+            "title": "False positives before",
+            "format": ".0f"
           },
           {
             "field": "comparison_fp",
             "type": "quantitative",
-            "title": "Interpolated comparison false positives",
-            "format": ".0f"
+            "title": "False positives after",
+            "format": ".1f"
           },
           {
-            "field": "precision_gap_percentage_points",
+            "field": "false_positive_reduction",
             "type": "quantitative",
-            "title": "Precision gap (percentage points)",
-            "format": "+.2f"
+            "title": "False positives reduced",
+            "format": "+.1f"
+          },
+          {
+            "field": "false_positive_reduction_percent",
+            "type": "quantitative",
+            "title": "False positive reduction (%)",
+            "format": "+.1f"
           }
         ]
       }

--- a/uk_address_matcher/analysis/overlay_precision_recall_charts.py
+++ b/uk_address_matcher/analysis/overlay_precision_recall_charts.py
@@ -341,6 +341,14 @@ def _build_diff_records(
             if not (min_comparison_recall <= baseline_recall <= max_comparison_recall):
                 continue
 
+            baseline_fp_value = baseline_record.get("fp")
+            if baseline_fp_value is None:
+                continue
+
+            baseline_fp = float(baseline_fp_value)
+            if baseline_fp <= 0.0:
+                continue
+
             baseline_precision = float(baseline_record["precision"])
             comparison_precision = _interpolate_precision_for_recall(
                 comparison_records,
@@ -351,20 +359,27 @@ def _build_diff_records(
                 field_name="fp",
                 target_recall=baseline_recall,
             )
+            if comparison_fp is None:
+                continue
+
+            false_positive_reduction = baseline_fp - comparison_fp
+            false_positive_reduction_percent = (
+                false_positive_reduction / baseline_fp * 100.0
+            )
             diff_records.append(
                 {
                     "baseline_recall": baseline_recall,
                     "recall": baseline_recall,
                     "baseline_precision": baseline_precision,
-                    "baseline_fp": baseline_record.get("fp"),
+                    "baseline_fp": baseline_fp,
                     "comparison_label": comparison_label,
                     "series_id": series_id,
                     "comparison_precision": comparison_precision,
                     "comparison_fp": comparison_fp,
-                    "precision_gap_percentage_points": (
-                        comparison_precision - baseline_precision
-                    )
-                    * 100.0,
+                    "false_positive_reduction": false_positive_reduction,
+                    "false_positive_reduction_percent": (
+                        false_positive_reduction_percent
+                    ),
                     "baseline_truth_threshold": baseline_record.get("truth_threshold"),
                     "baseline_match_probability": baseline_record.get(
                         "match_probability"
@@ -441,6 +456,7 @@ def _build_overlay_chart_definition(
         recall_axis_maximum,
     ]
     top_panel["encoding"]["y"]["scale"]["domain"] = [precision_axis_floor, 1.0]
+    top_panel["encoding"]["y"]["axis"]["format"] = ".2%"
     top_panel["encoding"]["color"] = {
         "field": "series_label",
         "type": "nominal",
@@ -717,25 +733,32 @@ def _build_overlay_chart_definition(
         recall_axis_minimum,
         recall_axis_maximum,
     ]
-    precision_gap_extent = max(
+    false_positive_reduction_extent = max(
         (
-            abs(float(record["precision_gap_percentage_points"]))
+            abs(float(record["false_positive_reduction_percent"]))
             for record in diff_records
         ),
         default=1.0,
     )
-    precision_gap_extent = round(precision_gap_extent, 12)
-    if precision_gap_extent == 0:
-        precision_gap_extent = 1.0
+    false_positive_reduction_extent = round(
+        false_positive_reduction_extent,
+        12,
+    )
+    if false_positive_reduction_extent == 0:
+        false_positive_reduction_extent = 1.0
     bottom_panel["layer"][1]["encoding"]["y"]["scale"] = {
-        "domain": [-precision_gap_extent, precision_gap_extent],
+        "domain": [
+            -false_positive_reduction_extent,
+            false_positive_reduction_extent,
+        ],
         "nice": False,
     }
 
     return {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
         "description": (
-            "Overlayed precision-recall curves with recall-aligned precision gaps"
+            "Overlayed precision-recall curves with recall-aligned false-positive "
+            "reductions"
         ),
         "title": "Precision-Recall Curve Comparison",
         "background": "#FFFFFF",


### PR DESCRIPTION
With this change, the bottom chart is easier to interpret as 'progress towards no errors'

It suffers a bit from variance at low recall, but nonethelss I still think it's a significnt improvement 

<img width="1758" height="969" alt="image" src="https://github.com/user-attachments/assets/b19f23b9-9a71-4532-9d87-7fc97dba3869" />
