### PR TITLE
Attempt to avoid double counting numerics/positionals

### DIFF
--- a/docs/experiments/structural_evidence_scoring.md
+++ b/docs/experiments/structural_evidence_scoring.md
@@ -1,0 +1,108 @@
+# Structural evidence scoring
+
+The four adjustments are applied in
+`post_linkage/distinguishing_features/structural_evidence.py`, after the existing
+distinguishing-token reranker and before relation-marker scoring, distinguishability,
+thresholding, and final ranking. Each adjustment is retained as a named score component
+in log2 Bayes-factor units.
+
+1. The distinguishing-token reranker identifies the positive bigram reward attributable
+   only to numeric, unit, floor, or layout tokens. The structural-evidence stage removes
+   that component only when no canonical variant for the candidate UPRN has the source's
+   exact normalised full postcode. Negative and mixed substantive bigram evidence is not
+   changed.
+2. The stage subtracts eight bits when every canonical variant lacks both exact full
+   postcode evidence and substantive token overlap.
+3. The stage subtracts three bits for an unambiguous explicit flat-letter contradiction
+   when a competing UPRN supports the source letter.
+4. The stage subtracts three bits when the candidate has no exact-postcode variant,
+   `gamma_postcode <= 2`, and `gamma_address_without_numbers = 0`.
+
+Postcode, substantive-token, and flat-letter evidence are grouped by source record and
+canonical `unique_id` before scoring, so all variants of a UPRN contribute. The shared
+token taxonomy lives in `post_linkage/token_classification.py` and is used by both the
+reranker and the structural-evidence stage.
+
+No Splink comparison configuration changed, so `data/splink_model.json` did not require
+regeneration. Candidate generation, the top-five reranker limit, final score threshold,
+and deterministic tie-breaking remain unchanged.
+
+Run the four-authority labelled validation with:
+
+```bash
+uv run python -m benchmarking.validate_structural_evidence
+```
+
+It writes an ID-only changed-winner audit and JSON/Markdown summaries under
+`benchmarking/results_structural_evidence_scoring/`.
+
+## Clean-main benchmark
+
+### Question
+
+Do the four adjustments improve precision-recall performance in each labelled
+authority relative to a clean checkout of `main`?
+
+### Runs compared
+
+- Baseline: `main-1fbaa19`, built from commit `1fbaa19` in a clean worktree.
+- Current: `feature-structural-evidence-scoring`.
+- Authorities: Hackney, Rhondda Cynon Taf, Aberdeenshire, and Mid Sussex.
+- Date: 2026-08-13.
+
+The comparison used the same labelled inputs, prepared canonical data, canonical
+filters, production stage order, top-five reranker limit, and final match-weight
+threshold. The prepared canonical data was not rebuilt because the change only
+affects post-linkage scoring. No Splink comparison or threshold changed.
+
+### Headline metrics
+
+| Authority | PR-AUC baseline | PR-AUC current | PR-AUC delta | Correct-match delta | Precision delta | Recall delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Hackney | 0.572984 | 0.573523 | +0.000539 | +59 | +0.0741 pp | +0.0517 pp |
+| Rhondda | 0.310175 | 0.310112 | -0.000063 | -8 | +0.0026 pp | -0.0071 pp |
+| Aberdeenshire | 0.141238 | 0.141238 | 0.000000 | 0 | 0.0000 pp | 0.0000 pp |
+| Mid Sussex | 0.665033 | 0.665282 | +0.000249 | +1 | +0.1609 pp | +0.0221 pp |
+
+The result is mixed and does not establish unambiguous improvement in all four
+authorities. Hackney and Mid Sussex improve, Aberdeenshire is unchanged, and
+Rhondda has a small PR-AUC and recall regression. In particular, the Rhondda
+curve crosses the baseline curve rather than dominating it.
+
+The fixed-threshold Rhondda precision increase comes from greater abstention,
+not better ranking throughout the curve: the feature run emits 11 fewer Splink
+matches, while recall falls by 0.0071 percentage points. One additional
+`peeled_address_stripped` difference occurred outside the changed scoring stage
+and is treated as run-to-run noise in the end-to-end comparison.
+
+### Rule attribution
+
+Sequential replay across 130,153 probabilistic candidate groups found 163 winner
+changes, comprising 121 label-agreement fixes and 18 harms. The first three rules
+accounted for 106 fixes and four harms. The weak address-and-postcode rule
+accounted for 15 fixes and 14 harms.
+
+All 14 Rhondda harms came from the weak address-and-postcode rule and form one
+internally conflicting block. The source street text and labelled UPRNs identify
+Sandybank Road, while the source postcodes exactly identify same-number rivals on
+Pontrhondda Road. Every Sandybank canonical variant has the bottom
+`address_without_numbers` comparison level and a non-matching postcode, so UPRN
+variant aggregation does not change the rule outcome. All 14 candidates remain
+below the configured production threshold before and after scoring; they affect
+the raw-label precision-recall curve but do not create emitted wrong matches.
+
+This replay used ordinary production blocking and source labels. The separate
+4,740-row consensus-adjudication dataset used to review probabilistic cases was
+not available, so its conclusions should not be conflated with this
+whole-population raw-label curve.
+
+### Artefacts
+
+- Per-area comparison reports and primary precision-recall overlays:
+   `benchmarking/results_structural_evidence_main_vs_pr/`.
+- Rule-by-rule summary:
+   `benchmarking/results_structural_evidence_scoring/validation_summary.md`.
+- Machine-readable summary:
+   `benchmarking/results_structural_evidence_scoring/validation_summary.json`.
+- ID-only changed-winner audit:
+   `benchmarking/results_structural_evidence_scoring/changed_winner_label_agreements.csv`.

