### PR TITLE
feat: tweak distinguishability weights to improve accruacy (f1, recall)

### DIFF
--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -80,7 +80,7 @@
         {
           "sql_condition": "list_has_all(regexp_split_to_array(clean_full_address_r, '\\s+'), distinguishing_adj_start_tokens_l)",
           "label_for_charts": "All distinguishing tokens present",
-          "m_probability": 2.0,
+          "m_probability": 8.0,
           "u_probability": 1.0,
           "fix_m_probability": true,
           "fix_u_probability": true
@@ -88,7 +88,7 @@
         {
           "sql_condition": "list_has_any(regexp_split_to_array(clean_full_address_r, '\\s+'), distinguishing_adj_start_tokens_l)",
           "label_for_charts": "Some distinguishing tokens present",
-          "m_probability": 1.4142135623730951,
+          "m_probability": 2.8284271247461903,
           "u_probability": 1.0,
           "fix_m_probability": true,
           "fix_u_probability": true
@@ -97,7 +97,7 @@
           "sql_condition": "ELSE",
           "label_for_charts": "No distinguishing tokens present",
           "m_probability": 1.0,
-          "u_probability": 1024.0,
+          "u_probability": 1.0,
           "fix_m_probability": true,
           "fix_u_probability": true
         }

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -147,13 +147,14 @@ class SplinkStage(MatchingStage):
 
         table_name = f"__ukam__splink__predictions__{_uid()}"
         con.execute(
-            "CREATE OR REPLACE TEMP VIEW "
+            "CREATE OR REPLACE TEMP TABLE "
             + table_name
             + " AS SELECT * FROM ("
             + df_predict_ddb.sql_query()
             + ")"
         )
         self.predictions_table = table_name
+        df_predict_ddb = con.table(table_name)
 
         # Step 3: Improve predictions using distinguishing tokens
         df_improved = improve_predictions_using_distinguishing_tokens(


### PR DESCRIPTION
Adjust the weights assigned to our distinguishability comparison. Currently, it appears that the weight set for "else" is too punishing and it's causing us to lose a large number of matches we were previously getting correct. I imagine this is because of the issues with address permutations and the rarity of having alignment of these distinguishing tokens. This still remains a highly discriminating feature.

<img width="878" height="621" alt="distinguishability_at_thresholds" src="https://github.com/user-attachments/assets/017a5b18-30bc-4fb9-b1ea-f3ef8fae4b1f" />

It might be worth doing some analysis as to whether this increases the number of erroneous matches that are further away from the correct canonical location.

## Token check summary

# Distinguishing-token weight checks

Date: 2026-08-20
Package: `uk_address_matcher` 1.2.4
Primary matrix threshold: Splink match weight (`MW`) = 10.0
Additional threshold checks: `MW` = 8.0 and 12.0

## Question

Does the local `neighbour_distinguishing_tokens` comparison cause the
Hackney regression because its no-token level is too punitive, and can stronger
positive-token evidence recover correct matches without increasing wrong
matches disproportionately?

This document records the evidence from the canonical performance audit and
the follow-up weight experiments. It is an experiment record, not a production
configuration change.

## Current conclusion

The large regression is caused by the local distinguishing-token comparison
being active during Splink scoring, not by duplicated canonical rows. The
comparison is useful evidence, but the current `-10` no-token contribution is
sufficiently conservative to change candidate ordering around the fixed
`MW=10` boundary.

The reduced Hackney experiment shows that weaker no-token penalties recover a
large number of correct matches. The response is non-monotonic, so the result
is an interaction with the other comparison levels and the final threshold,
not a simple rule that the penalty should merely be reduced by a fixed amount.

No production model default or prepared canonical has been changed as part of
these checks.

## Dependence audit

The initial full-Hackney comparison-vector audit is recorded in
[comparison_dependence_hackney/comparison_dependence.md](comparison_dependence_hackney/comparison_dependence.md).
It found `gamma_neighbour_distinguishing_tokens = -1` for every raw candidate
in both the full-canonical and residential-subset runs. This is a feature
materialisation discrepancy that must be reconciled with the earlier weight
ablation before treating the configured neighbour weights as active evidence;
the audit found no neighbour-level correlation or double counting while the
comparison was constant.

## Evidence that isolated the comparison

The full Hackney control used the same messy input, canonical filter, stage
sequence, and `MW=10` threshold. The material results were:

| Configuration | Matched | Correct | Wrong | Unmatched |
| --- | ---: | ---: | ---: | ---: |
| Historical control | 113,165 | 112,549 | 616 | 1,001 |
| Fresh canonical, local-token scoring on | 111,918 | 111,366 | 552 | 2,248 |
| Fresh canonical, local-token comparison off | 113,162 | 112,540 | 622 | 1,004 |

A same-commit ablation on the remote code also separated the effects:

| Feature change | Matched delta | Correct delta |
| --- | ---: | ---: |
| Numeric-range reranking off to on, local tokens off | +31 | +33 |
| Local-token scoring off to on, range reranking off | -1,244 | -1,174 |
| Local-token scoring off to on, range reranking on | -1,249 | -1,178 |

The later post-linkage distinguishing-token adjustment was held constant. The
switch only removes the Splink `neighbour_distinguishing_tokens` comparison.
The no-token canonical control and scoring-only ablation produced identical
metrics, confirming that the scoring comparison is the dominant cause.

## Comparison levels and weights

The bundled comparison currently assigns these log2 Bayes-factor contributions:

| Level | `m_probability` | `u_probability` | Weight |
| --- | ---: | ---: | ---: |
| Ordered two-token signature, postcode exact | 1,024 | 1 | +10 |
| All distinguishing tokens present | 2 | 1 | +1 |
| Some distinguishing tokens present | sqrt(2) | 1 | +0.5 |
| No distinguishing tokens present | 1 | 1,024 | -10 |

The weight is `log2(m_probability / u_probability)`. The null level is neutral
when the messy-side token array is absent or empty; the `ELSE` level is the
negative no-token evidence when tokens exist but none are found in a candidate.

The `+10` ordered signature is already strong positive evidence. The follow-up
matrix will therefore concentrate on increasing the weaker `+1` and `+0.5`
levels while also testing the no-token penalty, rather than making the ordered
signature arbitrarily dominant.

## Existing reduced-canonical sweep

A temporary Hackney residential canonical was rebuilt from the raw NGD parquet
using:

```sql
lowertierlocalauthoritygsscode = 'E09000012'
AND substr(classificationcode, 1, 1) = 'R'
```

It contains 346,168 canonical rows. The experiment used the fixed Hackney
messy input, local-token scoring enabled, and changed only the no-token level.

| No-token weight | Matched | Correct | Wrong | Unmatched | PR-AUC |
| ---: | ---: | ---: | ---: | ---: | ---: |
| -10, current | 111,630 | 111,137 | 493 | 2,536 | 0.571277 |
| -6 | 111,513 | 111,022 | 491 | 2,653 | 0.570243 |
| -4 | 112,406 | 111,902 | 504 | 1,760 | 0.577938 |
| -2 | 112,889 | 112,374 | 515 | 1,277 | 0.582061 |
| 0 | 112,906 | 112,377 | 529 | 1,260 | 0.582080 |
| Comparison disabled | 112,754 | 112,194 | 560 | 1,412 | 0.580378 |

These reduced-canonical metrics are directional. They must not be compared
in absolute terms with a full-canonical pooled-councils run because the
candidate universe is smaller.

### Hackney positive-token follow-up

The same reduced Hackney canonical was then used to test stronger positive
levels. All rows below use `MW=10.0`, the fixed `114,166`-row Hackney input,
and the same `346,168`-row residential canonical as the sweep above. The
current positive levels are shown for context; the other rows are the selected
positive-weight checks from the reduced-canonical matrix.

| Positive levels | No-token weight | Matched | Correct | Wrong | Unmatched | P | R | F1 | PR-AUC |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Current (`+1`, `+0.5`) | -10 | 111,630 | 111,137 | 493 | 2,536 | 0.995584 | 0.973468 | 0.984402 | 0.571277 |
| Moderate (`+2`, `+1`) | -4 | 112,480 | 111,936 | 544 | 1,686 | 0.995164 | 0.980467 | 0.987761 | 0.578227 |
| Moderate (`+2`, `+1`) | -2 | 112,952 | 112,409 | 543 | 1,214 | 0.995193 | 0.984610 | 0.989873 | 0.582369 |
| Moderate (`+2`, `+1`) | 0 | 112,994 | 112,441 | 553 | 1,172 | 0.995106 | 0.984890 | 0.989972 | 0.582637 |
| Stronger (`+3`, `+1.5`) | 0 | 113,179 | 112,568 | 611 | 987 | 0.994601 | 0.986003 | 0.990283 | 0.583734 |
| Very strong (`+4`, `+2`) | -2 | 113,102 | 112,517 | 585 | 1,064 | 0.994828 | 0.985556 | 0.990170 | 0.583299 |
| Very strong (`+4`, `+2`) | 0 | 113,205 | 112,594 | 611 | 961 | 0.994603 | 0.986231 | 0.990399 | 0.583963 |

Within this reduced Hackney candidate universe, the best selected row by
correct matches is very strong positive evidence with no-token weight `0`.
It adds `1,457` correct matches over the current row, with `118` additional
wrong matches, and has the highest PR-AUC in this table. These results remain
directional because the reduced canonical is not the full pooled candidate
universe.

## Follow-up experiment design

The positive-weight matrix changes only the four levels in this comparison.
Candidate blocking, canonical data, messy data, post-linkage adjustments,
`MW=10`, and all other Splink comparisons remain unchanged.

The initial candidates are:

- current positive levels: ordered `+10`, all `+1`, some `+0.5`;
- moderate uplift: ordered `+10`, all `+2`, some `+1`;
- stronger uplift: ordered `+10`, all `+3`, some `+1.5`;
- very strong non-signature uplift: ordered `+10`, all `+4`, some `+2`.

Each candidate will be tested with no-token weights `-10`, `-4`, `-2`, and `0`
on the reduced canonical. The comparison-disabled control remains mandatory.
The top three complete configurations will be selected using correct matches
first, with PR-AUC and wrong matches used to break close or unsafe results.

The reduced-canonical selection was moderate uplift (`+2`, `+1`), stronger
uplift (`+3`, `+1.5`), and very strong non-signature uplift (`+4`, `+2`).
The ordered signature remained fixed at `+10` because increasing it did not
improve the reduced results.

The JSON settings are changed at runtime for these experiments only. The
production file `uk_address_matcher/data/splink_model.json` is not edited.

## Full pooled-councils experiment

The full experiment uses the virtual `pooled_councils` union of Hackney,
Rhondda, and Aberdeenshire, with the same stage sequence and comparison
settings as the MW10 matrix. The token-off baseline is evaluated at MW8, MW10,
and MW12, alongside the three highest MW10 matrix rows:

- very strong: all `+4`, some `+2`, no-token `0`;
- stronger: all `+3`, some `+1.5`, no-token `0`;
- very strong: all `+4`, some `+2`, no-token `-2`.

Every threshold table includes both the token-off baseline and the unchanged
current setup (`+1`, `+0.5`, no-token `-10`) before the experimental variants.

The strongest MW10 matrix result is very strong uplift with no-token `0`:
precision `0.988568`, recall `0.970684`, F1 `0.979545`, and PR-AUC `0.342615`.

Each table shows absolute values for the baseline and `value (delta)` for
comparisons, where deltas are relative to the baseline at that MW. `P`, `R`,
and `F1` mean precision, recall, and F1.

### MW 8

| Configuration | Correct | Wrong | Unmatched | P | R | F1 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Token-off baseline | 338,263 | 3,930 | 6,494 | 0.988515 | 0.970105 | 0.979224 |
| Current setup (`+1`, `+0.5`, `-10`) | 337,339 (-924) | 3,851 (-79) | 7,497 (+1,003) | 0.988713 (+0.000198) | 0.967455 (-0.002650) | 0.977969 (-0.001255) |
| Very strong, no-token 0 | 338,926 (+663) | 4,161 (+231) | 5,600 (-894) | 0.987872 (-0.000643) | 0.972006 (+0.001901) | 0.979875 (+0.000651) |
| Stronger, no-token 0 | 338,835 (+572) | 4,075 (+145) | 5,777 (-717) | 0.988116 (-0.000399) | 0.971745 (+0.001640) | 0.979863 (+0.000639) |
| Very strong, no-token -2 | 338,850 (+587) | 4,125 (+195) | 5,712 (-782) | 0.987973 (-0.000542) | 0.971788 (+0.001683) | 0.979814 (+0.000590) |

### MW 10

| Configuration | Correct | Wrong | Unmatched | P | R | F1 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Token-off baseline | 337,405 | 3,607 | 7,675 | 0.989423 | 0.967644 | 0.978412 |
| Current setup (`+1`, `+0.5`, `-10`) | 336,284 (-1,121) | 3,553 (-54) | 8,850 (+1,175) | 0.989545 (+0.000122) | 0.964429 (-0.003215) | 0.976826 (-0.001586) |
| Very strong, no-token 0 | 338,465 (+1,060) | 3,914 (+307) | 6,308 (-1,367) | 0.988568 (-0.000855) | 0.970684 (+0.003040) | 0.979545 (+0.001133) |
| Stronger, no-token 0 | 338,337 (+932) | 3,829 (+222) | 6,521 (-1,154) | 0.988810 (-0.000613) | 0.970317 (+0.002673) | 0.979476 (+0.001064) |
| Very strong, no-token -2 | 338,291 (+886) | 3,885 (+278) | 6,511 (-1,164) | 0.988646 (-0.000777) | 0.970185 (+0.002541) | 0.979329 (+0.000917) |

### MW 12

| Configuration | Correct | Wrong | Unmatched | P | R | F1 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Token-off baseline | 336,118 | 3,250 | 9,319 | 0.990423 | 0.963953 | 0.977009 |
| Current setup (`+1`, `+0.5`, `-10`) | 335,185 (-933) | 3,184 (-66) | 10,318 (+999) | 0.990590 (+0.000167) | 0.961278 (-0.002675) | 0.975714 (-0.001295) |
| Very strong, no-token 0 | 337,710 (+1,592) | 3,665 (+415) | 7,312 (-2,007) | 0.989264 (-0.001159) | 0.968519 (+0.004566) | 0.978782 (+0.001773) |
| Stronger, no-token 0 | 337,472 (+1,354) | 3,546 (+296) | 7,669 (-1,650) | 0.989602 (-0.000821) | 0.967836 (+0.003883) | 0.978598 (+0.001589) |
| Very strong, no-token -2 | 337,309 (+1,191) | 3,634 (+384) | 7,744 (-1,575) | 0.989341 (-0.001082) | 0.967369 (+0.003416) | 0.978232 (+0.001223) |

### Complete MW 10 matrix

The following tables retain every full pooled-councils matrix check from the
original experiment. Every row in this section is at `MW=10`; the MW8 and MW12
tables above are separate threshold checks using the selected configurations.

| Current active positive levels (`+1`, `+0.5`) | No-token | Matched | Correct | Wrong | Unmatched | P | R | F1 | PR-AUC | Run ID |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Current active | -10 | 339,837 | 336,284 | 3,553 | 8,850 | 0.989545 | 0.964429 | 0.976826 | 0.336425 | `7f28f846f368f2cf` |

| Moderate positive levels (`+2`, `+1`) | No-token | Matched | Correct | Wrong | Unmatched | P | R | F1 | PR-AUC | Run ID |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Moderate | -10 | 340,183 | 336,540 | 3,643 | 8,504 | 0.989291 | 0.965164 | 0.977078 | 0.337153 | `8e6a9fd5f1f41bf2` |
| Moderate | -4 | 341,207 | 337,570 | 3,637 | 7,480 | 0.989341 | 0.968118 | 0.978614 | 0.340088 | `2982385634b371d1` |
| Moderate | -2 | 341,681 | 337,989 | 3,692 | 7,006 | 0.989195 | 0.969319 | 0.979156 | 0.341278 | `879b950e328ffacd` |
| Moderate | 0 | 341,897 | 338,155 | 3,742 | 6,790 | 0.989055 | 0.969795 | 0.979331 | 0.341746 | `d7ad48ad591419d0` |

| Stronger positive levels (`+3`, `+1.5`) | No-token | Matched | Correct | Wrong | Unmatched | P | R | F1 | PR-AUC | Run ID |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Stronger | -10 | 340,470 | 336,729 | 3,741 | 8,217 | 0.989012 | 0.965706 | 0.977220 | 0.337684 | `1d24eb4b3ce6a82d` |
| Stronger | -4 | 341,571 | 337,812 | 3,759 | 7,116 | 0.988995 | 0.968812 | 0.978799 | 0.340764 | `304d8ae04bbedf19` |
| Stronger | -2 | 341,909 | 338,115 | 3,794 | 6,778 | 0.988903 | 0.969681 | 0.979198 | 0.341627 | `4ce081faa3020fd3` |
| Stronger | 0 | 342,166 | 338,337 | 3,829 | 6,521 | 0.988810 | 0.970317 | 0.979476 | 0.342260 | `9e8a5f16bb2d64f8` |

| Very strong positive levels (`+4`, `+2`) | No-token | Matched | Correct | Wrong | Unmatched | P | R | F1 | PR-AUC | Run ID |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Very strong | -10 | 340,718 | 336,875 | 3,843 | 7,969 | 0.988721 | 0.966124 | 0.977292 | 0.338089 | `0b3b210ef4e725ec` |
| Very strong | -4 | 341,887 | 338,001 | 3,886 | 6,800 | 0.988634 | 0.969354 | 0.978899 | 0.341295 | `b44cbce3c7133b79` |
| Very strong | -2 | 342,176 | 338,291 | 3,885 | 6,511 | 0.988646 | 0.970185 | 0.979329 | 0.342123 | `cf3dda0c4d66c289` |
| Very strong | 0 | 342,379 | 338,465 | 3,914 | 6,308 | 0.988568 | 0.970684 | 0.979545 | 0.342615 | `4a75b7345032cf94` |

The MW10 token-off baseline for these comparisons is 341,012 matched,
337,405 correct, 3,607 wrong, 7,675 unmatched, precision 0.989423, recall
0.967644, F1 0.978412, and PR-AUC 0.339517.

## Recommendation

For a recall-first candidate, I would use ordered `+10`, all tokens `+4`, some
tokens `+2`, and no-token `0`. At MW10 on pooled councils this gives `1,060`
more correct matches than the token-off baseline, with `307` additional wrong
matches; it also has the best selected MW10 F1 and PR-AUC. On the reduced
Hackney experiment it gives the most correct matches and highest PR-AUC, with
the same wrong-match count as the stronger `+3`, `+1.5`, `0` setting.

The stronger `+3`, `+1.5`, `0` setting is the conservative alternative: it gives
up `128` correct pooled-council matches for `85` fewer wrong matches at MW10.
The token-off baseline still has the highest precision, so the very-strong
setting should be treated as a validated candidate for a recall-prioritised
operating point, not as an automatic production default.

The regenerated overlays now display scores from `MW=6` upward. This changes
chart coverage only; it is not a recommendation to deploy the matcher with a
final threshold of six.

Across all three thresholds, the positive-token variants increase recall and
correct matches while also increasing wrong matches; the baseline retains the
highest precision. The gain in correct matches is largest at MW12, while the
best overall F1 among the selected rows is at MW10.

## Interpretation rules

A weight setting is promising only if it improves correct matches without a
material false-positive increase, and its PR-AUC is at least competitive with
the scoring-off baseline. A reduced-canonical winner is a candidate for full
validation, not a deployment recommendation.

The practical question is not whether distinguishing tokens are useful. They
can be highly discriminating when a positive signature or token overlap is
present. The question is whether the negative evidence for an absent token
match overwhelms the other address evidence for otherwise viable candidates.

