### PR TITLE
refactor: move to a struct to store numeric range info

### DIFF
--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -297,10 +297,10 @@ def test_legacy_prepared_canonical_keeps_canonical_raw_result_column(
     assert "original_address_concat_canonical" in result.matches(all_columns=True).columns
 
 
-def test_legacy_prepared_canonical_skips_numeric_range_reranking(
+def test_prepared_canonical_without_numeric_range_still_matches(
     con, canonical_data, messy_data, tmp_path
 ):
-    prepared_folder = tmp_path / "legacy_without_numeric_range"
+    prepared_folder = tmp_path / "without_numeric_range"
     prepare_canonical_folder(
         canonical_data,
         output_folder=prepared_folder,
@@ -309,19 +309,21 @@ def test_legacy_prepared_canonical_skips_numeric_range_reranking(
     )
 
     canonical_path = prepared_folder / "ukam_canonical_addresses.parquet"
-    legacy_path = prepared_folder / "ukam_canonical_addresses.legacy.parquet"
+    without_range_path = (
+        prepared_folder / "ukam_canonical_addresses.without_range.parquet"
+    )
     con.execute(
         f"""
         COPY (
             SELECT * EXCLUDE (
-                numeric_range_attributes
+                numeric_range
             )
             FROM read_parquet('{canonical_path}')
-        ) TO '{legacy_path}' (FORMAT PARQUET, COMPRESSION ZSTD)
+        ) TO '{without_range_path}' (FORMAT PARQUET, COMPRESSION ZSTD)
         """
     )
     canonical_path.unlink()
-    legacy_path.rename(canonical_path)
+    without_range_path.rename(canonical_path)
 
     result = AddressMatcher(
         canonical_addresses=prepared_folder,

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -159,23 +159,47 @@ def test_align_distinguishing_tokens_adds_typed_empty_and_preserves_values(duck_
     )
 
 
-def test_align_numeric_range_columns_adds_typed_null_endpoints(duck_con):
+def test_align_numeric_range_columns_adds_typed_null_struct(duck_con):
     messy = duck_con.sql("SELECT 1 AS unique_id")
-    canonical = duck_con.sql("SELECT 2 AS unique_id, 20::UINTEGER AS numeric_range_start")
+    canonical = duck_con.sql(
+        """
+        SELECT
+            2 AS unique_id,
+            struct_pack(
+                raw := '20-23',
+                lower := 20::UINTEGER,
+                upper := 23::UINTEGER,
+                width := 3::UINTEGER,
+                lower_suffix := NULL::VARCHAR,
+                upper_suffix := NULL::VARCHAR,
+                role := 1::UTINYINT,
+                flags := 0::UTINYINT,
+                lower_tf := NULL::DOUBLE
+            ) AS numeric_range
+        """
+    )
 
     aligned_messy, aligned_canonical = _align_numeric_range_columns(
         messy,
         canonical,
     )
 
-    assert aligned_messy.project("numeric_range_start, numeric_range_end").fetchone() == (
-        None,
-        None,
+    assert aligned_messy.project("numeric_range").fetchone() == (None,)
+    assert aligned_messy.project(
+        "numeric_range_lower, numeric_range_upper"
+    ).fetchone() == (None, None)
+    assert aligned_canonical.project(
+        "numeric_range.lower, numeric_range.upper"
+    ).fetchone() == (
+        20,
+        23,
     )
     assert aligned_canonical.project(
-        "numeric_range_start, numeric_range_end"
-    ).fetchone() == (20, None)
-    assert str(aligned_messy.types[-2:]) == "[UINTEGER, UINTEGER]"
+        "numeric_range_lower, numeric_range_upper"
+    ).fetchone() == (20, 23)
+    range_type = aligned_messy.types[aligned_messy.columns.index("numeric_range")]
+    assert "lower UINTEGER" in str(range_type)
+    assert "lower_tf DOUBLE" in str(range_type)
 
 
 def test_packaged_distinguishing_token_comparison_has_exact_fixed_weights():

--- a/tests/test_numeric_range_reranker.py
+++ b/tests/test_numeric_range_reranker.py
@@ -5,7 +5,7 @@ from uk_address_matcher.post_linkage.distinguishing_features.numeric_range impor
     NumericRangeRerankerConfig,
     build_numeric_range_adjustments,
     build_numeric_range_candidate_pool,
-    ensure_numeric_range_metadata,
+    ensure_numeric_range_struct,
 )
 
 _RANGE_TYPE = (
@@ -32,14 +32,14 @@ def _attribute(
     return (
         "struct_pack("
         f"raw := '{raw}', lower := {lower}::UINTEGER, "
-        f"upper := {upper}::UINTEGER, width := {upper - lower}::UINTEGER, "
+        f"upper := {upper}::UINTEGER, width := {max(0, upper - lower)}::UINTEGER, "
         f"lower_suffix := {lower_suffix_sql}, upper_suffix := {upper_suffix_sql}, "
         f"role := {role}::UTINYINT, flags := {flags}::UTINYINT, "
         f"lower_tf := {lower_tf_sql})"
     )
 
 
-def test_legacy_numeric_range_is_normalised_for_reranking():
+def test_numeric_range_struct_is_preserved_for_reranking():
     con = duckdb.connect()
     relation = con.sql("""
         SELECT
@@ -58,11 +58,24 @@ def test_legacy_numeric_range_is_normalised_for_reranking():
             ) AS numeric_range
     """)
 
-    metadata = ensure_numeric_range_metadata(con, relation)
-    range_metadata = metadata.select("numeric_range_metadata").fetchone()[0]
+    normalised = ensure_numeric_range_struct(relation)
+    numeric_range = normalised.select("numeric_range").fetchone()[0]
 
-    assert range_metadata["range_count"] == 1
-    assert range_metadata["range_attributes"][0]["lower"] == 20
+    assert numeric_range["lower"] == 20
+    assert numeric_range["upper"] == 23
+
+
+def test_missing_numeric_range_is_normalised_to_typed_null():
+    con = duckdb.connect()
+    relation = con.sql("SELECT 'C1' AS unique_id")
+
+    normalised = ensure_numeric_range_struct(relation)
+    numeric_range = normalised.select("numeric_range").fetchone()[0]
+
+    assert numeric_range is None
+    range_type = normalised.types[normalised.columns.index("numeric_range")]
+    assert "lower UINTEGER" in str(range_type)
+    assert "lower_tf DOUBLE" in str(range_type)
 
 
 def test_splink_owns_numeric_range_reranker_configuration():
@@ -294,11 +307,15 @@ def _range_candidates(con):
             scalar_value if suffix_value == "NULL" else scalar_value + suffix_value
         )
         numeric_tokens_sql = f"['{numeric_token}']::VARCHAR[]"
+        range_l_sql = (
+            f"NULL::{_RANGE_TYPE}" if count_l == 0 else f"list_extract({attrs_l}, 1)"
+        )
+        range_r_sql = (
+            f"NULL::{_RANGE_TYPE}" if count_r == 0 else f"list_extract({attrs_r}, 1)"
+        )
         value_rows.append(
             f"('{case_id}', 'L{index}', 'R{index}', {index}, {index + 1000}, "
-            f"{count_l}::UTINYINT, {attrs_l}, {count_r}::UTINYINT, {attrs_r}, "
-            f"{scalars_l}::UINTEGER[], {suffixes_l}::VARCHAR[], {roles_l}::UTINYINT[], "
-            f"{scalars_l}::UINTEGER[], {suffixes_l}::VARCHAR[], {roles_l}::UTINYINT[], "
+            f"{range_l_sql}, {range_r_sql}, "
             f"{numeric_tokens_sql}, {numeric_tokens_sql}, "
             f"{flat_l}::VARCHAR, {flat_r}::VARCHAR, {legacy}::DOUBLE, {weight}::DOUBLE)"
         )
@@ -309,37 +326,14 @@ def _range_candidates(con):
         ) AS candidates(
             case_id, unique_id_l, unique_id_r,
             ukam_address_id_l, ukam_address_id_r,
-            numeric_range_count_l, numeric_range_attributes_l,
-            numeric_range_count_r, numeric_range_attributes_r,
-            numeric_scalar_tokens_l, numeric_scalar_suffixes_l,
-            numeric_scalar_roles_l, numeric_scalar_tokens_r,
-            numeric_scalar_suffixes_r, numeric_scalar_roles_r,
+            numeric_range_l, numeric_range_r,
             numeric_tokens_l, numeric_tokens_r,
             flat_identity_l, flat_identity_r,
             legacy_numeric_bits, match_weight
         )
         """
     )
-    return con.sql(
-        f"""
-        SELECT
-            * EXCLUDE (
-                numeric_range_count_l,
-                numeric_range_attributes_l,
-                numeric_range_count_r,
-                numeric_range_attributes_r
-            ),
-            struct_pack(
-                range_count := numeric_range_count_l,
-                range_attributes := numeric_range_attributes_l
-            ) AS numeric_range_metadata_l,
-            struct_pack(
-                range_count := numeric_range_count_r,
-                range_attributes := numeric_range_attributes_r
-            ) AS numeric_range_metadata_r
-        FROM ({relation.sql_query()}) AS relation
-        """
-    )
+    return relation
 
 
 def test_numeric_range_adjustments_are_postcode_agnostic_and_guarded():
@@ -374,7 +368,7 @@ def test_numeric_range_adjustments_are_postcode_agnostic_and_guarded():
     assert rows["L11"] == ("scalar_range_endpoint", True, 5.0)
     assert rows["L12"] == ("scalar_range_endpoint", True, 0.0)
     assert rows["L13"][0:2] == ("scalar_range_endpoint", True)
-    assert "L14" not in rows
+    assert rows["L14"][0:2] == ("scalar_range_endpoint", True)
 
 
 def test_numeric_range_adjustment_respects_configured_cap():
@@ -395,17 +389,13 @@ def test_numeric_range_adjustment_respects_configured_cap():
 
 def test_numeric_range_candidate_pool_can_rescue_raw_rank_six():
     con = duckdb.connect()
-    empty = f"[]::{_RANGE_TYPE}[]"
+    empty = f"NULL::{_RANGE_TYPE}"
     candidate_rows = []
     for rank in range(1, 7):
-        range_count = 1 if rank == 6 else 0
-        range_attributes = f"[{_attribute('20-23', 20, 23)}]" if rank == 6 else empty
+        numeric_range = _attribute("20-23", 20, 23) if rank == 6 else empty
         candidate_rows.append(
             f"('L{rank}', 'M', {rank}, 100, {21.0 - rank}::DOUBLE, "
-            f"{range_count}::UTINYINT, {range_attributes}, "
-            f"0::UTINYINT, {empty}, ['20']::VARCHAR[], ['20']::VARCHAR[], "
-            "[20]::UINTEGER[], [NULL]::VARCHAR[], [0]::UTINYINT[], "
-            "[20]::UINTEGER[], [NULL]::VARCHAR[], [0]::UTINYINT[], "
+            f"{numeric_range}, {empty}, ['20']::VARCHAR[], ['20']::VARCHAR[], "
             "NULL::VARCHAR, NULL::VARCHAR, "
             "2.0::DOUBLE, 1.0::DOUBLE, 1.0::DOUBLE, "
             "1.0::DOUBLE, 1.0::DOUBLE, 1.0::DOUBLE)"
@@ -414,31 +404,14 @@ def test_numeric_range_candidate_pool_can_rescue_raw_rank_six():
         WITH candidates AS (
             SELECT * FROM (VALUES {", ".join(candidate_rows)}) AS rows(
                 unique_id_l, unique_id_r, ukam_address_id_l, ukam_address_id_r,
-                match_weight, range_count_l, range_attributes_l,
-                range_count_r, range_attributes_r, numeric_tokens_l,
-                numeric_tokens_r, numeric_scalar_tokens_l,
-                numeric_scalar_suffixes_l, numeric_scalar_roles_l,
-                numeric_scalar_tokens_r, numeric_scalar_suffixes_r,
-                numeric_scalar_roles_r, flat_identity_l, flat_identity_r,
+                match_weight, numeric_range_l, numeric_range_r,
+                numeric_tokens_l, numeric_tokens_r, flat_identity_l, flat_identity_r,
                 bf_numeric_token_1, bf_numeric_token_2, bf_numeric_token_3,
                 bf_tf_adj_numeric_token_1, bf_tf_adj_numeric_token_2,
                 bf_tf_adj_numeric_token_3
             )
         )
-        SELECT
-            * EXCLUDE (
-                range_count_l, range_attributes_l,
-                range_count_r, range_attributes_r
-            ),
-            struct_pack(
-                range_count := range_count_l,
-                range_attributes := range_attributes_l
-            ) AS numeric_range_metadata_l,
-            struct_pack(
-                range_count := range_count_r,
-                range_attributes := range_attributes_r
-            ) AS numeric_range_metadata_r
-        FROM candidates
+        SELECT * FROM candidates
     """)
 
     result = build_numeric_range_candidate_pool(
@@ -481,14 +454,16 @@ def test_numeric_window_metadata_is_derived_only_from_supported_tokens():
     )
     matcher._resolve_canonical_data()
     rows = (
-        matcher._canonical_clean.project("unique_id, numeric_range_attributes")
+        matcher._canonical_clean.project("unique_id, numeric_range")
         .order("unique_id")
         .fetchall()
     )
 
-    assert len(rows[0][1]) == 1
+    assert rows[0][1]["lower"] == 20
+    assert rows[0][1]["upper"] == 23
     assert rows[1][1] is None
-    assert len(rows[2][1]) == 1
+    assert rows[2][1]["lower"] == 20
+    assert rows[2][1]["upper"] == 23
     con.close()
 
 
@@ -519,9 +494,8 @@ def test_enabled_splink_path_collapses_intermediate_numeric_columns():
     prediction_columns = con.table(stage.predictions_table).columns
 
     assert "legacy_numeric_bits" not in prediction_columns
-    assert "numeric_range_metadata_l" in prediction_columns
-    assert "numeric_range_metadata_r" in prediction_columns
-    assert "numeric_range_count_l" not in prediction_columns
+    assert "numeric_range_l" in prediction_columns
+    assert "numeric_range_r" in prediction_columns
     assert not any(column.startswith("bf_") for column in prediction_columns)
     assert not any(column.startswith("gamma_") for column in prediction_columns)
     assert not any(column.startswith("tf_") for column in prediction_columns)

--- a/uk_address_matcher/cleaning/pipelines.py
+++ b/uk_address_matcher/cleaning/pipelines.py
@@ -189,7 +189,7 @@ def _clean_data_using_precomputed_rel_tok_freq(
         _add_term_frequencies_to_address_tokens_using_registered_df,
         _add_numeric_term_frequencies_using_registered_df,
     ] + QUEUE_POST_TF
-    if "numeric_range_attributes" in address_table.columns:
+    if not pre_cleaned_addresses or "numeric_range" in address_table.columns:
         tf_and_post.insert(2, _add_numeric_range_lower_endpoint_tf)
     stage_queue = (
         pre_queue + tf_and_post + additional_stages

--- a/uk_address_matcher/cleaning/steps/numeric_ranges.py
+++ b/uk_address_matcher/cleaning/steps/numeric_ranges.py
@@ -107,56 +107,11 @@ def _derive_numeric_range(
     )
     SELECT
         * EXCLUDE (range_tokens, parsed_range_attributes),
-        len(parsed_range_attributes)::UINTEGER AS numeric_range_count,
-        list_extract(parsed_range_attributes, 1).lower AS numeric_range_start,
-        list_extract(parsed_range_attributes, 1).upper AS numeric_range_end,
-        list_extract(parsed_range_attributes, 1).lower_suffix
-            AS numeric_range_start_suffix,
-        list_extract(parsed_range_attributes, 1).upper_suffix
-            AS numeric_range_end_suffix,
-        list_extract(parsed_range_attributes, 1).role AS numeric_range_role,
-        list_extract(parsed_range_attributes, 1).flags AS numeric_range_flags,
-        list_transform(
-            list_filter(
-                numeric_tokens,
-                token -> NOT regexp_matches(
-                    token,
-                    '^\\d{{1,5}}[A-Z]?-\\d{{1,5}}[A-Z]?$'
-                )
-            ),
-            token -> TRY_CAST(regexp_extract(token, '\\d{{1,5}}', 0) AS UINTEGER)
-        ) AS numeric_scalar_tokens,
-        list_transform(
-            list_filter(
-                numeric_tokens,
-                token -> NOT regexp_matches(
-                    token,
-                    '^\\d{{1,5}}[A-Z]?-\\d{{1,5}}[A-Z]?$'
-                )
-            ),
-            token -> NULLIF(regexp_replace(token, '\\d', '', 'g'), '')
-        ) AS numeric_scalar_suffixes,
-        list_transform(
-            list_filter(
-                numeric_tokens,
-                token -> NOT regexp_matches(
-                    token,
-                    '^\\d{{1,5}}[A-Z]?-\\d{{1,5}}[A-Z]?$'
-                )
-            ),
-            token -> 0::UTINYINT
-        ) AS numeric_scalar_roles,
         CASE
-            WHEN len(list_filter(
-                parsed_range_attributes,
-                attribute -> (attribute.flags & 27) = 0
-            )) > 0
-            THEN list_filter(
-                parsed_range_attributes,
-                attribute -> (attribute.flags & 27) = 0
-            )
+            WHEN len(parsed_range_attributes) > 0
+            THEN list_extract(parsed_range_attributes, 1)
             ELSE NULL
-        END AS numeric_range_attributes
+        END AS numeric_range
     FROM range_attributes
     """
 
@@ -167,7 +122,7 @@ def _derive_numeric_range(
     tags=["term_frequency"],
 )
 def _add_numeric_range_lower_endpoint_tf() -> str:
-    """Add lower-endpoint TF without carrying numeric TF columns downstream."""
+    """Add lower-endpoint TF to the nullable numeric-range struct."""
     return """
     WITH tf_lookup AS (
         SELECT
@@ -178,23 +133,23 @@ def _add_numeric_range_lower_endpoint_tf() -> str:
         FROM __ukam__tmp_numeric_term_frequencies
     )
     SELECT
-        input.* EXCLUDE (numeric_range_attributes),
-        list_transform(
-            input.numeric_range_attributes,
-            attribute -> struct_pack(
-                raw := attribute.raw,
-                lower := attribute.lower,
-                upper := attribute.upper,
-                width := attribute.width,
-                lower_suffix := attribute.lower_suffix,
-                upper_suffix := attribute.upper_suffix,
-                role := attribute.role,
-                flags := attribute.flags,
+        input.* EXCLUDE (numeric_range),
+        CASE
+            WHEN input.numeric_range IS NULL THEN NULL
+            ELSE struct_pack(
+                raw := input.numeric_range.raw,
+                lower := input.numeric_range.lower,
+                upper := input.numeric_range.upper,
+                width := input.numeric_range.width,
+                lower_suffix := input.numeric_range.lower_suffix,
+                upper_suffix := input.numeric_range.upper_suffix,
+                role := input.numeric_range.role,
+                flags := input.numeric_range.flags,
                 lower_tf := lookup.values[
-                    CAST(attribute.lower AS VARCHAR)
+                    CAST(input.numeric_range.lower AS VARCHAR)
                 ]
             )
-        ) AS numeric_range_attributes
+        END AS numeric_range
     FROM {input} AS input
     CROSS JOIN tf_lookup AS lookup
     """

--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -53,7 +53,7 @@
       "sql_dialect": "duckdb"
     },
     {
-      "blocking_rule": "l.postcode = r.postcode AND l.numeric_range_start = r.numeric_range_start AND l.numeric_range_end = r.numeric_range_end",
+      "blocking_rule": "l.postcode = r.postcode AND l.numeric_range IS NOT NULL AND r.numeric_range IS NOT NULL AND l.numeric_range_lower = r.numeric_range_lower AND l.numeric_range_upper = r.numeric_range_upper",
       "sql_dialect": "duckdb"
     },
     {

--- a/uk_address_matcher/linking_model/matching/stages/splink.py
+++ b/uk_address_matcher/linking_model/matching/stages/splink.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from uk_address_matcher.linking_model.matching.stages.base_stage import MatchingStage
 from uk_address_matcher.post_linkage.distinguishing_features.numeric_range import (
     NumericRangeRerankerConfig,
-    ensure_numeric_range_metadata,
+    ensure_numeric_range_struct,
     project_splink_predictions,
 )
 
@@ -129,41 +129,25 @@ class SplinkStage(MatchingStage):
             return None
 
         numeric_range_reranker = NumericRangeRerankerConfig()
-        range_source_columns = {"numeric_range_attributes", "numeric_range"}
         range_metadata_available = (
-            bool(range_source_columns.intersection(df_canonical.columns))
-            and bool(range_source_columns.intersection(df_unmatched.columns))
+            "numeric_range" in df_canonical.columns
+            and "numeric_range" in df_unmatched.columns
             and "numeric_tokens" in df_canonical.columns
             and "numeric_tokens" in df_unmatched.columns
             and "flat_identity" in df_canonical.columns
             and "flat_identity" in df_unmatched.columns
         )
         if range_metadata_available:
-            df_unmatched = ensure_numeric_range_metadata(con, df_unmatched)
-            df_canonical = ensure_numeric_range_metadata(con, df_canonical)
+            df_unmatched = ensure_numeric_range_struct(df_unmatched)
+            df_canonical = ensure_numeric_range_struct(df_canonical)
             range_input_columns = [
-                "numeric_range_metadata",
+                "numeric_range",
                 "numeric_tokens",
                 "flat_identity",
             ]
         else:
             numeric_range_reranker = None
             range_input_columns = []
-            range_columns_to_drop = [
-                column
-                for column in (
-                    "numeric_range_attributes",
-                    "numeric_range_metadata",
-                    "numeric_scalar_tokens",
-                    "numeric_scalar_suffixes",
-                    "numeric_scalar_roles",
-                )
-                if column in df_unmatched.columns and column not in df_canonical.columns
-            ]
-            if range_columns_to_drop:
-                df_unmatched = df_unmatched.select(
-                    f"* EXCLUDE ({', '.join(range_columns_to_drop)})"
-                )
         linker_columns = list(self.additional_columns_to_retain or [])
         linker_columns.extend(range_input_columns)
         linker_columns = list(dict.fromkeys(linker_columns))

--- a/uk_address_matcher/linking_model/splink_model.py
+++ b/uk_address_matcher/linking_model/splink_model.py
@@ -6,6 +6,9 @@ from contextlib import contextmanager
 from duckdb import DuckDBPyConnection, DuckDBPyRelation
 from splink import DuckDBAPI, Linker, SettingsCreator
 
+from uk_address_matcher.post_linkage.distinguishing_features.numeric_range import (
+    ensure_numeric_range_struct,
+)
 from uk_address_matcher.sql_pipeline.helpers import package_resource_read_sql
 
 _SPLINK_SETTINGS_LOGGER = "splink.internals.settings"
@@ -96,26 +99,19 @@ def _align_numeric_range_columns(
     df_addresses_to_match: DuckDBPyRelation,
     df_addresses_to_search_within: DuckDBPyRelation,
 ) -> tuple[DuckDBPyRelation, DuckDBPyRelation]:
-    """Add typed nullable range endpoints where an input schema lacks them."""
+    """Normalise both inputs to one nullable numeric-range struct."""
 
     def align_relation(relation: DuckDBPyRelation) -> DuckDBPyRelation:
-        missing_columns = [
-            column
-            for column in ("numeric_range_start", "numeric_range_end")
-            if column not in relation.columns
+        relation = ensure_numeric_range_struct(relation)
+        aliases = [
+            f"numeric_range.{field} AS numeric_range_{field}"
+            for field in ("lower", "upper")
+            if f"numeric_range_{field}" not in relation.columns
         ]
-        if missing_columns:
-            relation = relation.select(
-                "*, "
-                + ", ".join(
-                    f"CAST(NULL AS UINTEGER) AS {column}" for column in missing_columns
-                )
-            )
-        return relation
+        return relation.select("*, " + ", ".join(aliases)) if aliases else relation
 
-    return (
-        align_relation(df_addresses_to_match),
-        align_relation(df_addresses_to_search_within),
+    return align_relation(df_addresses_to_match), align_relation(
+        df_addresses_to_search_within
     )
 
 

--- a/uk_address_matcher/post_linkage/distinguishing_features/numeric_range.py
+++ b/uk_address_matcher/post_linkage/distinguishing_features/numeric_range.py
@@ -22,8 +22,8 @@ class NumericRangeRerankerConfig:
 
 
 _RANGE_STRUCT_COLUMNS = {
-    "numeric_range_metadata_l",
-    "numeric_range_metadata_r",
+    "numeric_range_l",
+    "numeric_range_r",
     "numeric_tokens_l",
     "numeric_tokens_r",
     "flat_identity_l",
@@ -43,121 +43,22 @@ _LEGACY_NUMERIC_FACTOR_COLUMNS = [
     *(f"bf_tf_adj_numeric_token_{position}" for position in range(1, 4)),
 ]
 
+_NUMERIC_RANGE_STRUCT_TYPE = (
+    "STRUCT(raw VARCHAR, lower UINTEGER, upper UINTEGER, width UINTEGER, "
+    "lower_suffix VARCHAR, upper_suffix VARCHAR, role UTINYINT, "
+    "flags UTINYINT, lower_tf DOUBLE)"
+)
 
-def ensure_numeric_range_metadata(
-    con: duckdb.DuckDBPyConnection,
+
+def ensure_numeric_range_struct(
     relation: duckdb.DuckDBPyRelation,
 ) -> duckdb.DuckDBPyRelation:
-    """Expose nullable valid range attributes as one internal struct."""
-    if "numeric_range_metadata" in relation.columns:
+    """Expose the current numeric-range struct, or a typed NULL when absent."""
+    if "numeric_range" in relation.columns:
         return relation
-
-    missing_columns = []
-    if "numeric_tokens" not in relation.columns:
-        missing_columns.append("numeric_tokens")
-    if not {"numeric_range_attributes", "numeric_range"}.intersection(relation.columns):
-        missing_columns.append("numeric_range_attributes or numeric_range")
-    if missing_columns:
-        raise ValueError(
-            "Numeric-range reranking requires numeric_range_metadata or these "
-            f"columns: {', '.join(missing_columns)}"
-        )
-    if "numeric_range_attributes" not in relation.columns:
-        return con.sql(f"""
-            WITH input AS (
-                SELECT *
-                FROM ({relation.sql_query()}) AS input
-            ),
-            attributes AS (
-                SELECT
-                    input.* EXCLUDE (numeric_range),
-                    CASE
-                        WHEN numeric_range IS NULL THEN NULL
-                        ELSE [struct_pack(
-                            raw := numeric_range.raw,
-                            lower := numeric_range.lower,
-                            upper := numeric_range.upper,
-                            width := numeric_range.width,
-                            lower_suffix := NULL::VARCHAR,
-                            upper_suffix := NULL::VARCHAR,
-                            role := 1::UTINYINT,
-                            flags := 0::UTINYINT,
-                            lower_tf := NULL::DOUBLE
-                        )]
-                    END AS numeric_range_attributes
-                FROM input
-            )
-            SELECT
-                attributes.* EXCLUDE (numeric_range_attributes),
-                COALESCE(len(numeric_range_attributes), 0)::UINTEGER
-                    AS numeric_range_count,
-                list_extract(numeric_range_attributes, 1).lower
-                    AS numeric_range_start,
-                list_extract(numeric_range_attributes, 1).upper
-                    AS numeric_range_end,
-                list_extract(numeric_range_attributes, 1).lower_suffix
-                    AS numeric_range_start_suffix,
-                list_extract(numeric_range_attributes, 1).upper_suffix
-                    AS numeric_range_end_suffix,
-                list_extract(numeric_range_attributes, 1).role
-                    AS numeric_range_role,
-                list_extract(numeric_range_attributes, 1).flags
-                    AS numeric_range_flags,
-                list_transform(
-                    list_filter(
-                        numeric_tokens,
-                        token -> NOT regexp_matches(
-                            token,
-                            '^\\d{{1,5}}[A-Z]?-\\d{{1,5}}[A-Z]?$'
-                        )
-                    ),
-                    token -> TRY_CAST(
-                        regexp_extract(token, '\\d{{1,5}}', 0) AS UINTEGER
-                    )
-                ) AS numeric_scalar_tokens,
-                list_transform(
-                    list_filter(
-                        numeric_tokens,
-                        token -> NOT regexp_matches(
-                            token,
-                            '^\\d{{1,5}}[A-Z]?-\\d{{1,5}}[A-Z]?$'
-                        )
-                    ),
-                    token -> NULLIF(regexp_replace(token, '\\d', '', 'g'), '')
-                ) AS numeric_scalar_suffixes,
-                list_transform(
-                    list_filter(
-                        numeric_tokens,
-                        token -> NOT regexp_matches(
-                            token,
-                            '^\\d{{1,5}}[A-Z]?-\\d{{1,5}}[A-Z]?$'
-                        )
-                    ),
-                    token -> 0::UTINYINT
-                ) AS numeric_scalar_roles,
-                numeric_range_attributes,
-                CASE
-                    WHEN numeric_range_attributes IS NULL THEN NULL
-                    ELSE struct_pack(
-                        range_count := len(numeric_range_attributes)::UTINYINT,
-                        range_attributes := numeric_range_attributes
-                    )
-                END AS numeric_range_metadata
-            FROM attributes
-        """)
-
-    return con.sql(f"""
-        SELECT
-            input.* EXCLUDE (numeric_range_attributes),
-            CASE
-                WHEN numeric_range_attributes IS NULL THEN NULL
-                ELSE struct_pack(
-                    range_count := len(numeric_range_attributes)::UTINYINT,
-                    range_attributes := numeric_range_attributes
-                )
-            END AS numeric_range_metadata
-        FROM ({relation.sql_query()}) AS input
-    """)
+    return relation.select(
+        f"*, CAST(NULL AS {_NUMERIC_RANGE_STRUCT_TYPE}) AS numeric_range"
+    )
 
 
 def _validate_legacy_numeric_factors(relation: duckdb.DuckDBPyRelation) -> None:
@@ -212,29 +113,12 @@ def add_legacy_numeric_bits(
 
 
 def _stable_prediction_columns(relation: duckdb.DuckDBPyRelation) -> list[str]:
-    range_blocking_columns = {
-        f"{column}_{side}"
-        for column in (
-            "numeric_range_count",
-            "numeric_range_start",
-            "numeric_range_end",
-            "numeric_range_start_suffix",
-            "numeric_range_end_suffix",
-            "numeric_range_role",
-            "numeric_range_flags",
-            "numeric_scalar_tokens",
-            "numeric_scalar_suffixes",
-            "numeric_scalar_roles",
-        )
-        for side in ("l", "r")
-    }
     excluded_columns = {
         column
         for column in relation.columns
         if column.startswith(("gamma_", "bf_", "tf_"))
         or column.startswith("numeric_token_")
         or column == "legacy_numeric_bits"
-        or column in range_blocking_columns
     }
     return [column for column in relation.columns if column not in excluded_columns]
 
@@ -427,12 +311,12 @@ def _materialise_numeric_range_adjustments(
         SELECT {", ".join(range_candidate_columns)}
         FROM ({relation.sql_query()}) AS candidates
         WHERE (
-            COALESCE(numeric_range_metadata_l.range_count, 0) = 1
-            AND COALESCE(numeric_range_metadata_r.range_count, 0) = 0
+            numeric_range_l IS NOT NULL
+            AND numeric_range_r IS NULL
         )
         OR (
-            COALESCE(numeric_range_metadata_l.range_count, 0) = 0
-            AND COALESCE(numeric_range_metadata_r.range_count, 0) = 1
+            numeric_range_l IS NULL
+            AND numeric_range_r IS NOT NULL
         )
     """)
     range_candidates_with_bits = add_legacy_numeric_bits(con, range_candidates)
@@ -475,12 +359,12 @@ def build_numeric_range_adjustments(
         SELECT *
         FROM {source_name} AS candidate
         WHERE (
-            COALESCE(numeric_range_metadata_l.range_count, 0) = 1
-            AND COALESCE(numeric_range_metadata_r.range_count, 0) = 0
+            numeric_range_l IS NOT NULL
+            AND numeric_range_r IS NULL
         )
         OR (
-            COALESCE(numeric_range_metadata_l.range_count, 0) = 0
-            AND COALESCE(numeric_range_metadata_r.range_count, 0) = 1
+            numeric_range_l IS NULL
+            AND numeric_range_r IS NOT NULL
         )
     """).create(range_candidate_name)
 
@@ -489,18 +373,8 @@ def build_numeric_range_adjustments(
         WITH attributes AS (
             SELECT
                 candidate.*,
-                CASE WHEN COALESCE(numeric_range_metadata_l.range_count, 0) = 1
-                    THEN list_extract(
-                        numeric_range_metadata_l.range_attributes, 1
-                    )
-                    ELSE NULL
-                END AS range_l,
-                CASE WHEN COALESCE(numeric_range_metadata_r.range_count, 0) = 1
-                    THEN list_extract(
-                        numeric_range_metadata_r.range_attributes, 1
-                    )
-                    ELSE NULL
-                END AS range_r,
+                numeric_range_l AS range_l,
+                numeric_range_r AS range_r,
                 match_weight - legacy_numeric_bits AS non_numeric_bits
             FROM {range_candidate_name} AS candidate
         ),

--- a/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
+++ b/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
@@ -31,8 +31,8 @@ def improve_predictions_using_distinguishing_tokens(
 
     if numeric_range_reranker is not None:
         required_range_columns = {
-            "numeric_range_metadata_l",
-            "numeric_range_metadata_r",
+            "numeric_range_l",
+            "numeric_range_r",
             "numeric_tokens_l",
             "numeric_tokens_r",
             "flat_identity_l",


### PR DESCRIPTION
## Summary

- Add live progress bars and quieter stage-level logging.
- Support reading canonical data from and writing prepared artefacts to cloud storage.
- Standardise persisted numeric ranges as one nullable typed `numeric_range` struct, including `lower_tf`.
- Add typed-NULL handling for missing range data and remove legacy persisted-schema support.
- Add focused regression tests and benchmark coverage.

## Validation

- Hackney benchmarks completed with and without the prepared `numeric_range` column.
- Precision: 0.994506 with the column vs 0.994486 without it & Recall: 0.986152 with the column vs 0.985863 without it -> same results we were getting with this across multiple columns.

The benchmark varied the prepared canonical input because the raw Hackney loader projects away arbitrary source columns.