--- a/tests/post_linkage/test_structural_evidence.py
+++ b/tests/post_linkage/test_structural_evidence.py
@@ -1,0 +1,344 @@
+import duckdb
+import pytest
+
+from uk_address_matcher.post_linkage.distinguishing_features.structural_evidence import (
+    improve_predictions_using_structural_evidence,
+)
+from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
+    improve_predictions_using_distinguishing_tokens,
+)
+
+
+def _predictions(con, rows):
+    con.execute("""
+        CREATE TABLE predictions (
+            unique_id_r VARCHAR,
+            unique_id_l VARCHAR,
+            clean_full_address_r VARCHAR,
+            postcode_r VARCHAR,
+            flat_letter_r VARCHAR,
+            flat_number_r VARCHAR,
+            has_flat_indicator_r BOOLEAN,
+            structural_bigram_reward DOUBLE,
+            gamma_postcode INTEGER,
+            gamma_address_without_numbers INTEGER,
+            bigram_absence_penalty DOUBLE,
+            match_weight DOUBLE
+        )
+    """)
+    con.executemany(
+        "INSERT INTO predictions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    return con.table("predictions")
+
+
+def _canonical(con, rows):
+    con.execute("""
+        CREATE TABLE canonical (
+            unique_id VARCHAR,
+            clean_full_address VARCHAR,
+            postcode VARCHAR,
+            flat_letter VARCHAR
+        )
+    """)
+    con.executemany("INSERT INTO canonical VALUES (?, ?, ?, ?)", rows)
+    return con.table("canonical")
+
+
+def _apply(con, prediction_rows, canonical_rows):
+    return improve_predictions_using_structural_evidence(
+        df_predict=_predictions(con, prediction_rows),
+        df_canonical=_canonical(con, canonical_rows),
+        con=con,
+    ).df()
+
+
+def _prediction_row(
+    *,
+    source_id="messy",
+    candidate_id="candidate",
+    address="FLAT 2 10 ALPHA ROAD",
+    postcode="AA1 1AA",
+    flat_letter=None,
+    flat_number="2",
+    has_flat_indicator=True,
+    structural_bigram_reward=0.0,
+    gamma_postcode=5,
+    gamma_address_without_numbers=3,
+    bigram_absence_penalty=1.15,
+    match_weight=10.0,
+):
+    return (
+        source_id,
+        candidate_id,
+        address,
+        postcode,
+        flat_letter,
+        flat_number,
+        has_flat_indicator,
+        structural_bigram_reward,
+        gamma_postcode,
+        gamma_address_without_numbers,
+        bigram_absence_penalty,
+        match_weight,
+    )
+
+
+def test_reranker_classifies_only_all_structural_positive_bigrams():
+    con = duckdb.connect()
+    con.execute("""
+        CREATE TABLE reranker_input AS
+        SELECT
+            * EXCLUDE (common_end_tokens_hist_r),
+            CAST(common_end_tokens_hist_r AS MAP(VARCHAR, INTEGER))
+                AS common_end_tokens_hist_r
+        FROM (VALUES
+            (0.0, 0.5, 'candidate', 'messy',
+             'FLAT 2 CHARDMORE ROAD', 'FLAT 2 CHARDMORE ROAD',
+             'AA1 1AB', 'AA1 1AA', 1, 10, map([], [])),
+            (0.0, 0.5, 'rival', 'messy',
+             'FLAT 3 CHARDMORE ROAD', 'FLAT 2 CHARDMORE ROAD',
+             'AA1 1AC', 'AA1 1AA', 2, 10, map([], []))
+        ) AS input(
+            match_weight,
+            match_probability,
+            unique_id_l,
+            unique_id_r,
+            clean_full_address_l,
+            clean_full_address_r,
+            postcode_l,
+            postcode_r,
+            ukam_address_id_l,
+            ukam_address_id_r,
+            common_end_tokens_hist_r
+        )
+    """)
+
+    result = (
+        improve_predictions_using_distinguishing_tokens(
+            df_predict=con.table("reranker_input"),
+            con=con,
+            match_weight_threshold=-100,
+        )
+        .df()
+        .set_index("unique_id_l")
+    )
+
+    candidate = result.loc["candidate"]
+    assert candidate["structural_bigram_reward"] == pytest.approx(2.2)
+    assert candidate["bigram_reward"] == pytest.approx(4.4)
+
+
+@pytest.mark.parametrize(
+    ("canonical_rows", "expected_adjustment"),
+    [
+        (
+            [("candidate", "FLAT 2 10 ALPHA ROAD", "BB1 1BB", None)],
+            -2.2,
+        ),
+        (
+            [
+                ("candidate", "FLAT 2 10 ALPHA ROAD", "BB1 1BB", None),
+                ("candidate", "FLAT 2 10 ALPHA ROAD", "AA1 1AA", None),
+            ],
+            0.0,
+        ),
+    ],
+)
+def test_structural_bigram_reward_depends_on_any_exact_postcode_variant(
+    canonical_rows,
+    expected_adjustment,
+):
+    con = duckdb.connect()
+    result = _apply(
+        con,
+        [_prediction_row(structural_bigram_reward=2.2)],
+        canonical_rows,
+    ).iloc[0]
+
+    assert result["structural_bigram_adjustment"] == pytest.approx(expected_adjustment)
+    assert result["bigram_absence_penalty"] == pytest.approx(1.15)
+    assert result["match_weight"] == pytest.approx(10.0 + expected_adjustment)
+
+
+def test_postcode_or_substantive_identity_evidence_is_aggregated_by_uprn():
+    con = duckdb.connect()
+    result = _apply(
+        con,
+        [
+            _prediction_row(candidate_id="neither"),
+            _prediction_row(candidate_id="postcode_variant"),
+            _prediction_row(candidate_id="identity_variant"),
+            _prediction_row(candidate_id="structural_only"),
+        ],
+        [
+            ("neither", "FLAT 2 10 BETA STREET", "BB1 1BB", None),
+            ("postcode_variant", "FLAT 2 10 BETA STREET", "BB1 1BB", None),
+            ("postcode_variant", "FLAT 2 10 BETA STREET", "AA1 1AA", None),
+            ("identity_variant", "FLAT 2 10 BETA STREET", "BB1 1BB", None),
+            ("identity_variant", "ALPHA HOUSE", "BB1 1BC", None),
+            ("structural_only", "FLAT 2 10 UNIT FLOOR", "BB1 1BD", None),
+        ],
+    ).set_index("unique_id_l")
+
+    assert result.loc["neither", "no_postcode_or_identity_adjustment"] == -8.0
+    assert result.loc["postcode_variant", "no_postcode_or_identity_adjustment"] == 0.0
+    assert result.loc["identity_variant", "no_postcode_or_identity_adjustment"] == 0.0
+    assert result.loc["structural_only", "no_postcode_or_identity_adjustment"] == -8.0
+
+
+def test_flat_letter_contradiction_guards_and_variant_support():
+    con = duckdb.connect()
+    result = _apply(
+        con,
+        [
+            _prediction_row(
+                source_id="explicit",
+                candidate_id="only_b",
+                address="FLAT A 27 CHARDMORE ROAD",
+                flat_letter="A",
+                flat_number=None,
+            ),
+            _prediction_row(
+                source_id="explicit",
+                candidate_id="supports_a",
+                address="FLAT A 27 CHARDMORE ROAD",
+                flat_letter="A",
+                flat_number=None,
+            ),
+            _prediction_row(
+                source_id="explicit",
+                candidate_id="a_variant",
+                address="FLAT A 27 CHARDMORE ROAD",
+                flat_letter="A",
+                flat_number=None,
+            ),
+            _prediction_row(
+                source_id="no_rival",
+                candidate_id="only_b_no_rival",
+                address="FLAT A 27 CHARDMORE ROAD",
+                flat_letter="A",
+                flat_number=None,
+            ),
+            _prediction_row(
+                source_id="empty_letter",
+                candidate_id="only_b_empty",
+                flat_letter=None,
+                flat_number=None,
+            ),
+            _prediction_row(
+                source_id="numbered",
+                candidate_id="only_b_numbered",
+                address="FLAT 2 AT 1A HIGH ROAD",
+                flat_letter="A",
+                flat_number="2",
+            ),
+            _prediction_row(
+                source_id="numbered",
+                candidate_id="supports_a_numbered",
+                address="FLAT 2 AT 1A HIGH ROAD",
+                flat_letter="A",
+                flat_number="2",
+            ),
+        ],
+        [
+            ("only_b", "FLAT B 27 CHARDMORE ROAD", "AA1 1AA", "B"),
+            ("supports_a", "FLAT A 27 CHARDMORE ROAD", "AA1 1AA", "A"),
+            ("a_variant", "FLAT B 27 CHARDMORE ROAD", "AA1 1AA", "B"),
+            ("a_variant", "FLAT A 27 CHARDMORE ROAD", "AA1 1AA", "A"),
+            ("only_b_no_rival", "FLAT B 27 CHARDMORE ROAD", "AA1 1AA", "B"),
+            ("only_b_empty", "FLAT B 10 ALPHA ROAD", "AA1 1AA", "B"),
+            ("only_b_numbered", "FLAT B 1 HIGH ROAD", "AA1 1AA", "B"),
+            ("supports_a_numbered", "FLAT A 1 HIGH ROAD", "AA1 1AA", "A"),
+        ],
+    ).set_index(["unique_id_r", "unique_id_l"])
+
+    adjustment = "flat_letter_conflict_adjustment"
+    assert result.loc[("explicit", "only_b"), adjustment] == -3.0
+    assert result.loc[("explicit", "supports_a"), adjustment] == 0.0
+    assert result.loc[("explicit", "a_variant"), adjustment] == 0.0
+    assert result.loc[("no_rival", "only_b_no_rival"), adjustment] == 0.0
+    assert result.loc[("empty_letter", "only_b_empty"), adjustment] == 0.0
+    assert result.loc[("numbered", "only_b_numbered"), adjustment] == 0.0
+
+
+@pytest.mark.parametrize(
+    (
+        "gamma_postcode",
+        "gamma_address_without_numbers",
+        "canonical_postcode",
+        "expected_adjustment",
+    ),
+    [
+        (2, 0, "BB1 1BB", -3.0),
+        (3, 0, "BB1 1BB", 0.0),
+        (2, 1, "BB1 1BB", 0.0),
+        (2, 0, "AA1 1AA", 0.0),
+    ],
+)
+def test_weak_postcode_and_address_level_guards(
+    gamma_postcode,
+    gamma_address_without_numbers,
+    canonical_postcode,
+    expected_adjustment,
+):
+    con = duckdb.connect()
+    result = _apply(
+        con,
+        [
+            _prediction_row(
+                gamma_postcode=gamma_postcode,
+                gamma_address_without_numbers=gamma_address_without_numbers,
+            )
+        ],
+        [("candidate", "FLAT 2 10 ALPHA ROAD", canonical_postcode, None)],
+    ).iloc[0]
+
+    assert result["weak_address_and_postcode_adjustment"] == expected_adjustment
+
+
+def test_four_adjustments_are_additive_and_change_only_ranking():
+    con = duckdb.connect()
+    result = _apply(
+        con,
+        [
+            _prediction_row(
+                candidate_id="wrong",
+                address="FLAT A 27 CHARDMORE ROAD",
+                postcode="N16 6JA",
+                flat_letter="A",
+                flat_number=None,
+                structural_bigram_reward=2.2,
+                gamma_postcode=2,
+                gamma_address_without_numbers=0,
+                match_weight=20.0,
+            ),
+            _prediction_row(
+                candidate_id="right",
+                address="FLAT A 27 CHARDMORE ROAD",
+                postcode="N16 6JA",
+                flat_letter="A",
+                flat_number=None,
+                match_weight=10.0,
+            ),
+        ],
+        [
+            ("wrong", "FLAT B 27 FORBURG ROAD", "N16 6HP", "B"),
+            ("right", "FLAT B 27 CHARDMORE ROAD", "N16 6HP", "B"),
+            ("right", "FLAT A 27 CHARDMORE ROAD", "N16 6JA", "A"),
+        ],
+    ).set_index("unique_id_l")
+
+    wrong = result.loc["wrong"]
+    assert wrong["structural_bigram_adjustment"] == pytest.approx(-2.2)
+    assert wrong["no_postcode_or_identity_adjustment"] == -8.0
+    assert wrong["flat_letter_conflict_adjustment"] == -3.0
+    assert wrong["weak_address_and_postcode_adjustment"] == -3.0
+    assert wrong["match_weight"] == pytest.approx(3.8)
+
+    right = result.loc["right"]
+    assert right["match_weight"] == pytest.approx(10.0)
+    assert len(result) == 2
+    assert result["match_weight"].idxmax() == "right"
+    assert (result["match_weight"] >= 0.0).any()

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -109,6 +109,7 @@ class SplinkStage(MatchingStage):
         )
         from uk_address_matcher.post_linkage.distinguishing_features import (
             relation_markers,
+            structural_evidence,
         )
         from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
             improve_predictions_using_distinguishing_tokens,
