### PR TITLE
feat: updates and QoL changes to labeller

### DIFF
--- a/benchmarking/hackney_labelling_examples.py
+++ b/benchmarking/hackney_labelling_examples.py
@@ -9,7 +9,7 @@ from benchmarking.config.datasets import get_dataset_definition, load_dataset
 from benchmarking.config.sources import resolve_data_source
 from benchmarking.settings import CANONICAL_PATH
 from uk_address_matcher import AddressMatcher, ExactMatchStage, SplinkStage
-from uk_address_matcher.labelling import launch_labelling_app
+from uk_address_matcher.labelling import _launch_labelling_app_beta
 
 HACKNEY_GSS_CODE = "E09000012"
 CLASSIFICATION_CODE_PREFIX = "R"
@@ -41,7 +41,7 @@ matcher = AddressMatcher(
 )
 
 result = matcher.match()
-bundle_path = result.export_labelling_bundle(overwrite=True)
+bundle_path = result._export_labelling_bundle_beta(overwrite=True)
 accuracy_table = result.accuracy_analysis(
     output_type="table",
     add_metrics=["f1"],
@@ -57,7 +57,7 @@ con.sql(f"""
     read_parquet('{bundle_path}/review_data.parquet')
 """).show(max_width=10000, max_rows=1)
 
-launch_labelling_app(
+_launch_labelling_app_beta(
     labelling_bundle_path="ukam_labelling_bundle",
     input_dataset_path=HACKNEY_INPUT_PATH,
     input_dataset_label_column="UPRN",

--- a/tests/labelling/test_bundle.py
+++ b/tests/labelling/test_bundle.py
@@ -8,7 +8,7 @@ import pyarrow
 import pytest
 
 from uk_address_matcher import AddressMatcher, ExactMatchStage, SplinkStage
-from uk_address_matcher.labelling import export_labelling_bundle
+from uk_address_matcher.labelling import _export_labelling_bundle_beta
 
 
 def _relation(con: duckdb.DuckDBPyConnection, records: list[dict[str, str]]):
@@ -55,7 +55,7 @@ def test_exports_default_bundle_with_deterministic_candidates(
 
     monkeypatch.chdir(tmp_path)
     caplog.set_level(logging.INFO, logger="uk_address_matcher")
-    bundle_path = result.export_labelling_bundle()
+    bundle_path = result._export_labelling_bundle_beta()
 
     assert bundle_path == (tmp_path / "ukam_labelling_bundle").resolve()
     assert (bundle_path / "review_data.parquet").is_file()
@@ -101,7 +101,7 @@ def test_exports_default_bundle_with_deterministic_candidates(
     assert rows[1][5] == 0
     assert rows[1][6] == []
 
-    custom_bundle_path = export_labelling_bundle(
+    custom_bundle_path = _export_labelling_bundle_beta(
         result,
         tmp_path / "custom_bundle",
     )
@@ -151,7 +151,7 @@ def test_exports_reranked_splink_candidates(tmp_path):
         ],
     ).match()
 
-    bundle_path = result.export_labelling_bundle(tmp_path / "splink_bundle")
+    bundle_path = result._export_labelling_bundle_beta(tmp_path / "splink_bundle")
     with duckdb.connect() as fresh_con:
         candidate_count, candidates = fresh_con.execute(
             """
@@ -206,7 +206,7 @@ def test_preserves_labels_with_fixed_default_schema(tmp_path):
         stages=[ExactMatchStage()],
     ).match()
 
-    bundle_path = result.export_labelling_bundle(tmp_path / "review_bundle")
+    bundle_path = result._export_labelling_bundle_beta(tmp_path / "review_bundle")
     with duckdb.connect() as fresh_con:
         row = fresh_con.execute(
             """
@@ -231,6 +231,6 @@ def test_preserves_labels_with_fixed_default_schema(tmp_path):
     assert not any(column.startswith("top_candidate_") for column in columns)
 
     with pytest.raises(FileExistsError, match="already exists"):
-        result.export_labelling_bundle(bundle_path)
-    result.export_labelling_bundle(bundle_path, overwrite=True)
+        result._export_labelling_bundle_beta(bundle_path)
+    result._export_labelling_bundle_beta(bundle_path, overwrite=True)
     con.close()

--- a/tests/labelling/test_canonical_search.py
+++ b/tests/labelling/test_canonical_search.py
@@ -16,7 +16,9 @@ from uk_address_matcher.labelling.canonical import (
 )
 
 
-def write_canonical_data(path: Path, *, include_cleaned: bool = True) -> None:
+def write_canonical_data(
+    path: Path, *, include_cleaned: bool = True, include_long_postcode: bool = False
+) -> None:
     records: list[tuple[str | None, str, str, str]] = []
     for index in range(200):
         canonical_id = f"CANON_{index:04d}"
@@ -43,6 +45,15 @@ def write_canonical_data(path: Path, *, include_cleaned: bool = True) -> None:
             (None, "NULL ID STREET", "NULL ID STREET", "N16 5FD"),
         ]
     )
+    if include_long_postcode:
+        records.append(
+            (
+                "LONG_POSTCODE",
+                "LONG POSTCODE TEST ROAD",
+                "LONG POSTCODE TEST ROAD",
+                "ME5 8RY",
+            )
+        )
     random.Random(42).shuffle(records)
     connection = duckdb.connect()
     try:
@@ -72,6 +83,27 @@ def write_canonical_data(path: Path, *, include_cleaned: bool = True) -> None:
         connection.close()
 
 
+def write_classified_canonical_data(path: Path) -> None:
+    source_path = path.with_name("base-canonical.parquet")
+    write_canonical_data(source_path)
+    source_sql = str(source_path).replace("'", "''")
+    connection = duckdb.connect()
+    try:
+        connection.execute(
+            f"""COPY (
+                SELECT *,
+                    CASE WHEN unique_id IS NULL THEN 'RD99' ELSE 'RD06' END
+                        AS classificationcode,
+                    CASE WHEN unique_id IS NULL THEN NULL ELSE '2' END
+                        AS floorlevel
+                FROM read_parquet('{source_sql}')
+            ) TO ? (FORMAT PARQUET)""",
+            [str(path)],
+        )
+    finally:
+        connection.close()
+
+
 def test_loads_direct_file_and_prepared_folder_layouts(tmp_path: Path) -> None:
     direct_file = tmp_path / "canonical.parquet"
     write_canonical_data(direct_file)
@@ -80,6 +112,12 @@ def test_loads_direct_file_and_prepared_folder_layouts(tmp_path: Path) -> None:
     assert direct_source is not None
     assert direct_source.display_address_column == "original_address_concat"
     assert direct_source.cleaned_address_column == "clean_full_address"
+    assert direct_source.columns_to_retain() == (
+        "unique_id",
+        "postcode",
+        "clean_full_address",
+        "original_address_concat",
+    )
 
     prepared_folder = tmp_path / "prepared"
     prepared_folder.mkdir()
@@ -126,6 +164,12 @@ def test_search_returns_stable_pages_and_literal_substrings(
     page_four = search_canonical_data(
         source, postcode="E5 8RY", address_query="STREET", page=4
     )
+    partial_postcode = search_canonical_data(
+        source, postcode="E5", address_query=None, page=1
+    )
+    tokenised_address = search_canonical_data(
+        source, postcode=None, address_query="LONDON 199", page=1
+    )
 
     assert len(page_one.rows) == CANONICAL_PAGE_SIZE
     assert len(page_two.rows) == CANONICAL_PAGE_SIZE
@@ -146,6 +190,9 @@ def test_search_returns_stable_pages_and_literal_substrings(
     assert page_two.has_next is True
     assert page_four.has_previous is True
     assert page_four.has_next is False
+    assert partial_postcode.has_next is True
+    assert {row["canonical_postcode"] for row in partial_postcode.rows} == {"E5 8RY"}
+    assert len(tokenised_address.rows) == 2
     duplicate_id_rows = search_canonical_data(
         source, postcode="E5 8RY", address_query="199 TEST STREET", page=1
     ).rows
@@ -207,3 +254,45 @@ def test_search_validation_lookup_and_parquet_plan(tmp_path: Path) -> None:
     finally:
         connection.close()
     assert "PARQUET_SCAN" in str(plan).upper() or "READ_PARQUET" in str(plan).upper()
+
+
+def test_valid_spaced_postcode_uses_exact_matching(tmp_path: Path) -> None:
+    path = tmp_path / "canonical.parquet"
+    write_canonical_data(path, include_long_postcode=True)
+    source = load_canonical_source(path)
+    assert source is not None
+
+    exact_postcode = search_canonical_data(source, postcode="E5 8RY", page=1)
+    unspaced_postcode = search_canonical_data(
+        source, postcode="E58RY", address_query="LONG POSTCODE", page=1
+    )
+    partial_postcode = search_canonical_data(
+        source, postcode="E5 8R", address_query="LONG POSTCODE", page=1
+    )
+
+    assert {row["canonical_postcode"] for row in exact_postcode.rows} == {"E5 8RY"}
+    assert [row["canonical_postcode"] for row in unspaced_postcode.rows] == ["ME5 8RY"]
+    assert [row["canonical_postcode"] for row in partial_postcode.rows] == ["ME5 8RY"]
+
+
+def test_search_returns_additional_canonical_columns(tmp_path: Path) -> None:
+    path = tmp_path / "classified-canonical.parquet"
+    write_classified_canonical_data(path)
+
+    source = load_canonical_source(path)
+    assert source is not None
+    assert source.additional_canonical_columns == ("classificationcode", "floorlevel")
+
+    page = search_canonical_data(source, postcode="E5", page=1)
+
+    assert page.rows
+    assert page.additional_canonical_columns == ("classificationcode", "floorlevel")
+    assert {row["classificationcode"] for row in page.rows} == {"RD06"}
+    assert {row["floorlevel"] for row in page.rows} == {"2"}
+    assert find_canonical_record(source, "CANON_0000")["classificationcode"] == "RD06"
+
+    floor_only_source = load_canonical_source(
+        path, additional_canonical_columns=("floorlevel", "missing")
+    )
+    assert floor_only_source is not None
+    assert floor_only_source.additional_canonical_columns == ("floorlevel",)

--- a/tests/labelling/test_server.py
+++ b/tests/labelling/test_server.py
@@ -13,6 +13,7 @@ from urllib.request import Request, urlopen
 import duckdb
 import pytest
 
+import uk_address_matcher.labelling.server as server_module
 from tests.labelling.test_state import create_test_bundle
 from uk_address_matcher.labelling.canonical import load_canonical_source
 from uk_address_matcher.labelling.server import (
@@ -21,11 +22,12 @@ from uk_address_matcher.labelling.server import (
     _bootstrap_payload,
     _ensure_state_database,
     _handler_factory,
+    _launch_labelling_app_beta,
     _load_bundle,
     _load_input_dataset,
     _records_payload,
+    _ReviewPrefetchCache,
     _save_label,
-    launch_labelling_app,
 )
 
 
@@ -170,7 +172,38 @@ def test_server_requires_token_and_serves_application_shell(
     assert isinstance(payload, str)
     assert 'id="score-range-min"' in payload
     assert 'id="review-current-label-value"' in payload
+    assert 'id="review-canonical-additional-fields"' in payload
+    assert 'id="canonical-results-header-row"' in payload
+    assert 'id="review-cards"' in payload
+    assert 'id="review-sticky-context"' in payload
+    assert 'id="review-sticky-messy-address"' in payload
+    assert 'id="review-sticky-canonical-address"' in payload
+    assert payload.index('id="review-sticky-context"') < payload.index(
+        'id="review-cards"'
+    )
+    assert 'id="review-next"' in payload
+    assert 'id="review-complete"' in payload
     assert 'id="review-content"' in payload
+    assert 'id="review-search-canonical"' not in payload
+
+    status, payload = request(base_url, "/app.css")
+    assert status == 200
+    assert ".review-sticky-context {\n  position: sticky;\n  top: 117px;" in payload
+    assert "align-self: start" in payload
+    assert ".review-sticky-context.is-active" not in payload
+    assert "grid-template-columns: minmax(0, 1fr) minmax(0, 1fr)" in payload
+    assert "#review-canonical-card .review-canonical-additional-field" in payload
+    assert "grid-template-rows: auto auto" in payload
+
+    status, payload = request(base_url, "/app.js")
+    assert status == 200
+    assert "IntersectionObserver" not in payload
+    assert "setReviewStickyActive" not in payload
+    assert "Predicted value -" in payload
+    assert "function resetReviewScroll()" in payload
+    assert 'window.scrollTo({ top: 0, behavior: "auto" })' in payload
+    assert "reviewSearch" not in payload
+    assert "review-sticky-sentinel" not in payload
 
     status, payload = request(base_url, "/api/bootstrap", token=session.token)
     assert status == 200
@@ -220,6 +253,24 @@ def test_records_and_review_share_score_and_stage_filters(
     assert payload == {
         "error": "The requested record does not exist in the current filtered review set"
     }
+
+
+def test_review_prefetch_cache_stores_the_next_review_payload(tmp_path: Path) -> None:
+    bundle = _load_bundle(create_api_test_bundle(tmp_path / "bundle"))
+    _ensure_state_database(bundle)
+    cache = _ReviewPrefetchCache(bundle, None, delay_seconds=0)
+    try:
+        cache.schedule({}, "messy-2")
+        deadline = time.monotonic() + 1
+        payload = None
+        while time.monotonic() < deadline and payload is None:
+            payload = cache.get({}, "messy-2")
+            time.sleep(0.01)
+        assert payload is not None
+        assert payload["record"]["unique_id"] == "messy-2"
+        assert payload["navigation"]["next_unique_id"] is None
+    finally:
+        cache.close()
 
 
 def test_records_support_score_sorting_and_mismatch_filter(tmp_path: Path) -> None:
@@ -459,11 +510,61 @@ def test_load_bundle_rejects_unsupported_data_format(tmp_path: Path) -> None:
 @pytest.mark.parametrize("port", [-1, 65_536])
 def test_launch_rejects_invalid_port(port: int) -> None:
     with pytest.raises(ValueError, match="port"):
-        launch_labelling_app(
+        _launch_labelling_app_beta(
             input_dataset_path="messy_addresses.parquet",
             port=port,
             open_browser=False,
         )
+
+
+def test_launch_passes_additional_canonical_columns_to_source_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeServer:
+        server_address = ("127.0.0.1", 12345)
+
+        def __init__(self, address: object, handler: object) -> None:
+            captured["address"] = address
+            captured["handler"] = handler
+
+        def serve_forever(self, poll_interval: float) -> None:
+            return
+
+        def server_close(self) -> None:
+            return
+
+    def fake_load_canonical_source(
+        _path: object, *, additional_canonical_columns: tuple[str, ...]
+    ) -> None:
+        captured["additional_canonical_columns"] = additional_canonical_columns
+
+    monkeypatch.setattr(server_module, "_load_bundle", lambda _path: object())
+    monkeypatch.setattr(
+        server_module,
+        "_load_input_dataset",
+        lambda _bundle, _path, label_column: object(),
+    )
+    monkeypatch.setattr(server_module, "_ensure_state_database", lambda _bundle: None)
+    monkeypatch.setattr(
+        server_module,
+        "_handler_factory",
+        lambda _bundle, _input_dataset, _session, _canonical_source: object(),
+    )
+    monkeypatch.setattr(server_module, "ThreadingHTTPServer", FakeServer)
+    monkeypatch.setattr(
+        server_module, "load_canonical_source", fake_load_canonical_source
+    )
+
+    _launch_labelling_app_beta(
+        input_dataset_path="messy_addresses.parquet",
+        canonical_address_path="canonical.parquet",
+        additional_canonical_columns=("floorlevel",),
+        open_browser=False,
+    )
+
+    assert captured["additional_canonical_columns"] == ("floorlevel",)
 
 
 def test_session_state_expires_after_configured_interval() -> None:
@@ -551,7 +652,9 @@ def test_handler_serves_static_html_bytes(tmp_path: Path) -> None:
             f"http://127.0.0.1:{server.server_address[1]}/?token={session.token}"
         ) as response:
             assert response.headers.get_content_type() == "text/html"
-            assert b"UKAM" in response.read()
+            body = response.read()
+            assert b"UKAM" in body
+            assert b'id="review-no-candidates"' in body
     finally:
         server.shutdown()
         server.server_close()
@@ -654,9 +757,11 @@ def test_canonical_search_api_and_selection_validation(tmp_path: Path) -> None:
             """COPY (
                 SELECT 'canonical-1' AS unique_id,
                     '1 TEST ROAD' AS original_address_concat,
-                    '1 TEST ROAD' AS clean_full_address, 'E1 1AA' AS postcode
+                    '1 TEST ROAD' AS clean_full_address, 'E1 1AA' AS postcode,
+                    'RD06' AS classificationcode, '1' AS floorlevel
                 UNION ALL
-                SELECT 'canonical-2', '2 TEST ROAD', '2 TEST ROAD', 'E1 1AA'
+                SELECT 'canonical-2', '2 TEST ROAD', '2 TEST ROAD', 'E1 1AA',
+                    'RD06', '2'
             ) TO ? (FORMAT PARQUET)""",
             [str(canonical_file)],
         )
@@ -684,6 +789,7 @@ def test_canonical_search_api_and_selection_validation(tmp_path: Path) -> None:
             "available": True,
             "source_name": "canonical.parquet",
             "page_size": 100,
+            "additional_canonical_columns": ["classificationcode", "floorlevel"],
             "warning": None,
         }
 
@@ -698,6 +804,8 @@ def test_canonical_search_api_and_selection_validation(tmp_path: Path) -> None:
             "canonical-1",
             "canonical-2",
         ]
+        assert payload["rows"][0]["classificationcode"] == "RD06"
+        assert payload["rows"][0]["floorlevel"] == "1"
 
         status, payload = request(
             base_url,
@@ -738,6 +846,20 @@ def test_canonical_search_api_and_selection_validation(tmp_path: Path) -> None:
         assert status == 201
         assert payload["decision"] == "select_canonical"
         assert payload["ukam_label"] == "canonical-2"
+
+        status, payload = request(
+            base_url,
+            "/api/review-record?unique_id=messy-1&include_current=true",
+            token=session.token,
+        )
+        assert status == 200
+        assert payload["record"]["current_label"] == "canonical-2"
+        assert payload["record"]["current_label_address"] == "2 TEST ROAD"
+        assert payload["record"]["current_label_postcode"] == "E1 1AA"
+        assert payload["record"]["current_label_additional_columns"] == {
+            "classificationcode": "RD06",
+            "floorlevel": "2",
+        }
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/labelling/test_state.py
+++ b/tests/labelling/test_state.py
@@ -98,6 +98,16 @@ def test_candidate_validation_and_page_sizes(tmp_path: Path) -> None:
         _records_payload(bundle, {"page_size": ["25"]})
 
 
+def test_records_payload_exposes_model_target_for_label_selector(tmp_path: Path) -> None:
+    bundle = _load_bundle(create_test_bundle(tmp_path / "bundle"))
+    _ensure_state_database(bundle)
+
+    row = _records_payload(bundle, {"page_size": ["20"]})["rows"][0]
+
+    assert row["resolved_label_id"] == "label-1"
+    assert row["top_candidates"][0]["label_id"] == "label-1"
+
+
 def test_review_record_returns_candidates_and_navigation(tmp_path: Path) -> None:
     bundle = _load_bundle(create_test_bundle(tmp_path / "bundle"))
     _ensure_state_database(bundle)

--- a/uk_address_matcher/labelling/__init__.py
+++ b/uk_address_matcher/labelling/__init__.py
@@ -1,4 +1,4 @@
-from .bundle import export_labelling_bundle
-from .server import launch_labelling_app
+from .bundle import _export_labelling_bundle_beta
+from .server import _launch_labelling_app_beta
 
-__all__ = ["export_labelling_bundle", "launch_labelling_app"]
+__all__ = ["_export_labelling_bundle_beta", "_launch_labelling_app_beta"]

--- a/uk_address_matcher/labelling/app/app.css
+++ b/uk_address_matcher/labelling/app/app.css
@@ -400,8 +400,7 @@ th {
 }
 .canonical-header button,
 .canonical-search-panel button,
-.canonical-results footer button,
-.canonical-search-selection button {
+.canonical-results footer button {
   min-height: 34px;
   padding: 0 12px;
   border: 1px solid #c9b7ff;
@@ -583,34 +582,6 @@ th {
   color: #fff;
   text-align: left;
   border-radius: 6px;
-}
-.canonical-search-selection {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 18px;
-  margin: 18px 0;
-  padding: 14px 16px;
-  background: #faf8ff;
-  border: 1px solid #c9b7ff;
-  border-radius: 6px;
-}
-.canonical-search-selection span {
-  display: block;
-  color: #667085;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-.canonical-search-selection strong {
-  display: block;
-  margin-top: 3px;
-  color: #5925dc;
-}
-.canonical-search-selection p {
-  margin: 4px 0 0;
-  color: #475467;
-  font-size: 12px;
 }
 @media (max-width: 900px) {
   .canonical-search-panel {
@@ -1324,6 +1295,42 @@ tbody tr:hover td {
   font-weight: 600;
   overflow-wrap: anywhere;
 }
+#review-canonical-card .review-canonical-additional-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0 18px;
+  width: calc(100% - 36px);
+  margin: 0 18px 18px;
+  border-top: 1px solid #98a2b33d;
+}
+#review-canonical-card .review-canonical-additional-field {
+  display: grid;
+  grid-template-rows: auto auto;
+  align-content: start;
+  min-width: 0;
+  padding: 12px 0;
+}
+#review-canonical-card .review-canonical-additional-field + .review-canonical-additional-field {
+  padding-left: 18px;
+  border-left: 1px solid #98a2b33d;
+}
+#review-canonical-card .review-canonical-field-label,
+#review-canonical-card .review-canonical-field-value {
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+#review-canonical-card .review-canonical-field-label {
+  padding-bottom: 6px;
+  color: #475467;
+  font-size: 12px;
+  font-weight: 700;
+}
+#review-canonical-card .review-canonical-field-value {
+  font-size: 13px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
 .review-card p {
   padding: 60px 18px;
   text-align: center;
@@ -1335,6 +1342,71 @@ tbody tr:hover td {
 .review-actions {
   max-width: 1380px;
   margin: 18px auto 0;
+}
+.review-sticky-context {
+  position: sticky;
+  top: 117px;
+  z-index: 8;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  align-self: start;
+  width: 100%;
+  max-width: 1380px;
+  margin: 0 auto 18px;
+  padding: 10px;
+  border: 1px solid #dfe3ea;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 8px #10182812;
+}
+.review-sticky-record {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px 10px;
+  min-width: 0;
+  padding: 10px 14px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+}
+.review-sticky-record > span {
+  color: #475467;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.review-sticky-record > strong,
+.review-sticky-record > small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.review-sticky-record > strong {
+  font-size: 14px;
+}
+.review-sticky-record > small {
+  color: #475467;
+  font-size: 12px;
+  font-weight: 700;
+}
+.review-sticky-record.messy {
+  border-color: #bfd4ff;
+  background: #eef4ff;
+}
+.review-sticky-record.messy > span,
+.review-sticky-record.messy > strong {
+  color: #175cd3;
+}
+.review-sticky-record.canonical {
+  border-color: #b8dfc6;
+  background: #e9f8ef;
+}
+.review-sticky-record.canonical > span,
+.review-sticky-record.canonical > strong {
+  color: #18794e;
 }
 .review-summary h2 {
   background: #f9fafb;
@@ -1469,6 +1541,14 @@ tbody tr:hover td {
   margin-top: 2px;
   color: #101828;
   font-size: 14px;
+  overflow-wrap: anywhere;
+}
+.review-current-label-details {
+  display: block;
+  margin-top: 3px;
+  color: #475467;
+  font-size: 11px;
+  line-height: 1.35;
   overflow-wrap: anywhere;
 }
 .review-actions .accept {

--- a/uk_address_matcher/labelling/app/app.js
+++ b/uk_address_matcher/labelling/app/app.js
@@ -215,23 +215,23 @@ function select(row) {
       uncertain: "uncertain",
     }[row.current_decision] || "";
   node.append(new Option("Select label...", "", false, !current));
+  const modelCandidate = candidates(row).find(
+      (candidate) => candidate.is_model_selection,
+    ),
+    modelLabel = row.resolved_label_id ?? modelCandidate?.label_id;
   const seen = new Set();
   const add = (value, label, name) => {
-    if (seen.has(label)) return;
-    seen.add(label);
+    if (seen.has(value)) return;
+    seen.add(value);
     node.append(new Option(name, value, false, current === value));
   };
+  if (modelLabel != null && modelLabel !== "")
+    add("model", String(modelLabel), `Predicted value - ${modelLabel}`);
   if (row.imported_label)
     add(
       "existing",
       String(row.imported_label),
       `Existing label - ${row.imported_label}`,
-    );
-  if (row.resolved_label_id)
-    add(
-      "model",
-      String(row.resolved_label_id),
-      `Accept model - ${row.resolved_label_id}`,
     );
   candidates(row).forEach((candidate, index) =>
     add(
@@ -285,6 +285,8 @@ async function save(row, value) {
   }
 }
 function review(id) {
+  sessionStorage.setItem("ukam-review-filter-query", reviewFilterQuery());
+  sessionStorage.setItem("ukam-last-review-id", id);
   location.hash = `review/${encodeURIComponent(id)}`;
   view("review");
 }
@@ -644,6 +646,33 @@ function reviewId() {
 function display(value, fallback = "Not available") {
   return value == null || value === "" ? fallback : String(value);
 }
+function canonicalColumnLabel(column) {
+  const key = String(column).toLowerCase();
+  if (key === "classificationcode" || key === "classification_code")
+    return "OS classification";
+  if (key === "floorlevel" || key === "floor_level") return "Floor level";
+  return String(column)
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+function renderCanonicalAdditionalFields(container, values) {
+  const fields = Object.entries(values || {}).filter(
+    ([, value]) => value != null && value !== "",
+  );
+  container.replaceChildren(
+    ...fields.map(([column, value]) => {
+      const field = document.createElement("div");
+      field.className = "review-canonical-additional-field";
+      field.append(
+        text("span", canonicalColumnLabel(column), "review-canonical-field-label"),
+        text("span", value, "review-canonical-field-value"),
+      );
+      return field;
+    }),
+  );
+  container.hidden = !container.hasChildNodes();
+}
 function metric(value, applicable = true) {
   if (!applicable) return "Not applicable";
   const number = Number(value);
@@ -732,6 +761,20 @@ function renderReview() {
       record.resolved_canonical_postcode,
     );
   }
+  $("review-sticky-messy-address").textContent = display(
+    record.messy_cleaned_address || messyAddress,
+  );
+  $("review-sticky-messy-postcode").textContent = display(messyPostcode, "");
+  $("review-sticky-canonical-address").textContent = matched
+    ? display(record.resolved_canonical_address)
+    : "No accepted canonical match";
+  $("review-sticky-canonical-postcode").textContent = matched
+    ? display(record.resolved_canonical_postcode, "")
+    : "";
+  renderCanonicalAdditionalFields(
+    $("review-canonical-additional-fields"),
+    matched ? record.resolved_canonical_additional_columns : {},
+  );
   const splink = record.match_stage === "splink",
     score = $("review-score");
   $("review-stage").replaceChildren(
@@ -770,6 +813,17 @@ function renderReview() {
     : record.is_labelled
       ? "Decision recorded without a canonical label."
       : "Not labelled yet.";
+  const currentLabelDetails = [
+    record.current_label_address,
+    record.current_label_postcode,
+  ]
+    .filter(Boolean)
+    .join(" - ");
+  $("review-current-label-details").textContent = currentLabelDetails
+    ? `Points to: ${currentLabelDetails}`
+    : record.current_label
+      ? "Canonical target unavailable"
+      : "";
   updateReviewAccept();
 }
 function candidateRow(candidate) {
@@ -835,6 +889,7 @@ function updateReviewAccept() {
 }
 async function loadReview(
   id = reviewId() || sessionStorage.getItem("ukam-last-review-id"),
+  includeCurrent = false,
 ) {
   if (!id) return showReviewEmpty();
   try {
@@ -842,6 +897,7 @@ async function loadReview(
       sessionStorage.getItem("ukam-review-filter-query") || reviewFilterQuery(),
     );
     parameters.set("unique_id", id);
+    if (includeCurrent) parameters.set("include_current", "true");
     const payload = await api(`/api/review-record?${parameters}`);
     state.review.record = payload.record;
     state.review.navigation = payload.navigation;
@@ -853,27 +909,76 @@ async function loadReview(
     showReviewEmpty();
   }
 }
-function openReview(id) {
-  sessionStorage.setItem("ukam-review-filter-query", reviewFilterQuery());
-  sessionStorage.setItem("ukam-last-review-id", id);
-  location.hash = `review/${encodeURIComponent(id)}`;
+async function refreshSavedReview() {
+  state.bootstrap = await api("/api/bootstrap");
+  $("label-progress").textContent =
+    `${state.bootstrap.labelled_records} / ${state.bootstrap.total_records}`;
+  await load();
+}
+function showReviewComplete() {
+  reviewElements.content.hidden = true;
+  reviewElements.complete.hidden = false;
+  resetReviewScroll();
+}
+function resetReviewScroll() {
+  window.scrollTo({ top: 0, behavior: "auto" });
+}
+async function advanceAfterReviewSave(nextId) {
+  if (nextId) {
+    location.hash = `review/${encodeURIComponent(nextId)}`;
+  } else {
+    showReviewComplete();
+  }
+  if (nextId) resetReviewScroll();
+  refreshSavedReview().catch((error) => toast(error.message));
+}
+async function saveCanonicalSelection(canonicalRecord) {
+  const record = state.review.record;
+  if (!record) {
+    toast("Open a record in Review before selecting a canonical result.");
+    return;
+  }
+  const nextId = state.review.navigation?.next_unique_id;
+  try {
+    await api("/api/labels", {
+      method: "POST",
+      body: JSON.stringify({
+        unique_id: record.unique_id,
+        decision: "select_canonical",
+        ukam_label: canonicalRecord.canonical_id,
+        selected_candidate_rank: null,
+        next_unique_id: nextId,
+        review_query: reviewFilterQuery(),
+      }),
+    });
+    await advanceAfterReviewSave(nextId);
+    toast("Label saved");
+  } catch (error) {
+    toast(error.message);
+  }
 }
 function navigateReview(direction) {
   const id =
     state.review.navigation?.[
       direction === "previous" ? "previous_unique_id" : "next_unique_id"
     ];
-  if (id) location.hash = `review/${encodeURIComponent(id)}`;
+    if (id) {
+      resetReviewScroll();
+      location.hash = `review/${encodeURIComponent(id)}`;
+    }
 }
 async function saveReviewDecision(decision) {
   const record = state.review.record,
     candidate = selectedReviewCandidate();
   if (!record) return;
+  const nextId = state.review.navigation?.next_unique_id;
   let payload = {
     unique_id: record.unique_id,
     decision,
     ukam_label: null,
     selected_candidate_rank: null,
+    next_unique_id: nextId,
+    review_query: reviewFilterQuery(),
   };
   if (decision === "accept") {
     if (record.match_stage === "splink") {
@@ -891,12 +996,8 @@ async function saveReviewDecision(decision) {
   }
   try {
     await api("/api/labels", { method: "POST", body: JSON.stringify(payload) });
+    await advanceAfterReviewSave(nextId);
     toast("Label saved");
-    if (state.review.navigation.next_unique_id) navigateReview("next");
-    else {
-      reviewElements.content.hidden = true;
-      reviewElements.complete.hidden = false;
-    }
   } catch (error) {
     toast(error.message);
   }
@@ -933,15 +1034,12 @@ reviewElements.undo.onclick = () => undoReviewDecision();
 reviewElements.accept.onclick = () => saveReviewDecision("accept");
 $("review-no-match").onclick = () => saveReviewDecision("no_match");
 $("review-uncertain").onclick = () => saveReviewDecision("uncertain");
-$("review-skip").onclick = () =>
-  state.review.navigation?.next_unique_id
-    ? navigateReview("next")
-    : ((reviewElements.content.hidden = true),
-      (reviewElements.complete.hidden = false));
+$("review-skip").onclick = () => {
+  if (state.review.navigation?.next_unique_id) navigateReview("next");
+  else showReviewComplete();
+};
 $("review-complete-previous").onclick = () => navigateReview("previous");
 $("review-complete-overview").onclick = () => (location.hash = "overview");
-const existingReview = review;
-if (typeof existingReview === "function") review = (id) => openReview(id);
 if (location.hash.startsWith("#review")) loadReview();
 (() => {
   const c = {
@@ -957,17 +1055,36 @@ if (location.hash.startsWith("#review")) loadReview();
     page: $("canonical-page-number"),
     message: $("canonical-results-message"),
     table: $("canonical-results-table-shell"),
+    headerRow: $("canonical-results-header-row"),
+    actionHeading: $("canonical-action-heading"),
     body: $("canonical-results-body"),
     previous: $("canonical-previous"),
     next: $("canonical-next"),
     summary: $("canonical-pagination-summary"),
     pagination: $("canonical-pagination"),
-    reviewSearch: $("review-search-canonical"),
-    selection: $("review-canonical-search-selection"),
-    selectionId: $("review-search-selection-id"),
-    selectionAddress: $("review-search-selection-address"),
-    clearSelection: $("review-clear-search-selection"),
   };
+  const requiredCanonicalElements = [
+    c.unavailable,
+    c.content,
+    c.uniqueId,
+    c.postcode,
+    c.address,
+    c.usePostcode,
+    c.search,
+    c.clear,
+    c.status,
+    c.page,
+    c.message,
+    c.table,
+    c.headerRow,
+    c.actionHeading,
+    c.body,
+    c.previous,
+    c.next,
+    c.summary,
+    c.pagination,
+  ];
+  if (requiredCanonicalElements.some((element) => !element)) return;
   state.canonical = {
     available: false,
     page: 1,
@@ -976,32 +1093,9 @@ if (location.hash.startsWith("#review")) loadReview();
     hasNext: false,
     loading: false,
     initialisedReviewId: null,
-    pendingSelection: null,
+    additionalColumns: [],
   };
   const format = (value) => Number(value).toLocaleString("en-GB");
-  const pending = (record) => {
-    let selection = state.canonical.pendingSelection;
-    if (!selection) {
-      try {
-        selection = JSON.parse(
-          sessionStorage.getItem("ukam-pending-canonical-selection") || "null",
-        );
-      } catch {
-        sessionStorage.removeItem("ukam-pending-canonical-selection");
-      }
-      if (selection) state.canonical.pendingSelection = selection;
-    }
-    return selection &&
-      record &&
-      String(selection.messy_unique_id) === String(record.unique_id)
-      ? selection
-      : null;
-  };
-  const clearPending = () => {
-    state.canonical.pendingSelection = null;
-    sessionStorage.removeItem("ukam-pending-canonical-selection");
-    c.selection.hidden = true;
-  };
   const reset = () => {
     c.body.replaceChildren();
     c.table.hidden = true;
@@ -1020,6 +1114,16 @@ if (location.hash.startsWith("#review")) loadReview();
     c.next.disabled = state.canonical.loading || !state.canonical.hasNext;
     c.pagination.hidden =
       !state.canonical.hasPrevious && !state.canonical.hasNext;
+  };
+  const renderAdditionalHeadings = () => {
+    c.headerRow
+      .querySelectorAll("[data-canonical-additional-column]")
+      .forEach((heading) => heading.remove());
+    state.canonical.additionalColumns.forEach((column) => {
+      const heading = text("th", canonicalColumnLabel(column));
+      heading.dataset.canonicalAdditionalColumn = column;
+      c.headerRow.insertBefore(heading, c.actionHeading);
+    });
   };
   const appendHighlight = (node, value, needle) => {
     node.replaceChildren();
@@ -1048,25 +1152,7 @@ if (location.hash.startsWith("#review")) loadReview();
     if (!node.hasChildNodes()) node.textContent = source || "Not available";
   };
   const selectResult = (record) => {
-    const reviewRecord = state.review.record;
-    if (!reviewRecord) {
-      toast("Open a record in Review before selecting a canonical result.");
-      return;
-    }
-    const selection = {
-      messy_unique_id: String(reviewRecord.unique_id),
-      canonical_id: String(record.canonical_id),
-      canonical_address: record.canonical_address,
-      cleaned_address: record.cleaned_address,
-      canonical_postcode: record.canonical_postcode,
-    };
-    state.canonical.pendingSelection = selection;
-    sessionStorage.setItem(
-      "ukam-pending-canonical-selection",
-      JSON.stringify(selection),
-    );
-    toast("Canonical record selected");
-    location.hash = `review/${encodeURIComponent(reviewRecord.unique_id)}`;
+    saveCanonicalSelection(record);
   };
   const renderRows = () => {
     c.body.replaceChildren();
@@ -1092,6 +1178,9 @@ if (location.hash.startsWith("#review")) loadReview();
         postcode = text("td", record.canonical_postcode || "-"),
         action = document.createElement("td"),
         button = text("button", "Use this record", "use-canonical-button");
+      const additional = state.canonical.additionalColumns.map((column) =>
+        text("td", record[column] || "-"),
+      );
       appendHighlight(
         cleaned,
         record.cleaned_address,
@@ -1100,7 +1189,7 @@ if (location.hash.startsWith("#review")) loadReview();
       button.type = "button";
       button.onclick = () => selectResult(record);
       action.append(button);
-      row.append(id, cleaned, postcode, action);
+      row.append(id, cleaned, postcode, ...additional, action);
       row.ondblclick = () => selectResult(record);
       c.body.append(row);
     });
@@ -1134,6 +1223,12 @@ if (location.hash.startsWith("#review")) loadReview();
       state.canonical.hasPrevious = payload.has_previous;
       state.canonical.hasNext = payload.has_next;
       state.canonical.addressQuery = payload.address_query || "";
+      state.canonical.additionalColumns = Array.isArray(
+        payload.additional_canonical_columns,
+      )
+        ? payload.additional_canonical_columns
+        : state.canonical.additionalColumns;
+      renderAdditionalHeadings();
       renderRows();
     } catch (error) {
       c.message.hidden = false;
@@ -1163,70 +1258,11 @@ if (location.hash.startsWith("#review")) loadReview();
       reset();
     }
   };
-  const renderSelection = (record) => {
-    const selection = pending(record);
-    c.selection.hidden = !selection;
-    if (!selection) return;
-    c.selectionId.textContent = selection.canonical_id;
-    c.selectionAddress.textContent = [
-      selection.cleaned_address,
-      selection.canonical_postcode,
-    ]
-      .filter(Boolean)
-      .join(" - ");
-  };
   const oldRender = renderReview;
   renderReview = () => {
     oldRender();
     prepare();
-    renderSelection(state.review.record);
   };
-  const oldAccept = updateReviewAccept;
-  updateReviewAccept = () => {
-    const selection = pending(state.review.record);
-    if (selection) {
-      reviewElements.accept.hidden = false;
-      reviewElements.accept.textContent = "Use canonical search selection";
-      return;
-    }
-    oldAccept();
-  };
-  const oldSave = saveReviewDecision;
-  saveReviewDecision = async (decision) => {
-    const selection = pending(state.review.record);
-    if (decision !== "accept" || !selection) return oldSave(decision);
-    const record = state.review.record;
-    try {
-      await api("/api/labels", {
-        method: "POST",
-        body: JSON.stringify({
-          unique_id: record.unique_id,
-          decision: "select_canonical",
-          ukam_label: selection.canonical_id,
-          selected_candidate_rank: null,
-        }),
-      });
-      clearPending();
-      toast("Label saved");
-      if (state.review.navigation.next_unique_id) navigateReview("next");
-      else {
-        reviewElements.content.hidden = true;
-        reviewElements.complete.hidden = false;
-      }
-    } catch (error) {
-      toast(error.message);
-    }
-  };
-  $("review-candidate-body").addEventListener(
-    "change",
-    () => {
-      if (pending(state.review.record)) {
-        clearPending();
-        updateReviewAccept();
-      }
-    },
-    true,
-  );
   c.search.onclick = () => {
     state.canonical.page = 1;
     load();
@@ -1257,18 +1293,6 @@ if (location.hash.startsWith("#review")) loadReview();
       scrollTo({ top: 0, behavior: "smooth" });
     }
   };
-  c.reviewSearch.onclick = () => {
-    if (!state.canonical.available) {
-      toast("Canonical data is not available.");
-      return;
-    }
-    c.content.scrollIntoView({ behavior: "smooth", block: "start" });
-    c.postcode.focus();
-  };
-  c.clearSelection.onclick = () => {
-    clearPending();
-    updateReviewAccept();
-  };
   [c.postcode, c.address].forEach(
     (input) =>
       (input.onkeydown = (event) => {
@@ -1283,6 +1307,12 @@ if (location.hash.startsWith("#review")) loadReview();
     if (!state.bootstrap) return setTimeout(initialise, 25);
     const config = state.bootstrap.canonical_search || {};
     state.canonical.available = Boolean(config.available);
+    state.canonical.additionalColumns = Array.isArray(
+      config.additional_canonical_columns,
+    )
+      ? config.additional_canonical_columns
+      : [];
+    renderAdditionalHeadings();
     c.unavailable.hidden = state.canonical.available;
     c.content.hidden = !state.canonical.available;
     prepare();

--- a/uk_address_matcher/labelling/app/index.html
+++ b/uk_address_matcher/labelling/app/index.html
@@ -264,7 +264,23 @@
             ><strong id="review-position">Record 1 of 1</strong
             ><button id="review-next" class="review-button">Next &rarr;</button>
           </div>
-          <div class="review-cards">
+          <aside
+            id="review-sticky-context"
+            class="review-sticky-context"
+            aria-label="Current record summary"
+          >
+            <div class="review-sticky-record messy">
+              <span>Messy input</span>
+              <strong id="review-sticky-messy-address"></strong>
+              <small id="review-sticky-messy-postcode"></small>
+            </div>
+            <div class="review-sticky-record canonical">
+              <span>Model suggestion</span>
+              <strong id="review-sticky-canonical-address"></strong>
+              <small id="review-sticky-canonical-postcode"></small>
+            </div>
+          </aside>
+          <div id="review-cards" class="review-cards">
             <article class="review-card messy-card">
               <div class="review-card-header messy-card-header">
                 <h2>Messy input record</h2>
@@ -309,11 +325,16 @@
                   <dt>Postcode</dt>
                   <dd id="review-canonical-postcode"></dd>
                 </dl>
+                <div
+                  id="review-canonical-additional-fields"
+                  class="review-canonical-additional-fields"
+                  hidden
+                ></div>
               </div>
               <p id="review-no-canonical" hidden>No accepted canonical match</p>
             </article>
           </div>
-          <section class="review-summary">
+          <section id="review-summary" class="review-summary">
             <h2>Match summary</h2>
             <dl>
               <div>
@@ -338,20 +359,6 @@
               </div>
             </dl>
           </section>
-          <section
-            id="review-canonical-search-selection"
-            class="canonical-search-selection"
-            hidden
-          >
-            <div>
-              <span>Canonical search selection</span
-              ><strong id="review-search-selection-id"></strong>
-              <p id="review-search-selection-address"></p>
-            </div>
-            <button id="review-clear-search-selection" type="button">
-              Clear
-            </button>
-          </section>
           <section id="review-candidates" class="review-candidates" hidden>
             <h2 id="review-candidates-heading">
               Candidates considered by reranker
@@ -361,8 +368,8 @@
               candidate set, but the match should still be checked against the
               input record.
             </p>
-            <p id="review-no-candidates" class="review-warning" hidden>
-              No retained candidate data is available for this Splink record.
+            <p id="review-no-candidates" class="review-info" hidden>
+              No candidates were retained for reranking.
             </p>
             <div class="candidate-table-shell">
               <table>
@@ -460,11 +467,11 @@
               <div id="canonical-results-table-shell" hidden>
                 <table>
                   <thead>
-                    <tr>
+                    <tr id="canonical-results-header-row">
                       <th>Canonical ID</th>
                       <th>Cleaned address</th>
                       <th>Postcode</th>
-                      <th>Action</th>
+                      <th id="canonical-action-heading">Action</th>
                     </tr>
                   </thead>
                   <tbody id="canonical-results-body"></tbody>
@@ -486,7 +493,12 @@
                 >&#127991;</span
               ><span>
                 <span class="review-current-label-heading">Current label</span
-                ><strong id="review-current-label-value"></strong> </span
+                ><strong id="review-current-label-value"></strong
+                ><span
+                  id="review-current-label-details"
+                  class="review-current-label-details"
+                ></span>
+              </span
             ></span>
             <div>
               <button id="review-undo" class="review-button" type="button">
@@ -494,12 +506,6 @@
               </button>
               <button id="review-accept" class="review-button accept">
                 Accept model match</button
-              ><button
-                id="review-search-canonical"
-                class="review-button"
-                type="button"
-              >
-                Go to canonical search</button
               ><button id="review-no-match" class="review-button">
                 No match</button
               ><button id="review-uncertain" class="review-button">

--- a/uk_address_matcher/labelling/bundle.py
+++ b/uk_address_matcher/labelling/bundle.py
@@ -34,7 +34,7 @@ _CANONICAL_COLUMNS: tuple[str, ...] = ()
 logger = logging.getLogger("uk_address_matcher")
 
 
-def export_labelling_bundle(
+def _export_labelling_bundle_beta(
     match_result: MatchResult,
     output_directory: str | Path = DEFAULT_LABELLING_BUNDLE_DIRECTORY,
     *,

--- a/uk_address_matcher/labelling/canonical.py
+++ b/uk_address_matcher/labelling/canonical.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,11 @@ DISPLAY_ADDRESS_COLUMNS = (
     "clean_full_address",
     "cleaned_full_address",
 )
+ADDITIONAL_COLUMNS_TO_RETAIN = ("classificationcode", "floorlevel")
+_UK_POSTCODE_PATTERN = re.compile(
+    r"^(?:GIR 0AA|[A-Z][A-HJ-Y]?\d[A-Z\d]? \d[A-Z]{2})$",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -30,10 +36,20 @@ class CanonicalSource:
     postcode_column: str
     cleaned_address_column: str
     display_address_column: str
+    additional_canonical_columns: tuple[str, ...] = ()
 
     @property
     def display_name(self) -> str:
         return self.supplied_path.name
+
+    def columns_to_retain(self) -> tuple[str, ...]:
+        return (
+            self.unique_id_column,
+            self.postcode_column,
+            self.cleaned_address_column,
+            self.display_address_column,
+            *self.additional_canonical_columns,
+        )
 
 
 @dataclass(frozen=True)
@@ -45,6 +61,7 @@ class CanonicalSearchPage:
     unique_id_query: str
     postcode: str | None
     address_query: str
+    additional_canonical_columns: tuple[str, ...]
     rows: list[dict[str, Any]]
 
 
@@ -54,6 +71,17 @@ def _quote_identifier(value: str) -> str:
 
 def _quote_sql_string(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
+
+
+def _find_available_columns(
+    available_columns: frozenset[str], candidates: tuple[str, ...]
+) -> tuple[str, ...]:
+    columns_by_lowercase = {column.lower(): column for column in available_columns}
+    return tuple(
+        columns_by_lowercase[candidate.lower()]
+        for candidate in candidates
+        if candidate.lower() in columns_by_lowercase
+    )
 
 
 def _resolve_canonical_parquet_paths(supplied_path: Path) -> list[Path]:
@@ -74,6 +102,8 @@ def _resolve_canonical_parquet_paths(supplied_path: Path) -> list[Path]:
 
 def load_canonical_source(
     canonical_data_path: str | Path | None,
+    *,
+    additional_canonical_columns: tuple[str, ...] = ADDITIONAL_COLUMNS_TO_RETAIN,
 ) -> CanonicalSource | None:
     if canonical_data_path is None:
         return None
@@ -117,6 +147,9 @@ def load_canonical_source(
         (column for column in DISPLAY_ADDRESS_COLUMNS if column in available_columns),
         cleaned_address_column,
     )
+    available_additional_columns = _find_available_columns(
+        available_columns, additional_canonical_columns
+    )
     return CanonicalSource(
         supplied_path=supplied_path,
         parquet_paths=tuple(parquet_paths),
@@ -125,6 +158,7 @@ def load_canonical_source(
         postcode_column="postcode",
         cleaned_address_column=cleaned_address_column,
         display_address_column=display_address_column,
+        additional_canonical_columns=available_additional_columns,
     )
 
 
@@ -146,15 +180,22 @@ def normalise_postcode_search(value: str | None) -> str | None:
     return compact if len(compact) <= 3 else f"{compact[:-3]} {compact[-3:]}"
 
 
+def _is_valid_spaced_postcode(value: str | None) -> bool:
+    return (
+        value is not None
+        and _UK_POSTCODE_PATTERN.fullmatch(str(value).strip()) is not None
+    )
+
+
 def _canonical_columns(source: CanonicalSource) -> tuple[str, str, str, str]:
-    return tuple(
-        _quote_identifier(column)
-        for column in (
-            source.unique_id_column,
-            source.postcode_column,
-            source.cleaned_address_column,
-            source.display_address_column,
-        )
+    columns = source.columns_to_retain()[:4]
+    return tuple(_quote_identifier(column) for column in columns)
+
+
+def _additional_columns_sql(source: CanonicalSource) -> str:
+    return "".join(
+        f", CAST({_quote_identifier(column)} AS VARCHAR) AS {_quote_identifier(column)}"
+        for column in source.additional_canonical_columns
     )
 
 
@@ -191,17 +232,27 @@ def search_canonical_data(
     unique_id, postcode_column, cleaned_address, display_address = _canonical_columns(
         source
     )
+    additional_columns = _additional_columns_sql(source)
     conditions = [f"{unique_id} IS NOT NULL"]
     parameters: list[Any] = []
     if cleaned_unique_id_query:
         conditions.append(f"contains(upper(CAST({unique_id} AS VARCHAR)), upper(?))")
         parameters.append(cleaned_unique_id_query)
     if normalised_postcode is not None:
-        conditions.append(f"{postcode_column} = ?")
-        parameters.append(normalised_postcode)
-    if cleaned_query:
+        compact_postcode = normalised_postcode.replace(" ", "")
+        postcode_expression = (
+            f"upper(replace(CAST({postcode_column} AS VARCHAR), ' ', ''))"
+        )
+        if _is_valid_spaced_postcode(postcode):
+            conditions.append(f"{postcode_expression} = upper(?)")
+        else:
+            conditions.append(f"contains({postcode_expression}, upper(?))")
+        parameters.append(compact_postcode)
+    address_tokens = cleaned_query.split()
+    cleaned_query = " ".join(address_tokens)
+    for token in address_tokens:
         conditions.append(f"contains(upper({cleaned_address}), upper(?))")
-        parameters.append(cleaned_query)
+        parameters.append(token)
     offset = (page - 1) * CANONICAL_PAGE_SIZE
     query = f"""
         SELECT
@@ -209,6 +260,7 @@ def search_canonical_data(
             CAST({display_address} AS VARCHAR) AS canonical_address,
             CAST({cleaned_address} AS VARCHAR) AS cleaned_address,
             CAST({postcode_column} AS VARCHAR) AS canonical_postcode
+            {additional_columns}
         FROM {canonical_scan_sql(source)}
         WHERE {" AND ".join(conditions)}
         ORDER BY canonical_postcode, cleaned_address, canonical_address, canonical_id
@@ -228,6 +280,7 @@ def search_canonical_data(
         unique_id_query=cleaned_unique_id_query,
         postcode=normalised_postcode,
         address_query=cleaned_query,
+        additional_canonical_columns=source.additional_canonical_columns,
         rows=rows[:CANONICAL_PAGE_SIZE],
     )
 
@@ -241,12 +294,14 @@ def find_canonical_record(
     unique_id, postcode_column, cleaned_address, display_address = _canonical_columns(
         source
     )
+    additional_columns = _additional_columns_sql(source)
     query = f"""
         SELECT
             CAST({unique_id} AS VARCHAR) AS canonical_id,
             CAST({display_address} AS VARCHAR) AS canonical_address,
             CAST({cleaned_address} AS VARCHAR) AS cleaned_address,
             CAST({postcode_column} AS VARCHAR) AS canonical_postcode
+            {additional_columns}
         FROM {canonical_scan_sql(source)}
         WHERE CAST({unique_id} AS VARCHAR) = ?
         ORDER BY canonical_postcode, cleaned_address, canonical_address, canonical_id

--- a/uk_address_matcher/labelling/server.py
+++ b/uk_address_matcher/labelling/server.py
@@ -20,6 +20,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 import duckdb
 
 from uk_address_matcher.labelling.canonical import (
+    ADDITIONAL_COLUMNS_TO_RETAIN,
     CANONICAL_PAGE_SIZE,
     CanonicalSource,
     find_canonical_record,
@@ -28,6 +29,8 @@ from uk_address_matcher.labelling.canonical import (
 )
 
 DEFAULT_PAGE_SIZE = 20
+REVIEW_PREFETCH_SIZE = 5
+REVIEW_PREFETCH_DELAY_SECONDS = 1.0
 ALLOWED_PAGE_SIZES = {10, 20, 50, 100}
 ALLOWED_MATCH_STAGES = {"exact", "peeled", "splink", "unique_trigram", "unmatched"}
 RECORD_SORT_COLUMNS = {
@@ -277,6 +280,15 @@ def _ensure_state_database(bundle: Bundle) -> None:
                 selected_candidate_rank BIGINT, created_at_utc TIMESTAMPTZ NOT NULL
             )
         """)
+        connection.execute("""
+            CREATE TABLE IF NOT EXISTS review_prefetch_cache (
+                cache_key VARCHAR NOT NULL,
+                unique_id VARCHAR NOT NULL,
+                queue_position INTEGER NOT NULL,
+                payload_json VARCHAR NOT NULL,
+                PRIMARY KEY (cache_key, unique_id)
+            )
+        """)
     finally:
         connection.close()
 
@@ -382,6 +394,11 @@ def _bootstrap_payload(
                 None if canonical_source is None else canonical_source.display_name
             ),
             "page_size": CANONICAL_PAGE_SIZE,
+            "additional_canonical_columns": (
+                []
+                if canonical_source is None
+                else list(canonical_source.additional_canonical_columns)
+            ),
             "warning": (
                 "No canonical path provided. If you wish to view canonical data in "
                 "this app, relaunch the application with canonical_data_path."
@@ -529,12 +546,42 @@ def _records_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[str, A
     }
 
 
-def _review_record_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[str, Any]:
+def _additional_canonical_values(
+    source: CanonicalSource | None,
+    record: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if source is None or record is None:
+        return {}
+    return {
+        column: record[column]
+        for column in source.additional_canonical_columns
+        if column in record and record[column] not in (None, "")
+    }
+
+
+def _review_record_payload(
+    bundle: Bundle,
+    query: dict[str, list[str]],
+    canonical_source: CanonicalSource | None = None,
+) -> dict[str, Any]:
     unique_id = query.get("unique_id", [""])[0]
     if not unique_id:
         raise ValueError("unique_id is required")
     filters = _parse_record_filters(query)
     where_clause, parameters = _record_filter_sql(filters)
+    include_current = query.get("include_current", ["false"])[0].lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if include_current:
+        where_clause = (
+            f"WHERE ({where_clause.removeprefix('WHERE ')}) OR unique_id = ?"
+            if where_clause
+            else "WHERE unique_id = ?"
+        )
+        parameters.append(str(unique_id))
     cleaned_address = (
         "messy_cleaned_address"
         if "messy_cleaned_address" in bundle.review_columns
@@ -575,6 +622,42 @@ def _review_record_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[
     finally:
         connection.close()
     candidates = _normalise_candidates(result.pop("candidates"))
+    current_label = result.get("current_label")
+    current_details = None
+    if current_label is not None and canonical_source is not None:
+        current_details = find_canonical_record(canonical_source, current_label)
+    if current_details is None and current_label is not None:
+        if str(current_label) == str(result.get("resolved_label_id")):
+            current_details = {
+                "canonical_address": result.get("resolved_canonical_address"),
+                "canonical_postcode": result.get("resolved_canonical_postcode"),
+            }
+        else:
+            current_details = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if str(candidate.get("label_id")) == str(current_label)
+                ),
+                None,
+            )
+    resolved_details = None
+    if result.get("resolved_label_id") is not None and canonical_source is not None:
+        resolved_details = find_canonical_record(
+            canonical_source, result["resolved_label_id"]
+        )
+    result["current_label_address"] = (
+        current_details.get("canonical_address") if current_details else None
+    )
+    result["current_label_postcode"] = (
+        current_details.get("canonical_postcode") if current_details else None
+    )
+    result["current_label_additional_columns"] = _additional_canonical_values(
+        canonical_source, current_details
+    )
+    result["resolved_canonical_additional_columns"] = _additional_canonical_values(
+        canonical_source, resolved_details
+    )
     navigation = {
         "position": result.pop("review_position"),
         "total": result.pop("review_total"),
@@ -583,6 +666,152 @@ def _review_record_payload(bundle: Bundle, query: dict[str, list[str]]) -> dict[
     }
     result["candidates"] = candidates
     return {"record": result, "navigation": navigation}
+
+
+def _review_cache_key(query: dict[str, list[str]]) -> str:
+    filters = {
+        key: values
+        for key, values in query.items()
+        if key not in {"unique_id", "include_current"}
+    }
+    return json.dumps(filters, sort_keys=True, separators=(",", ":"))
+
+
+class _ReviewPrefetchCache:
+    def __init__(
+        self,
+        bundle: Bundle,
+        canonical_source: CanonicalSource | None,
+        *,
+        delay_seconds: float = REVIEW_PREFETCH_DELAY_SECONDS,
+    ) -> None:
+        self._bundle = bundle
+        self._canonical_source = canonical_source
+        self._delay_seconds = delay_seconds
+        self._condition = threading.Condition()
+        self._cache_key: str | None = None
+        self._ready_version = 0
+        self._task: tuple[int, float, dict[str, list[str]], str] | None = None
+        self._version = 0
+        self._closed = False
+        self._worker = threading.Thread(target=self._run, daemon=True)
+        self._worker.start()
+
+    def get(
+        self, query: dict[str, list[str]], unique_id: str
+    ) -> dict[str, Any] | None:
+        cache_key = _review_cache_key(query)
+        with self._condition:
+            if self._cache_key != cache_key or self._ready_version != self._version:
+                return None
+        connection = duckdb.connect(str(self._bundle.state_file), read_only=True)
+        try:
+            row = connection.execute(
+                """SELECT payload_json FROM review_prefetch_cache
+                WHERE cache_key = ? AND unique_id = ?""",
+                [cache_key, unique_id],
+            ).fetchone()
+        finally:
+            connection.close()
+        return json.loads(row[0]) if row else None
+
+    def schedule(self, query: dict[str, list[str]], start_unique_id: str | None) -> None:
+        if not start_unique_id:
+            return
+        filters = {
+            key: list(values)
+            for key, values in query.items()
+            if key not in {"unique_id", "include_current"}
+        }
+        with self._condition:
+            self._version += 1
+            self._ready_version = 0
+            self._task = (
+                self._version,
+                time.monotonic() + self._delay_seconds,
+                filters,
+                str(start_unique_id),
+            )
+            self._condition.notify()
+
+    def clear(self) -> None:
+        with self._condition:
+            self._version += 1
+            self._ready_version = 0
+            self._cache_key = None
+            self._task = None
+            self._condition.notify()
+
+    def close(self) -> None:
+        with self._condition:
+            self._closed = True
+            self._condition.notify()
+        self._worker.join(timeout=2)
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                while not self._closed and self._task is None:
+                    self._condition.wait()
+                if self._closed:
+                    return
+                version, ready_at, query, unique_id = self._task
+                remaining = ready_at - time.monotonic()
+                if remaining > 0:
+                    self._condition.wait(remaining)
+                    continue
+                self._task = None
+            try:
+                payloads = self._build_payloads(query, unique_id)
+            except Exception:
+                payloads = []
+            with self._condition:
+                if self._closed:
+                    return
+                if version != self._version:
+                    continue
+                cache_key = _review_cache_key(query)
+                self._store(cache_key, payloads)
+                self._cache_key = cache_key
+                self._ready_version = version
+
+    def _build_payloads(
+        self, query: dict[str, list[str]], unique_id: str
+    ) -> list[tuple[str, dict[str, Any]]]:
+        payloads: list[tuple[str, dict[str, Any]]] = []
+        current_id: str | None = unique_id
+        while current_id and len(payloads) < REVIEW_PREFETCH_SIZE:
+            request_query = {key: list(values) for key, values in query.items()}
+            request_query["unique_id"] = [current_id]
+            try:
+                payload = _review_record_payload(
+                    self._bundle, request_query, self._canonical_source
+                )
+            except ValueError:
+                break
+            payloads.append((current_id, payload))
+            current_id = payload["navigation"]["next_unique_id"]
+        return payloads
+
+    def _store(self, cache_key: str, payloads: list[tuple[str, dict[str, Any]]]) -> None:
+        connection = duckdb.connect(str(self._bundle.state_file))
+        try:
+            connection.execute("DELETE FROM review_prefetch_cache")
+            if payloads:
+                connection.executemany(
+                    "INSERT INTO review_prefetch_cache VALUES (?, ?, ?, ?)",
+                    [
+                        (
+                            cache_key,
+                            unique_id,
+                            position,
+                            json.dumps(payload, default=_json_default),
+                        )
+                        for position, (unique_id, payload) in enumerate(payloads)
+                    ],
+                )
+        finally:
+            connection.close()
 
 
 def _record_for_validation(bundle: Bundle, unique_id: str) -> dict[str, Any]:
@@ -810,6 +1039,7 @@ def _handler_factory(
     canonical_source: CanonicalSource | None = None,
 ) -> type[BaseHTTPRequestHandler]:
     static_root = files("uk_address_matcher.labelling.app")
+    prefetch_cache = _ReviewPrefetchCache(bundle, canonical_source)
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, format_string: str, *args: Any) -> None:
@@ -892,7 +1122,19 @@ def _handler_factory(
                     return
                 if path == "/api/review-record":
                     session.touch()
-                    self._send(HTTPStatus.OK, _review_record_payload(bundle, query))
+                    unique_id = query.get("unique_id", [""])[0]
+                    review_payload = prefetch_cache.get(query, unique_id)
+                    if review_payload is None:
+                        review_payload = _review_record_payload(
+                            bundle, query, canonical_source
+                        )
+                    prefetch_cache.schedule(
+                        query, review_payload["navigation"]["next_unique_id"]
+                    )
+                    self._send(
+                        HTTPStatus.OK,
+                        review_payload,
+                    )
                     return
                 if path == "/api/canonical-search":
                     session.touch()
@@ -926,6 +1168,9 @@ def _handler_factory(
                             "unique_id_query": result.unique_id_query,
                             "postcode": result.postcode,
                             "address_query": result.address_query,
+                            "additional_canonical_columns": list(
+                                result.additional_canonical_columns
+                            ),
                             "rows": result.rows,
                         },
                     )
@@ -957,13 +1202,21 @@ def _handler_factory(
                     return
                 if path == "/api/labels":
                     session.touch()
+                    saved_label = _save_label(
+                        bundle, payload, input_dataset, canonical_source
+                    )
+                    prefetch_cache.schedule(
+                        parse_qs(str(payload.get("review_query", ""))),
+                        payload.get("next_unique_id"),
+                    )
                     self._send(
                         HTTPStatus.CREATED,
-                        _save_label(bundle, payload, input_dataset, canonical_source),
+                        saved_label,
                     )
                     return
                 if path == "/api/undo":
                     session.touch()
+                    prefetch_cache.clear()
                     self._send(HTTPStatus.OK, _undo_last_label(bundle, input_dataset))
                     return
                 self._send(HTTPStatus.NOT_FOUND, {"error": "API route not found"})
@@ -975,15 +1228,17 @@ def _handler_factory(
                     {"error": f"Unexpected server error: {error}"},
                 )
 
+    Handler.prefetch_cache = prefetch_cache
     return Handler
 
 
-def launch_labelling_app(
+def _launch_labelling_app_beta(
     labelling_bundle_path: str | Path = Path("ukam_labelling_bundle"),
     *,
     input_dataset_path: str | Path,
     input_dataset_label_column: str = "ukam_label",
     canonical_address_path: str | Path | None = None,
+    additional_canonical_columns: tuple[str, ...] = ADDITIONAL_COLUMNS_TO_RETAIN,
     port: int = 0,
     open_browser: bool = True,
 ) -> None:
@@ -998,12 +1253,13 @@ def launch_labelling_app(
         label_column=input_dataset_label_column,
     )
     _ensure_state_database(bundle)
-    canonical_source = load_canonical_source(canonical_address_path)
-    session = SessionState(600)
-    server = ThreadingHTTPServer(
-        ("127.0.0.1", port),
-        _handler_factory(bundle, input_dataset, session, canonical_source),
+    canonical_source = load_canonical_source(
+        canonical_address_path,
+        additional_canonical_columns=additional_canonical_columns,
     )
+    session = SessionState(600)
+    handler = _handler_factory(bundle, input_dataset, session, canonical_source)
+    server = ThreadingHTTPServer(("127.0.0.1", port), handler)
     url = f"http://127.0.0.1:{server.server_address[1]}/?token={session.token}"
     print(f"UKAM labelling tool: {url}", flush=True)  # noqa: T201
     print(  # noqa: T201
@@ -1028,6 +1284,9 @@ def launch_labelling_app(
         stop.set()
         server.server_close()
         thread.join(timeout=2)
+        prefetch_cache = getattr(handler, "prefetch_cache", None)
+        if prefetch_cache is not None:
+            prefetch_cache.close()
 
 
 def main() -> None:
@@ -1039,7 +1298,7 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=0)
     parser.add_argument("--no-browser", action="store_true")
     arguments = parser.parse_args()
-    launch_labelling_app(
+    _launch_labelling_app_beta(
         arguments.labelling_bundle,
         input_dataset_path=arguments.input_dataset,
         input_dataset_label_column=arguments.input_label_column,

--- a/uk_address_matcher/labelling/server.py
+++ b/uk_address_matcher/labelling/server.py
@@ -697,9 +697,7 @@ class _ReviewPrefetchCache:
         self._worker = threading.Thread(target=self._run, daemon=True)
         self._worker.start()
 
-    def get(
-        self, query: dict[str, list[str]], unique_id: str
-    ) -> dict[str, Any] | None:
+    def get(self, query: dict[str, list[str]], unique_id: str) -> dict[str, Any] | None:
         cache_key = _review_cache_key(query)
         with self._condition:
             if self._cache_key != cache_key or self._ready_version != self._version:

--- a/uk_address_matcher/post_linkage/match_result/result.py
+++ b/uk_address_matcher/post_linkage/match_result/result.py
@@ -100,7 +100,7 @@ class MatchResult:
             """
         )
 
-    def export_labelling_bundle(
+    def _export_labelling_bundle_beta(
         self,
         output_directory: str | Path = "ukam_labelling_bundle",
         *,
@@ -108,9 +108,9 @@ class MatchResult:
         overwrite: bool = False,
     ) -> Path:
         """Export a durable bundle for the UKAM labelling workflow."""
-        from uk_address_matcher.labelling import export_labelling_bundle
+        from uk_address_matcher.labelling import _export_labelling_bundle_beta
 
-        return export_labelling_bundle(
+        return _export_labelling_bundle_beta(
             match_result=self,
             output_directory=output_directory,
             top_n_candidates=top_n_candidates,


### PR DESCRIPTION
## Summary

- Renamed the labelling APIs to beta/private names:
  - `export_labelling_bundle` -> `_export_labelling_bundle_beta`
  - `launch_labelling_app` -> `_launch_labelling_app_beta`
- Updated the implementation references, tests, examples, benchmarking scripts, and documentation to use the renamed APIs.
- Added standalone examples for exporting a labelling bundle and launching the local labelling app.
- Documented the alpha status of the labelling workflow, canonical search configuration, and canonical ID validation when saving labels.
- Updated the Hackney benchmarking configuration and example launcher.
- Removed the blanket `*.html` ignore rule and refreshed the lockfile metadata.