### PR TITLE
feat: range-aware inverted index

### DIFF
--- a/tests/cleaning/test_abbreviation_replacement.py
+++ b/tests/cleaning/test_abbreviation_replacement.py
@@ -167,6 +167,35 @@ def test_first_pass_splits_non_numeric_underscores_only(duck_con):
     ]
 
 
+def test_first_pass_normalises_numeric_to_ranges(duck_con):
+    input_rel = duck_con.sql(
+        """
+        SELECT * FROM (VALUES
+            ('55 TO 57 OLD STREET ROAD'),
+            ('FLAT 2 55 TO 57 OLD STREET ROAD'),
+            ('NOT A RANGE TO 57 OLD STREET ROAD'),
+            ('55 TO 57-59 OLD STREET ROAD'),
+            ('1-55 TO 57 OLD STREET ROAD')
+        ) AS t(clean_full_address)
+        """
+    )
+
+    pipeline = create_sql_pipeline(
+        con=duck_con,
+        input_rel=input_rel,
+        stage_specs=[_clean_address_string_first_pass],
+    )
+    rows = [row[0] for row in pipeline.run().fetchall()]
+
+    assert rows == [
+        "55-57 OLD STREET ROAD",
+        "FLAT 2 55-57 OLD STREET ROAD",
+        "NOT A RANGE TO 57 OLD STREET ROAD",
+        "55 TO 57-59 OLD STREET ROAD",
+        "1-55 TO 57 OLD STREET ROAD",
+    ]
+
+
 def test_full_cleaning_queue_preserves_underscore_split_before_expansion(duck_con):
     input_rel = duck_con.sql(
         """

--- a/tests/cleaning/test_trigram_inverted_index.py
+++ b/tests/cleaning/test_trigram_inverted_index.py
@@ -156,7 +156,9 @@ class TestIndexingStrategySqlExpressions:
             WITH input AS (
                 SELECT
                     '9 LOVE LANE LONDON' AS clean_full_address,
-                    string_split('9 LOVE LANE LONDON', ' ') AS __tokens
+                    ['9']::VARCHAR[] AS numeric_tokens,
+                    string_split('9 LOVE LANE LONDON', ' ') AS __tokens,
+                    string_split('9 LOVE LANE LONDON', ' ') AS __range_tokens
             )
             SELECT {TRIGRAM_INDEX.keys_sql_expr} AS keys
             FROM input
@@ -172,7 +174,9 @@ class TestIndexingStrategySqlExpressions:
             WITH input AS (
                 SELECT
                     'HIGH STREET' AS clean_full_address,
-                    string_split('HIGH STREET', ' ') AS __tokens
+                    []::VARCHAR[] AS numeric_tokens,
+                    string_split('HIGH STREET', ' ') AS __tokens,
+                    string_split('HIGH STREET', ' ') AS __range_tokens
             )
             SELECT {TRIGRAM_INDEX.keys_sql_expr} AS keys
             FROM input
@@ -188,7 +192,9 @@ class TestIndexingStrategySqlExpressions:
             WITH input AS (
                 SELECT
                     '9 LOVE LANE LONDON' AS clean_full_address,
-                    string_split('9 LOVE LANE LONDON', ' ') AS __tokens
+                    ['9']::VARCHAR[] AS numeric_tokens,
+                    string_split('9 LOVE LANE LONDON', ' ') AS __tokens,
+                    string_split('9 LOVE LANE LONDON', ' ') AS __range_tokens
             )
             SELECT {BIGRAM_INDEX.keys_sql_expr} AS keys
             FROM input
@@ -204,13 +210,145 @@ class TestIndexingStrategySqlExpressions:
             WITH input AS (
                 SELECT
                     'LONDON' AS clean_full_address,
-                    string_split('LONDON', ' ') AS __tokens
+                    []::VARCHAR[] AS numeric_tokens,
+                    string_split('LONDON', ' ') AS __tokens,
+                    string_split('LONDON', ' ') AS __range_tokens
             )
             SELECT {BIGRAM_INDEX.keys_sql_expr} AS keys
             FROM input
         """).fetchone()[0]
 
         assert result == []