@@ -164,11 +165,25 @@ class SplinkStage(MatchingStage):
             use_bigrams=self.improve_use_bigrams,
             additional_columns_to_retain=self.additional_columns_to_retain,
         )
+        df_improved = structural_evidence.improve_predictions_using_structural_evidence(
+            df_predict=df_improved,
+            df_canonical=df_canonical,
+            con=con,
+        )
         df_improved = relation_markers.improve_predictions_using_relation_markers(
             df_predict=df_improved,
             con=con,
         )
-        self.improved_predictions_table = getattr(df_improved, "alias", None)
+        improved_table_name = f"__ukam__splink__improved_predictions__{_uid()}"
+        con.execute(
+            "CREATE OR REPLACE TEMP VIEW "
+            + improved_table_name
+            + " AS SELECT * FROM ("
+            + df_improved.sql_query()
+            + ")"
+        )
+        df_improved = con.table(improved_table_name)
+        self.improved_predictions_table = improved_table_name
 
         # Step 4: Compute distinguishability and select best match per record
         # This returns an unmaterialised relation

--- a/uk_address_matcher/post_linkage/distinguishing_features/structural_evidence.py
+++ b/uk_address_matcher/post_linkage/distinguishing_features/structural_evidence.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from duckdb import DuckDBPyConnection, DuckDBPyRelation
+
+from uk_address_matcher.post_linkage.token_classification import (
+    substantive_identity_token_sql,
+)
+
+NO_POSTCODE_OR_IDENTITY_PENALTY = 8.0
+FLAT_LETTER_CONFLICT_PENALTY = 3.0
+WEAK_ADDRESS_AND_POSTCODE_PENALTY = 3.0
+
+
+def improve_predictions_using_structural_evidence(
+    *,
+    df_predict: DuckDBPyRelation,
+    df_canonical: DuckDBPyRelation,
+    con: DuckDBPyConnection,
+) -> DuckDBPyRelation:
+    """Apply additive structural-evidence adjustments before candidate ranking."""
+    source_identity_sql = substantive_identity_token_sql("token")
+    candidate_identity_sql = substantive_identity_token_sql("token")
+
+    return con.sql(f"""
+        WITH candidate_uprns AS (
+            SELECT DISTINCT
+                unique_id_r,
+                CAST(unique_id_l AS VARCHAR) AS unique_id_l
+            FROM df_predict
+        ),
+        sources AS (
+            SELECT DISTINCT
+                unique_id_r,
+                coalesce(
+                    regexp_replace(upper(postcode_r), '\\s+', '', 'g'),
+                    ''
+                ) AS source_postcode,
+                list_distinct(list_filter(
+                    regexp_split_to_array(upper(clean_full_address_r), '\\s+'),
+                    token -> {source_identity_sql}
+                )) AS source_identity_tokens,
+                upper(coalesce(flat_letter_r, '')) AS source_flat_letter,
+                flat_number_r AS source_flat_number,
+                coalesce(has_flat_indicator_r, FALSE) AS source_has_flat_indicator
+            FROM df_predict
+        ),
+        canonical_variants AS (
+            SELECT
+                CAST(unique_id AS VARCHAR) AS unique_id_l,
+                coalesce(
+                    regexp_replace(upper(postcode), '\\s+', '', 'g'),
+                    ''
+                ) AS candidate_postcode,
+                list_distinct(list_filter(
+                    regexp_split_to_array(upper(clean_full_address), '\\s+'),
+                    token -> {candidate_identity_sql}
+                )) AS candidate_identity_tokens,
+                upper(coalesce(flat_letter, '')) AS candidate_flat_letter
+            FROM df_canonical
+        ),
+        variant_evidence AS (
+            SELECT
+                candidates.unique_id_r,
+                candidates.unique_id_l,
+                bool_or(
+                    source.source_postcode != ''
+                    AND source.source_postcode = canonical.candidate_postcode
+                ) AS candidate_uprn_has_exact_full_postcode,
+                bool_or(list_has_any(
+                    source.source_identity_tokens,
+                    canonical.candidate_identity_tokens
+                )) AS candidate_uprn_has_substantive_identity_overlap,
+                bool_or(
+                    source.source_flat_letter != ''
+                    AND source.source_flat_letter = canonical.candidate_flat_letter
+                ) AS candidate_uprn_has_exact_flat_letter,
+                bool_or(
+                    canonical.candidate_flat_letter != ''
+                    AND source.source_flat_letter != canonical.candidate_flat_letter
+                ) AS candidate_uprn_has_conflicting_flat_letter,
+                any_value(source.source_flat_letter) AS source_flat_letter,
+                any_value(source.source_flat_number) AS source_flat_number,
+                any_value(source.source_has_flat_indicator)
+                    AS source_has_flat_indicator
+            FROM candidate_uprns AS candidates
+            JOIN sources AS source USING (unique_id_r)
+            JOIN canonical_variants AS canonical USING (unique_id_l)
+            GROUP BY candidates.unique_id_r, candidates.unique_id_l
+        ),
+        candidate_evidence AS (
+            SELECT
+                evidence.*,
+                bool_or(candidate_uprn_has_exact_flat_letter) OVER (
+                    PARTITION BY unique_id_r
+                ) AS competing_uprn_has_exact_flat_letter
+            FROM variant_evidence AS evidence
+        ),
+        adjustments AS (
+            SELECT
+                predictions.*,
+                evidence.candidate_uprn_has_exact_full_postcode,
+                evidence.candidate_uprn_has_substantive_identity_overlap,
+                evidence.candidate_uprn_has_exact_flat_letter,
+                evidence.candidate_uprn_has_conflicting_flat_letter,
+                evidence.competing_uprn_has_exact_flat_letter,
+                CASE
+                    WHEN NOT evidence.candidate_uprn_has_exact_full_postcode
+                    THEN -predictions.structural_bigram_reward
+                    ELSE 0.0
+                END AS structural_bigram_adjustment,
+                CASE
+                    WHEN NOT evidence.candidate_uprn_has_exact_full_postcode
+                        AND NOT evidence.candidate_uprn_has_substantive_identity_overlap
+                    THEN -{NO_POSTCODE_OR_IDENTITY_PENALTY}
+                    ELSE 0.0
+                END AS no_postcode_or_identity_adjustment,
+                CASE
+                    WHEN evidence.source_has_flat_indicator
+                        AND evidence.source_flat_letter != ''
+                        AND evidence.source_flat_number IS NULL
+                        AND NOT evidence.candidate_uprn_has_exact_flat_letter
+                        AND evidence.candidate_uprn_has_conflicting_flat_letter
+                        AND evidence.competing_uprn_has_exact_flat_letter
+                    THEN -{FLAT_LETTER_CONFLICT_PENALTY}
+                    ELSE 0.0
+                END AS flat_letter_conflict_adjustment,
+                CASE
+                    WHEN NOT evidence.candidate_uprn_has_exact_full_postcode
+                        AND predictions.gamma_postcode <= 2
+                        AND predictions.gamma_address_without_numbers = 0
+                    THEN -{WEAK_ADDRESS_AND_POSTCODE_PENALTY}
+                    ELSE 0.0
+                END AS weak_address_and_postcode_adjustment
+            FROM df_predict AS predictions
+            JOIN candidate_evidence AS evidence
+                ON evidence.unique_id_r = predictions.unique_id_r
+                AND evidence.unique_id_l = CAST(predictions.unique_id_l AS VARCHAR)
+        )
+        SELECT
+            adjustments.* EXCLUDE (match_weight),
+            match_weight
+                + structural_bigram_adjustment
+                + no_postcode_or_identity_adjustment
+                + flat_letter_conflict_adjustment
+                + weak_address_and_postcode_adjustment AS match_weight
+        FROM adjustments
+    """)

