### PR TITLE
feat(cleaning): enhance range cleaning by merging split flat numbers …

### DIFF
--- a/uk_address_matcher/cleaning/steps/normalisation.py
+++ b/uk_address_matcher/cleaning/steps/normalisation.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from uk_address_matcher.cleaning.steps.regexes import (
     construct_nested_call,
+    merge_split_flat_number,
     move_flat_to_front,
     remove_apostrophes,
     remove_commas_periods,
@@ -204,6 +205,7 @@ def _clean_address_string_first_pass() -> str:
             separate_letter_num,
             standarise_num_letter,
             move_flat_to_front,
+            merge_split_flat_number,
             # remove_repeated_tokens,   # left commented as in original
             trim,
         ],

--- a/uk_address_matcher/cleaning/steps/regexes.py
+++ b/uk_address_matcher/cleaning/steps/regexes.py
@@ -17,6 +17,12 @@ def remove_multiple_spaces(input: str):
     return f"regexp_replace({input}, '\\s+', ' ', 'g')"
 
 
+def merge_split_flat_number(input: str):
+    """Merge zero-padded split flat numbers such as ``FLAT 3 02 AT``."""
+    pattern = r"\bFLAT\s+(\d{1,2})\s+(0\d{1,3})\s+(AT\b)"
+    return f"regexp_replace({input}, '{pattern}', 'FLAT \\1\\2 \\3', 'g')"
+
+
 def standarise_num_dash_num(input: str):
     """
     Standardizes numeric ranges with dashes by removing spaces around the dash.

--- a/uk_address_matcher/cleaning/steps/token_parsing.py
+++ b/uk_address_matcher/cleaning/steps/token_parsing.py
@@ -613,7 +613,7 @@ def _parse_out_numbers():
     regex_pattern = (
         r"\b"  # Word boundary
         # Prioritize matching number ranges first
-        r"(\d{1,5}-\d{1,5}|[A-Za-z]?\d{1,5}[A-Za-z]?)"
+        r"(\d{1,5}[A-Za-z]?-\d{1,5}[A-Za-z]?|[A-Za-z]?\d{1,5}[A-Za-z]?)"
         r"\b"  # Word boundary
     )
     sql = f"""


### PR DESCRIPTION
Minor tweaks to improve our cleaning and to merge zero-padded numerics when we identify them.

For example:
`3 02` -> `302`

This helps with issues where certain addresses are keyed to include a full stop representing the floor + flat number concatenated.

For example, we have various entities in our Hackney data in this shape:
```
FLAT 3.02 11-15 HOUSE
FLAT G.02 11-15 HOUSE
```