+
+    def test_range_candidate_gate_ignores_ordinary_numbers(self, duck_con):
+        """Test the range gate skips ordinary numbers and keeps dash ranges."""
+        from uk_address_matcher.cleaning.steps.inverted_index import (
+            RANGE_EXPANSION_CANDIDATE_SQL,
+        )
+
+        result = duck_con.sql(f"""
+            WITH input AS (
+                SELECT * FROM (VALUES
+                    ('100 HIGH STREET', ['100']::VARCHAR[]),
+                    ('1-2 OLD STREET', ['1-2']::VARCHAR[]),
+                    ('55-57 OLD STREET', ['55-57']::VARCHAR[])
+                ) AS rows(clean_full_address, numeric_tokens)
+            )
+            SELECT {RANGE_EXPANSION_CANDIDATE_SQL} AS is_candidate
+            FROM input
+        """).fetchall()
+
+        assert [row[0] for row in result] == [False, True, True]
+
+    def test_range_strategy_sql_preserves_and_expands_dash_range(self, duck_con):
+        """Test that bounded dash ranges retain their keys and add scalar keys."""
+        from uk_address_matcher.cleaning.steps.inverted_index import (
+            BIGRAM_INDEX,
+            TRIGRAM_INDEX,
+        )
+
+        result = duck_con.sql(f"""
+            WITH input AS (
+                SELECT
+                'FLAT 2 55-57 OLD STREET ROAD' AS clean_full_address,
+                string_split(
+                    'FLAT 2 55-57 OLD STREET ROAD', ' '
+                ) AS __tokens,
+                ['2', '55-57']::VARCHAR[] AS numeric_tokens,
+                string_split(
+                    'FLAT 2 55-57 OLD STREET ROAD', ' '
+                ) AS __range_tokens
+            )
+            SELECT
+                {BIGRAM_INDEX.keys_sql_expr} AS bigrams,
+                {TRIGRAM_INDEX.keys_sql_expr} AS trigrams
+            FROM input
+        """).fetchone()
+        bigrams = set(result[0])
+        trigrams = set(result[1])
+
+        assert {'2 55-57', '55-57 OLD'} <= bigrams
+        assert {'55 OLD', '56 OLD', '57 OLD'} <= bigrams
+        assert {'55-57 OLD STREET'} <= trigrams
+        assert {'55 OLD STREET', '56 OLD STREET', '57 OLD STREET'} <= trigrams
+
+    def test_range_strategy_sql_uses_cleaned_to_range(self, duck_con):
+        """Test that cleaned TO ranges retain their dash key and add scalars."""
+        from uk_address_matcher.cleaning.steps.inverted_index import (
+            BIGRAM_INDEX,
+            TRIGRAM_INDEX,
+        )
+
+        result = duck_con.sql(f"""
+            WITH input AS (
+                SELECT
+                'FLAT 2 55-57 OLD STREET ROAD' AS clean_full_address,
+                string_split(
+                    'FLAT 2 55-57 OLD STREET ROAD', ' '
+                ) AS __tokens,
+                ['2', '55-57']::VARCHAR[] AS numeric_tokens,
+                string_split(
+                    'FLAT 2 55-57 OLD STREET ROAD', ' '
+                ) AS __range_tokens
+            )
+            SELECT
+                {BIGRAM_INDEX.keys_sql_expr} AS bigrams,
+                {TRIGRAM_INDEX.keys_sql_expr} AS trigrams
+            FROM input
+        """).fetchone()
+        bigrams = set(result[0])
+        trigrams = set(result[1])
+
+        assert {'2 55-57', '55-57 OLD'} <= bigrams
+        assert '55-57 OLD STREET' in trigrams
+        assert {'55 OLD', '56 OLD', '57 OLD'} <= bigrams
+        assert {'55 OLD STREET', '56 OLD STREET', '57 OLD STREET'} <= trigrams
+
+    def test_range_strategy_sql_rejects_reversed_and_oversized_ranges(self, duck_con):
+        """Test that invalid spans do not produce scalarised keys."""
+        from uk_address_matcher.cleaning.steps.inverted_index import BIGRAM_INDEX
+
+        result = duck_con.sql(f"""
+            WITH input AS (
+                SELECT * FROM (VALUES
+                    ('57-55 OLD STREET ROAD',
+                     string_split('57-55 OLD STREET ROAD', ' '),
+                     ['57-55']::VARCHAR[],
+                     string_split('57-55 OLD STREET ROAD', ' ')),
+                    ('1-1000 OLD STREET ROAD',
+                     string_split('1-1000 OLD STREET ROAD', ' '),
+                     ['1-1000']::VARCHAR[],
+                     string_split('1-1000 OLD STREET ROAD', ' '))
+                 ) AS rows(clean_full_address, __tokens, numeric_tokens, __range_tokens)
+            )
+            SELECT {BIGRAM_INDEX.keys_sql_expr} AS bigrams
+            FROM input
+        """).fetchall()
+
+        assert '55 OLD' not in result[0][0]
+        assert '57 OLD' not in result[1][0]
+        assert '1 OLD' not in result[1][0]
+
+    def test_range_strategy_sql_expands_multiple_ranges_locally(self, duck_con):
+        """Test multiple ranges do not create full-address Cartesian variants."""
+        from uk_address_matcher.cleaning.steps.inverted_index import TRIGRAM_INDEX
+
+        result = duck_con.sql(f"""
+            WITH input AS (
+                SELECT
+                    '1-2 ALPHA 3-4 ROAD' AS clean_full_address,
+                    string_split('1-2 ALPHA 3-4 ROAD', ' ') AS __tokens,
+                    ['1-2', '3-4']::VARCHAR[] AS numeric_tokens,
+                    string_split('1-2 ALPHA 3-4 ROAD', ' ') AS __range_tokens
+            )
+            SELECT {TRIGRAM_INDEX.keys_sql_expr} AS trigrams
+            FROM input
+        """).fetchone()[0]
+
+        assert '1-2 ALPHA 3-4' in result
+        assert '1 ALPHA 3-4' in result
+        assert '1-2 ALPHA 3' in result
+        assert '1 ALPHA 3' not in result
 
 
 class TestInvertedIndexBuilding:
@@ -495,6 +633,68 @@ class TestDeriveInvertedIndexFunction:
         """).fetchall()
         strategy_names = [row[0] for row in strategies]
         assert strategy_names == ["trigram"]
+
+    def test_range_expansion_keeps_one_posting_identity(self, duck_con):
+        """Test scalarised keys do not duplicate a canonical record identity."""
+        from uk_address_matcher.cleaning.chunking_strategies import (
+            derive_inverted_index,
+            prepare_data_for_matching,
+        )
+
+        canonical_raw = duck_con.sql("""
+            SELECT * FROM (VALUES
+                ('range', 'FLAT 2 55-57 OLD STREET ROAD', 'SW1A 1AA')
+            ) AS t(unique_id, address_concat, postcode)
+        """)
+        canonical_clean = prepare_data_for_matching(
+            canonical_raw, duck_con, num_of_chunks=1
+        )
+        inverted_idx = derive_inverted_index(canonical_clean, duck_con)
+
+        posting = duck_con.sql("""
+            SELECT unique_ids
+            FROM inverted_idx
+            WHERE index_strategy = 'trigram'
+              AND key = '57 OLD STREET'
+        """).fetchone()
+
+        assert posting == (['range'],)
+
+    def test_range_expansion_recovers_scalar_messy_lookup(self, duck_con):
+        """Test dash and TO messy ranges find a scalar canonical address."""
+        from uk_address_matcher.cleaning.chunking_strategies import (
+            derive_inverted_index,
+            prepare_data_for_matching,
+        )
+
+        canonical = duck_con.sql("""
+            SELECT * FROM (VALUES
+                ('canonical', '57 OLD STREET ROAD', 'SW1A 1AA')
+            ) AS t(unique_id, address_concat, postcode)
+        """)
+        messy = duck_con.sql("""
+            SELECT * FROM (VALUES
+                ('dash', '55-57 OLD STREET ROAD', 'SW1A 1AA'),
+                ('to', '55 TO 57 OLD STREET ROAD', 'SW1A 1AA')
+            ) AS t(unique_id, address_concat, postcode)
+        """)
+        canonical_clean = prepare_data_for_matching(
+            canonical, duck_con, num_of_chunks=1, dataset_role="canonical"
+        )
+        inverted_idx = derive_inverted_index(canonical_clean, duck_con)
+        prepared_messy = prepare_data_for_matching(
+            messy,
+            duck_con,
+            num_of_chunks=1,
+            inverted_index=inverted_idx,
+            dataset_role="messy",
+        )
+
+        candidates = dict(
+            prepared_messy.select("unique_id, exploding_unique_ids").fetchall()
+        )
+
+        assert candidates == {'dash': ['canonical'], 'to': ['canonical']}
 
 
 class TestPrepareDataForMatchingWithInvertedIndex:

--- a/uk_address_matcher/cleaning/steps/inverted_index.py
+++ b/uk_address_matcher/cleaning/steps/inverted_index.py
@@ -75,9 +75,54 @@ class InvertedIndexPortfolio:
     lookup_strategies: tuple[InvertedIndexLookupStrategy, ...]
 
 
+def _range_aware_keys_sql_expr(keys_sql_expr: str) -> str:
+    """Add bounded scalar variants for numeric range tokens to a key expression."""
+    range_expansion_max_span = 20
+    range_expansion_available_sql = "len(__range_tokens) > 0"
+    range_tokens_sql = "__range_tokens"
+    range_positions_sql = f"""list_filter(
+        generate_series(1, len({range_tokens_sql})),
+        __position -> regexp_matches(
+            {range_tokens_sql}[__position], '^[0-9]{{1,5}}-[0-9]{{1,5}}$'
+        )
+        AND try_cast(split_part({range_tokens_sql}[__position], '-', 1) AS INTEGER)
+            <= try_cast(split_part({range_tokens_sql}[__position], '-', 2) AS INTEGER)
+        AND try_cast(split_part({range_tokens_sql}[__position], '-', 2) AS INTEGER)
+            - try_cast(split_part({range_tokens_sql}[__position], '-', 1) AS INTEGER)
+            + 1 <= {range_expansion_max_span}
+    )"""
+    range_variants_sql = f"""flatten(list_transform(
+        {range_positions_sql},
+        __position -> list_transform(
+            generate_series(
+                try_cast(split_part({range_tokens_sql}[__position], '-', 1) AS INTEGER),
+                try_cast(split_part({range_tokens_sql}[__position], '-', 2) AS INTEGER)
+            ),
+            __number -> list_transform(
+                {range_tokens_sql},
+                (__token, __token_position) -> CASE
+                    WHEN __token_position = __position THEN CAST(__number AS VARCHAR)
+                    ELSE __token
+                END
+            )
+        )
+    ))"""
+    variant_keys_sql_expr = keys_sql_expr.replace("__tokens", "__variant_tokens")
+    return f"""CASE
+        WHEN {range_expansion_available_sql} THEN list_concat(
+            {keys_sql_expr},
+            flatten(list_transform(
+                {range_variants_sql},
+                __variant_tokens -> {variant_keys_sql_expr}
+            ))
+        )
+        ELSE {keys_sql_expr}
+    END"""
+
+
 ADJACENT_TRIGRAM_KEYS = SignatureKeyGenerator(
     name="adjacent_trigram_keys",
-    keys_sql_expr="""\
+    keys_sql_expr=_range_aware_keys_sql_expr("""\
 CASE
     WHEN len(__tokens) >= 3 THEN
         list_transform(
@@ -87,12 +132,12 @@ CASE
                    || ' ' || __tokens[__i + 2]
         )
     ELSE []::VARCHAR[]
-END""",
+END"""),
 )
 
 ADJACENT_BIGRAM_KEYS = SignatureKeyGenerator(
     name="adjacent_bigram_keys",
-    keys_sql_expr="""\
+    keys_sql_expr=_range_aware_keys_sql_expr("""\
 CASE
     WHEN len(__tokens) >= 2 THEN
         list_transform(
@@ -100,11 +145,11 @@ CASE
             __i -> __tokens[__i] || ' ' || __tokens[__i + 1]
         )
     ELSE []::VARCHAR[]
-END""",
+END"""),
 )
 SKIP1_TRIGRAM_KEYS = SignatureKeyGenerator(
     name="skip1_trigram_keys",
-    keys_sql_expr="""\
+    keys_sql_expr=_range_aware_keys_sql_expr("""\
 CASE
     WHEN len(__tokens) >= 4 THEN list_concat(
         list_transform(
@@ -117,11 +162,11 @@ CASE
         )
     )
     ELSE []::VARCHAR[]
-END""",
+END"""),
 )
 SKIP1_BIGRAM_KEYS = SignatureKeyGenerator(
     name="skip1_bigram_keys",
-    keys_sql_expr="""\
+    keys_sql_expr=_range_aware_keys_sql_expr("""\
 CASE
     WHEN len(__tokens) >= 3 THEN
         list_transform(
@@ -129,11 +174,11 @@ CASE
             __i -> __tokens[__i] || ' ' || __tokens[__i + 2]
         )
     ELSE []::VARCHAR[]
-END""",
+END"""),
 )
 SKIP2_BIGRAM_KEYS = SignatureKeyGenerator(
     name="skip2_bigram_keys",
-    keys_sql_expr="""\
+    keys_sql_expr=_range_aware_keys_sql_expr("""\
 CASE
     WHEN len(__tokens) >= 4 THEN
         list_transform(
@@ -141,11 +186,11 @@ CASE
             __i -> __tokens[__i] || ' ' || __tokens[__i + 3]
         )
     ELSE []::VARCHAR[]
-END""",
+END"""),
 )
 SKIP2_TRIGRAM_KEYS = SignatureKeyGenerator(
     name="skip2_trigram_keys",
-    keys_sql_expr="""\
+    keys_sql_expr=_range_aware_keys_sql_expr("""\
 CASE
     WHEN len(__tokens) >= 5 THEN list_concat(
         list_transform(
@@ -162,7 +207,7 @@ CASE
         )
     )
     ELSE []::VARCHAR[]
-END""",
+END"""),
 )
 
 TRIGRAM_INDEX = PhysicalIndexStrategy(
@@ -254,6 +299,12 @@ def _derive_keys_for_strategy(
     )
     def _stage():
         keys_expr = strategy.key_generator.keys_sql_expr
+        range_expansion_candidate_sql = """(
+            len(list_filter(
+                COALESCE(numeric_tokens, []::VARCHAR[]),
+                __numeric_value -> contains(__numeric_value, '-')
+            )) > 0
+        )"""
         filtered_expr = keys_expr
         if chunked:
             filtered_expr = (
@@ -267,7 +318,16 @@ def _derive_keys_for_strategy(
             unique_id,
             {filtered_expr} AS __index_keys
         FROM (
-            SELECT *, regexp_split_to_array(trim(clean_full_address), '\\s+') AS __tokens
+            SELECT
+                *,
+                regexp_split_to_array(trim(clean_full_address), '\\s+') AS __tokens,
+                CASE
+                    WHEN {range_expansion_candidate_sql} THEN regexp_split_to_array(
+                        trim(clean_full_address),
+                        '\\s+'
+                    )
+                    ELSE []::VARCHAR[]
+                END AS __range_tokens
             FROM {{input}}
         ) AS tokenised
         """
@@ -331,9 +391,24 @@ def _lookup_keys_in_inverted_index(
         tags="inverted_index",
     )
     def _stage():
-        base_sql = """
-        SELECT *, regexp_split_to_array(trim(clean_full_address), '\\s+') AS __tokens
-        FROM {input}
+        range_expansion_candidate_sql = """(
+            len(list_filter(
+                COALESCE(numeric_tokens, []::VARCHAR[]),
+                __numeric_value -> contains(__numeric_value, '-')
+            )) > 0
+        )"""
+        base_sql = f"""
+        SELECT
+            *,
+            regexp_split_to_array(trim(clean_full_address), '\\s+') AS __tokens,
+            CASE
+                WHEN {range_expansion_candidate_sql} THEN regexp_split_to_array(
+                    trim(clean_full_address),
+                    '\\s+'
+                )
+                ELSE []::VARCHAR[]
+            END AS __range_tokens
+        FROM {{input}}
         """
         union_parts = []
         for strategy in lookup_strategies:
@@ -438,7 +513,7 @@ def _lookup_keys_in_inverted_index(
         """
         final_sql = """
         SELECT
-            base.* EXCLUDE (__tokens),
+            base.* EXCLUDE (__tokens, __range_tokens),
             COALESCE(candidates.exploding_unique_ids, []) AS exploding_unique_ids,
             COALESCE(
                 scores.signature_score_map,

--- a/uk_address_matcher/cleaning/steps/normalisation.py
+++ b/uk_address_matcher/cleaning/steps/normalisation.py
@@ -12,6 +12,7 @@ from uk_address_matcher.cleaning.steps.regexes import (
     replace_non_numeric_adjacent_underscores,
     separate_letter_num,
     standarise_num_letter,
+    standarise_num_to_num,
     trim,
 )
 from uk_address_matcher.sql_pipeline.helpers import package_resource_read_sql
@@ -200,6 +201,7 @@ def _clean_address_string_first_pass() -> str:
             replace_non_numeric_adjacent_underscores,
             remove_multiple_spaces,
             replace_fwd_slash_with_dash,
+            standarise_num_to_num,
             # standarise_num_dash_num,  # left commented as in original
             separate_letter_num,
             standarise_num_letter,

--- a/uk_address_matcher/cleaning/steps/regexes.py
+++ b/uk_address_matcher/cleaning/steps/regexes.py
@@ -17,6 +17,21 @@ def remove_multiple_spaces(input: str):
     return f"regexp_replace({input}, '\\s+', ' ', 'g')"
 
 
+def standarise_num_to_num(input: str):
+    """Standardise numeric ranges written with the word TO.
+
+    Examples:
+        '23 TO 24' -> '23-24'
+        '230 TO 234' -> '230-234'
+    """
+    regex_pattern = (
+        r"(^|[^0-9A-Za-z-])"
+        r"(\d{1,5})\s+TO\s+(\d{1,5})"
+        r"([^0-9A-Za-z-]|$)"
+    )
+    return f"regexp_replace({input}, '{regex_pattern}', '\\1\\2-\\3\\4', 'gi')"
+
+
 def standarise_num_dash_num(input: str):
     """
     Standardizes numeric ranges with dashes by removing spaces around the dash.


### PR DESCRIPTION
## Operational Change

The cleaning pipeline now converts numeric `TO` ranges into dash ranges:

- `55 TO 57` becomes `55-57`

The inverted-index pipeline then:

- Uses extracted `numeric_tokens` containing `-` as a cheap candidate filter.
- Expands valid numeric ranges up to a maximum span of `20`.
- Adds scalar keys for old ranges (`55-57 OLD`) -> `55 OLD`, `56 OLD`, and `57 OLD`.
- Retains the original range keys.
- Applies the same key generation to canonical and messy addresses.
- Preserves one canonical record identity; only additional index keys and postings are generated.
- Avoids Cartesian expansion when an address contains multiple ranges.

## Additional Canonical Records

No additional canonical address rows are created. The canonical row count remains unchanged.

The persisted inverted index changed as follows:

| Artefact | Baseline | Range-aware | Difference |
|---|---:|---:|---:|
| Index rows | 61,575,577 | 64,499,824 | +2,924,247 |

For the verified blocking-miss sample:

- Historical blocking recovered `0/143` rows.
- Range-aware blocking recovered `10/143` rows.
- This covered `3/80` distinct messy records.

## Accuracy Results

The change was tested on the pooled councils dataset:

- Hackney
- Rhondda
- Aberdeenshire
- 348,687 messy input rows

The controlled comparison used the same matching stages and compared the old canonical index with the range-aware canonical index:

| Metric | Baseline | Range-aware | Change |
|---|---:|---:|---:|
| Precision | 98.9577% | 98.9575% | -0.0002 pp |
| Recall | 96.8000% | 96.8066% | +0.0066 pp |
| F1 | 97.8670% | 97.8702% | +0.0032 pp |
| Correct matches | 337,529 | 337,552 | +23 |