--- a/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
+++ b/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from duckdb import DuckDBPyConnection, DuckDBPyRelation
 
-_POSITIONAL_TOKENS_SQL = "('LEFT', 'RIGHT', 'CENTRE', 'FRONT')"
+from uk_address_matcher.post_linkage.token_classification import (
+    POSITIONAL_TOKENS_SQL,
+    structural_token_sql,
+)
 
 
 def improve_predictions_using_distinguishing_tokens(
@@ -30,6 +33,26 @@ def improve_predictions_using_distinguishing_tokens(
         )
     if "ukam_label_r" in df_predict.columns:
         retained_columns += "ukam_label_r, "
+
+    structural_defaults = {
+        "gamma_address_without_numbers": "99::INTEGER",
+        "gamma_postcode": "99::INTEGER",
+        "has_flat_indicator_r": "FALSE",
+        "flat_letter_r": "NULL::VARCHAR",
+        "flat_number_r": "NULL::VARCHAR",
+    }
+    structural_columns_sql = ",\n                ".join(
+        (
+            f"candidate.{column}"
+            if column in df_predict.columns
+            else f"{default} AS {column}"
+        )
+        for column, default in structural_defaults.items()
+    )
+    structural_bigram_sql = (
+        f"{structural_token_sql('entry.key[1]')} "
+        f"AND {structural_token_sql('entry.key[2]')}"
+    )
 
     eligibility_filter = ""
     if histogram_eligibility_column is not None:
@@ -198,6 +221,7 @@ def improve_predictions_using_distinguishing_tokens(
                 candidate.ukam_address_id_r,
                 candidate.postcode_l,
                 candidate.postcode_r,
+                {structural_columns_sql},
                 concat_ws(' ', candidate.__token_address_l, candidate.postcode_l)
                     .trim()
                     .upper()
@@ -214,13 +238,13 @@ def improve_predictions_using_distinguishing_tokens(
                             .trim()
                             .upper()
                             .regexp_split_to_array('\\s+'),
-                            token -> token IN {_POSITIONAL_TOKENS_SQL}
+                            token -> token IN {POSITIONAL_TOKENS_SQL}
                     )
                 ) AS positional_tokens_l,
                 list_distinct(
                     list_filter(
                         statistics.tokens_r,
-                            token -> token IN {_POSITIONAL_TOKENS_SQL}
+                            token -> token IN {POSITIONAL_TOKENS_SQL}
                     )
                 ) AS positional_tokens_r
             FROM token_addresses AS candidate
@@ -368,6 +392,14 @@ def improve_predictions_using_distinguishing_tokens(
                     map_values(overlapping_bigrams_this_l_and_r_filtered),
                     value -> 1.0 / (value * value)
                 )), 0.0) * {BIGRAM_REWARD_MULTIPLIER} AS bigram_reward,
+                COALESCE(list_sum(list_transform(
+                    list_filter(
+                        map_entries(overlapping_bigrams_this_l_and_r_filtered),
+                        entry -> {structural_bigram_sql}
+                    ),
+                    entry -> 1.0 / (entry.value * entry.value)
+                )), 0.0) * {BIGRAM_REWARD_MULTIPLIER}
+                    AS structural_bigram_reward,
                 COALESCE(len(map_entries(
                     bigrams_elsewhere_in_block_but_not_this_filtered
                 )), 0)::DOUBLE
@@ -383,6 +415,7 @@ def improve_predictions_using_distinguishing_tokens(
             token_reward,
             token_absence_penalty,
             bigram_reward,
+            structural_bigram_reward,
             bigram_absence_penalty,
             missing_token_penalty,
             positional_conflict_penalty,
@@ -411,6 +444,11 @@ def improve_predictions_using_distinguishing_tokens(
             postcode_l,
             clean_full_address_r,
             postcode_r,
+            gamma_address_without_numbers,
+            gamma_postcode,
+            has_flat_indicator_r,
+            flat_letter_r,
+            flat_number_r,
             {retained_columns}
         FROM scored_candidates
     """).create(matches_table)

--- a/uk_address_matcher/post_linkage/token_classification.py
+++ b/uk_address_matcher/post_linkage/token_classification.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+
+def _sql_varchar_tuple(tokens: tuple[str, ...]) -> str:
+    return "(" + ", ".join(f"'{token}'" for token in tokens) + ")"
+
+
+POSITIONAL_TOKENS = ("LEFT", "RIGHT", "CENTRE", "FRONT")
+
+# These tokens describe unit, floor, or layout structure already represented by
+# dedicated address comparisons. Rewarding bigrams made only from this class
+# would count the same correlated evidence twice.
+STRUCTURAL_TOKENS = (
+    "FLAT",
+    "UNIT",
+    "APARTMENT",
+    "ROOM",
+    "SUITE",
+    "FLOOR",
+    "GROUND",
+    "FIRST",
+    "SECOND",
+    "THIRD",
+    "FOURTH",
+    "BASEMENT",
+    "LOWER",
+    "UPPER",
+    "LEFT",
+    "RIGHT",
+    "CENTRE",
+    "FRONT",
+    "REAR",
+)
+
+# Generic address grammar is not identifying evidence by itself. This broader
+# class is used only when asking whether two addresses share a substantive name.
+NON_IDENTITY_TOKENS = (
+    "A",
+    "AN",
+    "AND",
+    "AT",
+    "OF",
+    "ON",
+    "THE",
+    *STRUCTURAL_TOKENS,
+    "ROAD",
+    "STREET",
+    "LANE",
+    "AVENUE",
+    "DRIVE",
+    "CLOSE",
+    "WAY",
+    "PLACE",
+    "TERRACE",
+    "GARDENS",
+    "COURT",
+    "HOUSE",
+    "BUILDING",
+    "BLOCK",
+)
+
+POSITIONAL_TOKENS_SQL = _sql_varchar_tuple(POSITIONAL_TOKENS)
+STRUCTURAL_TOKENS_SQL = _sql_varchar_tuple(STRUCTURAL_TOKENS)
+NON_IDENTITY_TOKENS_SQL = _sql_varchar_tuple(NON_IDENTITY_TOKENS)
+
+
+def structural_token_sql(expression: str) -> str:
+    """Return SQL identifying numeric, unit, floor, and layout tokens."""
+    return (
+        f"({expression} IN {STRUCTURAL_TOKENS_SQL} "
+        f"OR regexp_full_match({expression}, '[0-9]+'))"
+    )
+
+
+def substantive_identity_token_sql(expression: str) -> str:
+    """Return SQL identifying tokens that can carry address identity."""
+    return (
+        f"({expression} != '' "
+        f"AND {expression} NOT IN {NON_IDENTITY_TOKENS_SQL} "
+        "AND NOT regexp_full_match("
+        f"{expression}, '[0-9]+|[A-Z]?[0-9]+[A-Z]?'))"
+    )


### PR DESCRIPTION
This is an experiment,I think the current code is too complex.  But it does improve Hackney fairly significantly with little change to the others.  So if we can find a way of doing a simpler implementation with similar gains probably worthwhile


<img width="1210" height="725" alt="image" src="https://github.com/user-attachments/assets/8e426f4a-6492-41c8-9d95-9c1c13eedeb6" />


<html><head></head><body><h2>Summary</h2><p>This PR adds four small scoring adjustments to address cases where UK Address Matcher selects a visibly weak candidate because correlated numeric, flat and layout evidence outweighs the overall address context.</p><p>The changes are applied before final ranking and aggregate evidence across all canonical variants of each candidate UPRN.</p><h2>Changes</h2><ul><li><p>Remove positive bigram rewards composed entirely of numeric, unit or layout tokens when the candidate has no exact-postcode variant.</p></li><li><p>Apply an <strong>−8 bit penalty</strong> when a candidate has neither an exact-postcode variant nor substantive address-token overlap.</p></li><li><p>Apply a <strong>−3 bit penalty</strong> for an explicit flat-letter contradiction when another candidate supports the source flat letter.</p></li><li><p>Apply a <strong>−3 bit penalty</strong> when both postcode evidence and <code inline="">address_without_numbers</code> agreement are at their weakest comparison levels.</p></li></ul><p>These changes reduce double counting and prevent isolated structural similarities—such as the same number or floor description—from overwhelming contradictory street, property and postcode evidence.</p><h2>Validation</h2><p>We evaluated the rules against:</p><ul><li><p>4,740 probabilistic matches independently reviewed multiple times using Hackney, Rhondda Cynon Taf, Mid Sussex and Aberdeenshire labelled data.</p></li><li><p>196,942 full-population probabilistic matches across the same four areas.</p></li><li><p>All canonical address variants for each candidate UPRN.</p></li></ul>


Area | Errors corrected | Reviewed regressions
-- | -- | --
Hackney | 162 | 0
Rhondda Cynon Taf | 14 | 0
Mid Sussex | 3 | 0
Aberdeenshire | 5 | 0
Total | 184 | 0

<p>Within the reviewed cohort, correct predictions increased from <strong>576 to 760 out of 4,740</strong>.</p><p>Across the full datasets:</p><ul><li><p>241 of 196,942 probabilistic winners changed.</p></li><li><p>No match/abstention decisions changed.</p></li><li><p>No reviewed correct prediction became incorrect.</p></li><li><p>Two existing winner/label agreements changed; manual review found both supplied labels to be incorrect.</p></li></ul><p>The reviewed cohort is deliberately enriched for disagreements, so these percentages are not population accuracy estimates. The relevant result is the paired comparison: <strong>184 known errors corrected with zero observed reviewed regressions</strong>.</p><h2>Testing</h2><ul><li><p>Added focused tests for each adjustment.</p></li><li><p>Tested aggregation across multiple canonical variants of one UPRN.</p></li><li><p>Added regression coverage for ambiguous flat parsing such as <code inline="">FLAT 2 ... 1A</code>.</p></li><li><p>Confirmed existing bigram, flat-matching, post-linkage and end-to-end matcher tests continue to pass.</p></li></ul></body></html>An 

Ref: https://chatgpt.com/c/6a738c20-0ba8-8351-9627-25f9eb60d63e