### PR TITLE
refactor: canonical preparation and improve performance metrics

### DIFF
--- a/docs/experiments/canonical_preparation_performance_2026-08-30.md
+++ b/docs/experiments/canonical_preparation_performance_2026-08-30.md
@@ -1,0 +1,418 @@
+# Canonical preparation performance, 2026-08-30
+
+## Scope
+
+This report measures the public `prepare_canonical_folder()` path on the configured
+71,438,939-row NGD parquet, not the road parser in isolation. The benchmark machine
+used 14 DuckDB threads, a 16 GB DuckDB memory limit, 10 work chunks, and eight
+canonical output shards. Peak RSS is the process high-water mark reported by macOS.
+
+The High-equivalent target is at most 480 seconds without changing canonical row
+values, term frequencies, IDs, ordering, or inverted-index postings. Proposed
+Medium and Low profiles may omit features only after labelled end-to-end accuracy
+measurement.
+
+## Current refactored result
+
+The current spill-aware v2 path completed in **537.531s (8m 57.5s)**. This is the
+current production timing: 39.0% faster than optimized v1, 72.0% faster than the
+matched road-enabled baseline, and 42.4% faster than the no-road baseline while
+retaining road features. It remains 57.531s above the strict 480s High-profile
+target.
+
+Three boundaries are useful when discussing how long "cleaning" takes:
+
+| Boundary | Elapsed | Meaning |
+| --- | ---: | --- |
+| Foundational address cleaning complete | 61.672s (1m 01.7s) | Address normalization, parsing, and pre-TF feature derivation |
+| Canonical rows finalized | 328.845s (5m 28.8s) | IDs, adjacent distinguishing, TF features, and all finalized canonical columns |
+| Prepared folder complete | 537.531s (8m 57.5s) | Canonical rows plus indexes, roads, Parquet serialization, and manifest |
+
+| Measure | Result |
+| --- | ---: |
+| Canonical rows | 71,438,939 |
+| Term-frequency rows | 926,832 |
+| Inverted-index rows | 61,562,885 |
+| Roads assigned | 62,859,358 |
+| Peak RSS | 18,661,588,992 bytes (17.38 GiB) |
+| Maximum observed spill | about 97 GB |
+| Prepared output | 1,928,966,850 bytes |
+| Size change from road baseline | +2.20% |
+
+The measured v2 boundaries were:
+
+| Stage | Time | Runtime share | Cumulative |
+| --- | ---: | ---: | ---: |
+| Shared foundational cleaning | 61.672s | 11.47% | 1m 01.7s |
+| Deterministic ID assignment | 111.690s | 20.78% | 2m 53.4s |
+| TF aggregation from shared clean data | 2.442s | 0.45% | 2m 55.8s |
+| Adjacent distinguishing | 71.897s | 13.38% | 4m 07.7s |
+| Post-TF processing | 80.876s | 15.05% | 5m 28.6s |
+| In-place finalization | 0.268s | 0.05% | 5m 28.8s |
+| Bigram and trigram indexes | 65.606s | 12.21% | 6m 34.5s |
+| Road enrichment under integrated spill pressure | 64.715s | 12.04% | 7m 39.2s |
+| TF/index serialization and canonical exports | 76.720s | 14.27% | 8m 55.9s |
+| Manifest finalization | 1.277s | 0.24% | 8m 57.2s |
+
+These boundaries account for 537.163s, or 99.93% of wall time; unlabelled setup and
+transitions total only 0.368s. End-to-end throughput is approximately 132,900 input
+rows per second, or 7.52 seconds per million rows. Index construction emits about
+938,000 index rows per second, road enrichment assigns about 971,000 roads per
+second, and the combined artifact serialization phase writes at an effective
+25.1 MB/s.
+
+The range path cut post-TF work by 140.758s and in-place finalization saved
+49.162s. Preserving the processed table's physical ID locality also reduced artifact
+serialization and canonical export from 239.655s to 76.720s. The full v2 audit found
+zero TF or index differences and zero physical-order violations in all eight shards.
+It found 802 bidirectional canonical differences, representing 401 rows; all become
+zero after normalizing only the order of `unusual_tokens_arr` and
+`extremely_unusual_tokens_arr`. This is the expected deterministic equal-frequency
+tie correction, with every other persisted value unchanged.
+
+## Historical baselines
+
+The completed no-road run produced:
+
+| Measure | Result |
+| --- | ---: |
+| Rows | 71,438,939 |
+| Total | 933.141s (15m 33.1s) |
+| Peak RSS | 20,087,422,976 bytes (18.71 GiB) |
+| Maximum observed DuckDB spill | at least 70 GB |
+| Prepared canonical output | 1,865,917,369 bytes |
+| Term-frequency rows | 926,832 |
+| Inverted-index rows | 61,562,885 |
+
+Its retained artifact timestamps provide only a coarse split: derivation and TF
+serialization took about 724s, index serialization 28s, eight canonical writes
+about 180s, and manifest finalization about 1s.
+
+A matched road-enabled diagnostic run retained event boundaries. The exact observed
+increments through inverted-index completion were:
+
+| Rank | Stage or interval | Time |
+| ---: | --- | ---: |
+| 1 | Trigram inverted index | 388.437s |
+| 2 | Bigram inverted index | 342.515s |
+| 3 | TF application | 222.694s |
+| 4 | ID assignment plus adjacent distinguishing | 159.851s |
+| 5 | Post-TF finalization plus road enrichment | 80.062s |
+| 6 | Foundational canonical cleaning | 63.568s |
+| 7 | TF cleaning | 33.950s |
+| 8 | Index setup/count | 20.703s |
+| 9 | Corpus TF aggregation/materialization | 4.045s |
+
+That run completed in **1,918.331s (31m 58.3s)** with a 20,078,952,448-byte peak
+RSS, 80 GB maximum observed spill, and 1,887,504,770 bytes of output. Roads were
+assigned to 62,859,358 rows. Output grew by only 1.16% versus no-road, while wall
+time grew by 105.6%, proving that file size does not explain the regression.
+
+The eight output loops took approximately 49.0s, 50.3s, 80.3s, 64.4s, 59.9s,
+68.1s, 60.3s, and 115.5s, or 548.8s combined. Each interval includes its redundant
+post-write recount and any lazy upstream road evaluation. Manifest finalization
+took another 1.432s.
+
+## First optimized full run (v1)
+
+The first complete optimized road-enabled run took **881.550s (14m 41.6s)**. This
+is 54.0% faster than the matched 1,918.331s road-enabled baseline and 5.5% faster
+than the 933.141s no-road baseline, but it does not yet meet the 480s target.
+
+| Measure | Result |
+| --- | ---: |
+| Canonical rows | 71,438,939 |
+| Term-frequency rows | 926,832 |
+| Inverted-index rows | 61,562,885 |
+| Roads assigned | 62,859,358 |
+| Peak RSS | 19,088,146,432 bytes (17.78 GiB) |
+| Maximum observed spill | about 74 GB |
+| Prepared output | 1,928,971,264 bytes |
+| Size change from road baseline | +2.20% |
+
+The measured stage boundaries were:
+
+| Stage | Time |
+| --- | ---: |
+| Shared foundational cleaning | 62.080s |
+| Deterministic ID assignment | 102.916s |
+| TF aggregation from shared clean data | 1.595s |
+| Adjacent distinguishing | 57.583s |
+| Post-TF processing | 221.634s |
+| Final full-table projection copy | 49.430s |
+| Bigram index | 38.433s |
+| Trigram index | 36.513s |
+| Road enrichment under integrated spill pressure | 69.552s |
+| TF/index serialization and canonical exports | 239.655s |
+| Manifest finalization | 1.343s |
+
+The two indexes fell from 730.969s to 74.946s, a 9.75x improvement. Canonical
+output loops and associated serialization fell from 548.8s to 239.7s. The full
+result instead identifies post-TF processing and its redundant final projection
+copy as the next controlling path. The latter copies all 71.4M wide rows only to
+remove the private `__ukam_row_id` column.
+
+A bounded per-shard `EXCEPT ALL` audit found zero TF and index differences. It
+found 57 canonical rows whose only changed field was the ordering of equal-frequency
+tokens inside `unusual_tokens_arr` or `extremely_unusual_tokens_arr`; membership and
+all other fields were identical. `list_grade_up` had no explicit tie-breaker. The
+pipeline now uses original token position as the deterministic secondary key and
+has a focused regression test for that rule.
+
+The final projection copy is also removed. A 5.10M-row low-memory comparison took
+0.367s for CTAS versus 0.0018s for `ALTER TABLE DROP COLUMN`, with zero differences
+(207x faster). At full scale this removes a measured 49.430s wide-table copy and
+reduces downstream spill pressure.
+
+## Where the original slowdown was contained
+
+The 31m 58.3s road-enabled run divides approximately as follows. Percentages use
+the full process wall time; the serialization residual is inferred from adjacent
+event boundaries rather than an isolated operator timer.
+
+| Area | Time | Share | What dominates |
+| --- | ---: | ---: | --- |
+| Bigram and trigram index construction | 731.0s | 38.1% | Repeated scans, tokenization, key derivation, aggregation, and lazy road replay |
+| Eight canonical output loops | 548.8s | 28.6% | Sorted writes, one redundant recount per shard, and lazy road replay |
+| Term-frequency application | 222.7s | 11.6% | Token explosion, lookup join, grouping, sorting, and list reconstruction |
+| ID assignment and adjacent distinguishing | 159.9s | 8.3% | Global deterministic sorts and six-neighbour suffix comparisons |
+| Post-TF finalization and road enrichment | 80.1s | 4.2% | Final wide materialization plus road keys/cardinalities |
+| Foundational canonical cleaning | 63.6s | 3.3% | Normalization, numeric parsing, and tokenization |
+| TF/index serialization residual | ~53.1s | 2.8% | Writing the TF and 61.6M-row index parquet files |
+| TF cleaning and aggregation | 38.0s | 2.0% | A second cleaning pass followed by corpus token aggregation |
+| Index setup/count | 20.7s | 1.1% | Input cardinality and setup queries |
+| Manifest/finalization | 1.4s | 0.1% | Hashing and metadata write |
+
+About two thirds of elapsed time is concentrated in index construction and output
+loops. Foundational address cleaning is only 3.3%, and the isolated road scorer is
+only 1.4% of total wall time. The regression is therefore not primarily expensive
+normalization or model arithmetic; it is repeated execution around materialization
+boundaries.
+
+## What happens behind the scenes
+
+Canonical preparation does not train or run the final Splink linkage model. It
+builds the normalized evidence and lookup structures that later matching stages
+consume:
+
+1. The source is minimally cleaned once to derive corpus token frequencies.
+2. The source is cleaned again to derive canonical address, flat, business-unit,
+   numeric, range, and token features.
+3. DuckDB globally sorts those rows to assign deterministic `ukam_address_id`
+   values. Adjacent distinguishing then performs another suffix-oriented global
+   ordering and examines three neighbours on each side.
+4. Token frequencies are attached to every address. In the baseline this explodes
+   token arrays to rows, joins 926,832 frequencies, groups by address, sorts token
+   positions, and rebuilds each array.
+5. The road scorecard selects one preferred source row per UPRN, generates candidate
+   road phrases, applies its SQL scorecard, and derives global road/cardinality
+   flags. This isolated computation takes 26.954s.
+6. The physical blocker builds bigram and trigram posting lists. Ten key-hash
+   buckets per strategy keep grouping within 16 GB and preserve global posting
+   caps, but the baseline regenerates all keys for every bucket.
+7. DuckDB writes the TF table, the 61,562,885-row inverted index, and eight sorted
+   canonical parquet shards, then hashes them into the manifest.
+
+The critical DuckDB behavior is laziness: a relation represents a SQL plan, not a
+cached result. Reusing `relation.sql_query()` in another query can execute the full
+upstream plan again. The baseline placed lazy road cardinality joins before the 20
+index bucket queries and reused that relation in every output shard. Each `COPY`
+was also followed by a `COUNT(*)` over the same shard query. Consequently a small
+1.16% increase in persisted bytes caused a 105.6% increase in wall time.
+
+`CREATE TEMPORARY TABLE ... AS SELECT ...` is the deliberate cache boundary used
+by the optimized path. It spends temporary disk once so later index, count, and
+export consumers scan materialized columns instead of replaying the model-derived
+SQL graph. The permitted 10% output-size increase gives ample room for persisted
+sidecars if useful, although the current changes add temporary staging rather than
+inflating final artifacts.
+
+## Main finding
+
+The optimized road assignment itself takes 26.954s for all 71.4 million rows. The
+large end-to-end road penalty instead comes from orchestration: road enrichment is
+a lazy relation placed before inverted-index construction. The index scans that
+relation for each strategy and each key-hash bucket even though index SQL uses only
+`unique_id` and `clean_full_address`. Output shards can evaluate the same upstream
+road joins again.
+
+The first correction is therefore structural:
+
+1. Materialize the base cleaned canonical rows.
+2. Build the index from only `unique_id` and `clean_full_address` in that base.
+3. Derive road keys after index completion.
+4. Explicitly materialize road-enriched rows once.
+5. Count and export only from that materialization.
+
+This preserves persisted values and index semantics while removing accidental road
+recomputation. A before/after relational equality check remains mandatory.
+
+This correction is now implemented: index construction precedes road enrichment,
+the enriched relation is materialized inside the road helper, and shard counts use
+contiguous ID boundaries instead of re-running each query. Canonical export now
+sorts by the integer ID that already encodes the full deterministic order. The
+focused optimization suite passes 101 tests, including a regression test that drops
+the road-key staging table before reading the enriched result. A full matched
+benchmark remains the performance acceptance gate.
+
+### Reproducible 1M-row findings
+
+A persisted, UPRN-coherent sample (`hash(unique_id) % 71 = 0`) contains 1,004,772
+rows. Isolated stages use 14 threads, a 16 GB DuckDB limit, and report zero spill:
+
+| Experiment | Baseline | Candidate | Result |
+| --- | ---: | ---: | --- |
+| Road enrichment | n/a | 1.466s | Road scoring is not the dominant cost |
+| TF attachment SQL | 0.147s exploded join | 17.570s map lookup | Map rejected: 119x slower |
+| Six key generators | n/a | 1.089s total | Individual generators take 0.110-0.203s |
+| Physical index | 2.882s repeated generation; 0.912s list staging | 0.801s scalar staging | 3.60x vs historical, 1.14x vs list staging |
+| Four-chunk post-TF orchestration | 2.075s materialized chunks | 1.189s direct relations | 1.74x faster |
+| Deterministic ID assignment | n/a | 0.462s | Moderate sort/materialization cost |
+| Adjacent distinguishing | 0.554s repeated tokenization | 0.421s carried token arrays | 24.0% faster |
+
+All TF, index, post-TF, and adjacent comparisons returned zero bidirectional
+`EXCEPT ALL` differences. The saved JSON, plans, and profiles are under
+`benchmarking/results/preprocessing_1m/`.
+
+A 5,104,699-row pressure test confirmed the index direction: scalar staging took
+2.720s, list-array staging 3.230s, and repeated generation 9.373s, again with zero
+differences and no spill. Peak RSS reached 12.13 GB while the benchmark retained all
+three comparator outputs, so this is evidence for runtime scaling but not a substitute
+for the full-run memory gate.
+
+The optimized production path was then exercised end to end with roads enabled:
+
+| Sample | Wall time | Peak RSS | Spill | Output size |
+| --- | ---: | ---: | ---: | ---: |
+| 1,004,772 rows | 22.078s | 4.78 GB | 0 | 74 MB |
+| 5,104,699 rows, optimized v1 | 35.925s | 13.62 GB | 0 | 288 MB |
+| 5,104,699 rows, spill-aware v2 | 33.657s | 13.84 GB | 0 | 288 MB |
+
+On 5.10M rows, pre-cleaning took 11.681s, ID assignment 1.016s, adjacent
+distinguishing 2.012s, post-TF processing 7.374s, both indexes 2.899s, roads
+2.409s, and final artifact writing 8.046s. The manifest reports 5,104,699
+canonical rows, 259,646 TF rows, and 9,633,787 index rows.
+
+## Other controlling costs
+
+### Inverted index
+
+Baseline bigram and trigram construction performs 20 passes: two strategies times
+10 key-hash buckets. Each pass rescans addresses, tokenizes `clean_full_address`,
+derives all keys, and filters the list to one bucket. The production path now
+unnests each strategy once into a narrow `(unique_id, key, key_bucket)` table ordered
+by bucket, then aggregates the 10 authoritative buckets without repeated list
+filtering or `UNNEST`. On 1M rows this takes 0.801s versus 0.912s for list-array
+staging and 2.882s for historical repeated generation; at 5.10M rows the respective
+times are 2.720s, 3.230s, and 9.373s. Both samples have identical postings.
+At full scale both optimized indexes took 65.606s with zero posting differences;
+peak process RSS for the complete run was 17.38 GiB.
+
+Bucket ownership must remain `hash(key)`: partitioning source rows by `unique_id`
+would split one key's postings across buckets and make global posting caps wrong.
+
+### Term-frequency application
+
+Canonical preparation previously ran foundational cleaning once to derive TF and
+again to prepare canonical rows. The production path now materializes that pre-clean
+result once and derives TF directly from it. On 1M rows, the standalone raw branch
+took 2.449s and reuse took 0.036s (68x); on 5.10M rows they took 3.437s and
+0.127s (27x). Both comparisons returned zero TF differences.
+
+Each work chunk filters the full clean table by a hash expression, inserts processed
+rows, and deletes those rows from the source. Materializing each filtered chunk before
+the post-TF pipeline was redundant; passing the filtered relation directly reduced
+the four-chunk 1M stage from 2.075s to 1.189s with identical output. Range partitioning
+was slower in memory and was initially rejected. The full run showed that direct
+hash filtering still takes 221.634s under spill. At 5.10M rows with a forced 4 GB
+limit, direct contiguous-ID ranges without per-chunk deletes took 6.440s versus
+7.710s for direct hash filtering, 16.5% faster, with zero exact differences. This
+spill-aware range path is now used in production. The final full-table copy has also
+been replaced by an in-place private-column drop.
+
+The inner TF operation explodes every token array, joins the frequency table, groups
+by row, sorts positions, and reconstructs the array. It takes only 0.147s on 1M rows.
+A reusable `MAP(token, rel_freq)` with `list_transform` produced identical values but
+took 17.570s, approximately 119x slower, so the existing exploded join remains.
+
+### Adjacent distinguishing
+
+The six-neighbour calculation globally sorts by reversed address. Carrying the
+already-tokenized arrays through the same ordered window avoids tokenizing each of
+the six lag/lead addresses separately. The 1M stage falls from 0.554s to 0.421s with
+identical output; all six neighbours and deterministic tie ordering are preserved.
+
+### Export
+
+Every baseline shard performs a filtered sorted `COPY` and then re-executes the
+shard query with `COUNT(*)` only for logging. Road-enabled shard 1 spent about 30s
+writing and 19s recounting. Optimized v1 uses the exact contiguous ID-range count
+and `ORDER BY ukam_address_id`; tests confirm that physical row order is unchanged.
+
+Compression was a material independent cost. On 5.10M rows, ZSTD levels 15, 9,
+and 6 took 8.674s, 2.473s, and 1.992s. Level 6 increased bytes by 4.31%, within
+the allowed 10%, and produced zero row differences and zero order violations, so it
+is now used for canonical and TF output. Level 3 took 1.149s on 1M rows but increased
+bytes by 12.06%, so it was rejected. Building one sorted staging table took 9.139s
+at 5.10M versus 8.674s for the existing independent writes and had 19 physical-order
+violations; that candidate was also rejected.
+
+Adding `ORDER BY ukam_address_id` back to staged ZSTD 6 writes removed the order
+violations but still took 2.043s versus 2.005s for direct ZSTD 6 writes at 5.10M.
+The ordered staging variant is therefore also rejected.
+
+## Remaining exact-output opportunities
+
+The accepted row-preserving work reduced the matched road-enabled run from
+1,918.331s to 537.531s. The strict High profile still needs 57.531s, but no single
+low-risk change is known to recover that amount. The remaining exact-output work
+should be a bounded experiment round, not open-ended expression tuning.
+
+| Priority | Candidate | Evidence and ceiling | Exact-output condition |
+| ---: | --- | --- | --- |
+| 1 | Memory-limit pressure test | The run spilled about 97 GB under a 16 GB DuckDB cap; 24 GB and 32 GB runs could reduce both global-sort and export pressure without changing SQL semantics | IDs, values, postings, shard order, and output-size limit must still pass |
+| 2 | Narrow deterministic ID assignment | The 111.690s stage globally sorts 71.4M wide rows and currently appends every source column as a tie-breaker | A primary-key tie audit must prove that a narrower key preserves the exact current ID-to-row mapping |
+| 3 | Earlier narrow road-key staging | Integrated road enrichment takes 64.715s versus 26.954s in isolation, giving a strict maximum recoverable gap of 37.761s | Join staged keys after spill-heavy processing and require exact road columns and cardinalities |
+| 4 | Work-chunk sweep | Post-TF range processing still takes 80.876s with 10 chunks; a small 5/10/20 full-pressure matrix may improve spill behavior | Exact canonical equality and peak disk/RSS gates remain mandatory |
+
+Adjacent distinguishing is not a low-hanging exact-output target. It already sorts a
+narrow keyed relation, carries token arrays through the six-neighbour window, and
+joins only the two derived columns back by `__ukam_row_id`. Removing it would save up
+to 71.897s and likely cross 480s, but that changes canonical artifacts and remains a
+Medium-profile accuracy trade-off.
+
+The recommended stopping rule is to run the memory-limit and narrow-ID experiments
+first. Continue to another full 71.4M-row acceptance run only if a pressure test
+demonstrates at least 20-30s of plausible end-to-end savings with exact logical
+output. Otherwise, 8m57.5s is a reasonable High-profile stopping point: the pipeline
+is already 3.57x faster than the matched road-enabled baseline, and reaching eight
+minutes would require combining several individually uncertain changes.
+
+## Proposed profiles
+
+| Capability | High accuracy | Medium/default | Low latency |
+| --- | --- | --- | --- |
+| Corpus TF | Required | Required | Packaged TF candidate |
+| Physical indexes | Bigram and trigram | Bigram and trigram | Trigram-only candidate |
+| Adjacent distinguishing | Required | Off pending accuracy gate | Off |
+| Numeric/signature features | Required | Required | Keep pending timing evidence |
+| Road keys | Full selected scorer | Only when road blocking is configured | Off |
+| Adaptive second road key | Optional calibrated feature | Off | Off |
+| Output policy | Maximum locality | Balanced | Faster compression candidate |
+
+High is the exact-output performance target. Medium and Low are experiment designs,
+not claims about accuracy: publish them only after measuring candidate reachability
+and labelled precision, recall, and F1 against High.
+
+## Reproducibility
+
+The benchmark harness writes incremental events to
+`benchmarking/results/road_scoring_experiment/*.events.jsonl`, so completed stage
+timings survive an interrupted run. The detailed implementation and verification
+sequence is in `plans/001-cut-canonical-preparation-under-eight-minutes.md`.
+
+The historical roughly five-minute artifact is not an equivalent baseline: it used
+UKAM 1.2.2, DuckDB 1.5.2, one output file, and no adjacent-distinguishing columns.
+The current run uses UKAM 1.3.0 code, DuckDB 1.5.0, eight files, and adjacent
+distinguishing. These variables require a controlled matrix before assigning the
+threefold difference to one regression.

--- a/docs/site/performance.md
+++ b/docs/site/performance.md
@@ -11,11 +11,14 @@ Note that runtimes depend on whether the canonical data covers a local council r
 | 1. Create data package and API key | 5 minutes | 5 minutes |
 | 2. Install Python, uv, and `uk_address_matcher` | 5 minutes | 5 minutes |
 | 3. Download and process OS data into a flat file | 5 seconds[^1] | 4 minutes[^2] |
-| 4. Pre-process indexes and features | Not necessary | 4 min 50 sec |
+| 4. Pre-process indexes and features | Not necessary | 8 min 58 sec[^3] |
 | 5. Match 100,000 records | 18 seconds | 26 seconds |
 
 [^1]: Plus ~15 seconds to download the data.
 [^2]: Plus ~18 minutes to download the data.
+[^3]: See [Canonical preparation runtime](#canonical-preparation-runtime) for
+    the benchmark configuration, stage breakdown, and comparison with the
+    previous implementation.
 
 These timings are measured on a MacBook Pro M4 Max.
 
@@ -374,3 +377,56 @@ The full precision-recall curve is shown below:
 	"schema-url": "assets/charts/mid_sussex_precision_recall.json"
 }
 ```
+
+## Canonical preparation runtime
+
+??? info "How the 8 min 58 sec timing was measured"
+    The current refactored `prepare_canonical_folder()` path completed in
+    **537.531 seconds (8 min 57.5 sec)** for 71,438,939 national-scale NGD
+    canonical rows. This is the complete one-time preparation job, not just
+    address text normalization.
+
+    The run used a MacBook Pro M4 Max, DuckDB 1.5.0, 14 DuckDB threads, a 16 GB
+    DuckDB memory limit, 10 work chunks, and eight canonical output shards. Road
+    features were enabled. Peak process memory was 17.38 GiB and DuckDB spilled
+    approximately 97 GB of temporary data to disk.
+
+    | Stage | Time | Share |
+    | --- | ---: | ---: |
+    | Shared foundational cleaning | 61.672s | 11.47% |
+    | Deterministic ID assignment | 111.690s | 20.78% |
+    | Term-frequency aggregation | 2.442s | 0.45% |
+    | Adjacent distinguishing | 71.897s | 13.38% |
+    | Post-TF feature processing | 80.876s | 15.05% |
+    | In-place finalization | 0.268s | 0.05% |
+    | Bigram and trigram indexes | 65.606s | 12.21% |
+    | Road enrichment | 64.715s | 12.04% |
+    | TF/index serialization and canonical exports | 76.720s | 14.27% |
+    | Manifest finalization | 1.277s | 0.24% |
+
+    The measured stages account for 537.163 seconds; setup and transitions
+    account for the remaining 0.368 seconds. Foundational cleaning itself takes
+    61.672 seconds. IDs, adjacent-record features, term-frequency features, and
+    all canonical columns are finalized after 328.845 seconds (5 min 28.8 sec).
+    Index construction, road enrichment, Parquet serialization, and manifest
+    generation bring the complete prepared folder to 537.531 seconds.
+
+    The benchmark includes all work performed by `prepare_canonical_folder()`:
+    canonical cleaning, deterministic IDs, term frequencies, adjacent-record
+    features, physical indexes, road features, Parquet output, and manifest
+    generation. It excludes downloading NGD and transforming the source product
+    into the input flat file; those are covered separately by step 3 above.
+
+    Before the refactor, the matched road-enabled path took 1,918.331 seconds
+    (31 min 58.3 sec). The current path is 72.0% faster. It produced 1,928,966,850
+    bytes of prepared output, 2.20% more than the old road-enabled baseline.
+
+    The full comparison found no term-frequency or inverted-index differences
+    and no physical-order violations across the eight canonical shards. There
+    were 401 canonical rows whose only difference was the now-deterministic
+    ordering of equal-frequency entries in the unusual-token arrays; all other
+    persisted values were unchanged.
+
+    These figures are indicative rather than a hardware-independent guarantee.
+    Available memory, temporary-disk speed, source schema, enabled features, and
+    output-shard count can materially affect national-scale preparation time.

--- a/tests/cleaning/test_cleaning_steps.py
+++ b/tests/cleaning/test_cleaning_steps.py
@@ -10,6 +10,7 @@ from uk_address_matcher.cleaning.steps import (
     _parse_out_sub_premise_location,
     _remove_duplicate_end_tokens,
     _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records,
+    _separate_unusual_tokens,
 )
 from uk_address_matcher.sql_pipeline.runner import DebugOptions, DuckDBPipeline
 
@@ -18,6 +19,29 @@ def _run_single_stage(stage_factory, input_relation, connection):
     pipeline = DuckDBPipeline(connection, input_relation)
     pipeline.add_step(stage_factory())
     return pipeline.run(DebugOptions(pretty_print_sql=False))
+
+
+def test_separate_unusual_tokens_preserves_source_order_for_frequency_ties():
+    connection = duckdb.connect()
+    input_relation = connection.sql("""
+        SELECT [
+            {'tok': 'CLEEVE', 'rel_freq': 5e-5},
+            {'tok': 'ALCESTER', 'rel_freq': 5e-5},
+            {'tok': 'BENHOLMS', 'rel_freq': 5e-8},
+            {'tok': 'TILLYDRON', 'rel_freq': 5e-8}
+        ] AS token_rel_freq_arr
+    """)
+
+    result = _run_single_stage(
+        _separate_unusual_tokens,
+        input_relation,
+        connection,
+    ).fetchone()
+
+    assert result[-2:] == (
+        ["CLEEVE", "ALCESTER"],
+        ["BENHOLMS", "TILLYDRON"],
+    )
 
 
 def test_separate_distinguishing_tokens_uses_valid_local_neighbours():

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -360,9 +360,9 @@ def test_prepare_progress_stages_logs_boundaries_without_chunk_updates(
 
     messages = [record.getMessage() for record in caplog.records]
 
-    assert any(message.startswith("Cleaning for TF derivation:") for message in messages)
+    assert any(message.startswith("Cleaning and preprocessing:") for message in messages)
     assert any(
-        message.startswith("Cleaning for TF derivation completed:")
+        message.startswith("Cleaning and preprocessing completed:")
         for message in messages
     )
     assert not any("chunk 1/" in message for message in messages)
@@ -382,7 +382,6 @@ def test_prepare_progress_off_suppresses_stage_status_logs(
         )
 
     stage_prefixes = (
-        "Cleaning for TF derivation",
         "Cleaning and preprocessing",
         "Applying term frequencies",
         "Building inverted index",
@@ -497,11 +496,11 @@ def test_prepare_logs_stage_and_batch_progress(con, canonical_data, tmp_path, ca
         record.getMessage() for record in caplog.records if record.levelno == logging.INFO
     ]
     assert any(
-        message.startswith("Cleaning for TF derivation:") and "records across" in message
+        message.startswith("Cleaning and preprocessing:") and "records across" in message
         for message in info_messages
     )
     assert any(
-        message.startswith("Cleaning for TF derivation completed:")
+        message.startswith("Cleaning and preprocessing completed:")
         for message in info_messages
     )
     assert any(
@@ -513,7 +512,7 @@ def test_prepare_logs_stage_and_batch_progress(con, canonical_data, tmp_path, ca
         for message in info_messages
     )
     assert any(
-        message.startswith("Cleaning for TF derivation:") and "chunk 1/1" in message
+        message.startswith("Cleaning and preprocessing:") and "chunk 1/1" in message
         for message in info_messages
     )
     progress_glyphs = ("█", "░", "▕", "▏", "▮", "▯")
@@ -681,8 +680,13 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch, add_debug_fe
 
     monkeypatch.setattr(
         chunking_strategies,
-        "derive_term_frequencies_table",
-        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
+        "clean_data_pre_term_frequencies",
+        lambda data, con, num_of_chunks, show_progress=True: clean_relation,
+    )
+    monkeypatch.setattr(
+        chunking_strategies,
+        "_derive_term_frequencies_from_precleaned",
+        lambda data, con: tf_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,
@@ -729,7 +733,7 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch, add_debug_fe
         "ORDER BY index_strategy, left(key, 1), unique_ids, key"
         in (inverted_index_copies[0])
     )
-    assert all("COMPRESSION_LEVEL 15" in sql for sql in other_copies)
+    assert all("COMPRESSION_LEVEL 6" in sql for sql in other_copies)
     assert all("ROW_GROUP_SIZE 122880" in sql for sql in parquet_copies)
 
     assert _written("s3://bucket/output/prepared/ukam_term_frequencies.parquet")
@@ -780,8 +784,13 @@ def test_prepare_remote_output_writes_chunked_paths(monkeypatch, add_debug_featu
 
     monkeypatch.setattr(
         chunking_strategies,
-        "derive_term_frequencies_table",
-        lambda data, con, num_of_chunks, show_progress=True: tf_relation,
+        "clean_data_pre_term_frequencies",
+        lambda data, con, num_of_chunks, show_progress=True: clean_relation,
+    )
+    monkeypatch.setattr(
+        chunking_strategies,
+        "_derive_term_frequencies_from_precleaned",
+        lambda data, con: tf_relation,
     )
     monkeypatch.setattr(
         chunking_strategies,

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -22,6 +23,7 @@ from uk_address_matcher.cleaning.steps.inverted_index import (
     InvertedIndexLookupStrategy,
     PhysicalIndexStrategy,
     _build_inverted_index_from_keys,
+    _build_inverted_index_from_scalar_keys,
     _derive_keys_for_strategy,
     _lookup_keys_in_inverted_index,
 )
@@ -46,6 +48,8 @@ from uk_address_matcher.sql_pipeline.runner import create_sql_pipeline
 
 if TYPE_CHECKING:
     from uk_address_matcher.sql_pipeline.runner import DebugOptions
+
+logger = logging.getLogger("uk_address_matcher")
 
 
 def _materialise_relation(
@@ -242,11 +246,13 @@ def clean_data_pre_term_frequencies(
 
     chunked_table = f"__ukam_chunked_addresses_{uid}"
     cleaned_table = f"__ukam_cleaned_{uid}"
+    logger.debug("Assigning deterministic UKAM address IDs")
     _materialise_relation_with_ukam_address_id(
         con,
         con.table(chunked_table),
         cleaned_table,
     )
+    logger.debug("Deterministic UKAM address IDs assigned")
     _drop_table_and_registered_aliases(con, chunked_table)
     return con.table(cleaned_table)
 
@@ -387,11 +393,29 @@ def derive_term_frequencies_table(
         progress_mode=progress_mode,
     )
 
-    # Compute token frequencies from clean_full_address tokens
+    result = _derive_term_frequencies_from_precleaned(cleaned_table, con)
+
+    # Clean up intermediate table
+    con.execute(f"DROP TABLE IF EXISTS {cleaned_table}")
+    _drop_table_and_registered_aliases(con, input_name)
+
+    return result
+
+
+def _derive_term_frequencies_from_precleaned(
+    cleaned_address_table: DuckDBPyRelation | str,
+    con: DuckDBPyConnection,
+) -> DuckDBPyRelation:
+    """Aggregate corpus token frequencies from canonical pre-clean output."""
+    source_sql = (
+        cleaned_address_table
+        if isinstance(cleaned_address_table, str)
+        else f"({cleaned_address_table.sql_query()})"
+    )
     tf_sql = f"""
     WITH unnested AS (
         SELECT unnest(string_split(clean_full_address, ' ')) AS token
-        FROM {cleaned_table}
+        FROM {source_sql}
     )
     SELECT
         token,
@@ -401,15 +425,9 @@ def derive_term_frequencies_table(
     ORDER BY COUNT(*) DESC
     """
 
-    # Materialise the result (consistent with parquet loading pattern)
     result_table = "__ukam_derived_term_frequencies"
     con.sql(f"DROP TABLE IF EXISTS {result_table}")
     con.sql(tf_sql).create(result_table)
-
-    # Clean up intermediate table
-    con.execute(f"DROP TABLE IF EXISTS {cleaned_table}")
-    _drop_table_and_registered_aliases(con, input_name)
-
     return con.table(result_table)
 
 
@@ -527,6 +545,7 @@ def derive_inverted_index(
         else:
             # Chunked path for this strategy
             stage_started_at = time.perf_counter()
+            strategy_keys_table = f"__ukam_index_keys_{uid}_{strategy.name}"
             progress = _ProgressBar(
                 label=stage_label,
                 total=total_rows,
@@ -540,24 +559,52 @@ def derive_inverted_index(
                 progress_mode=progress_mode,
             )
             try:
+                logger.debug("%s: staging keys once", stage_label)
+                key_pipeline = create_sql_pipeline(
+                    con,
+                    input_rel=cleaned_address_table,
+                    stage_specs=[_derive_keys_for_strategy(strategy)],
+                    pipeline_name=f"Stage inverted index keys ({strategy.name})",
+                    pipeline_description=(
+                        f"Derive {strategy.name} keys once before bucket aggregation"
+                    ),
+                )
+                strategy_keys = key_pipeline.run(debug_options if first_insert else None)
+                scalar_keys = con.sql(f"""
+                    WITH scalar_keys AS (
+                        SELECT unique_id, unnest(__index_keys) AS key
+                        FROM ({strategy_keys.sql_query()})
+                    )
+                    SELECT
+                        unique_id,
+                        key,
+                        abs(hash(key)) % {num_of_chunks} AS key_bucket
+                    FROM scalar_keys
+                    ORDER BY key_bucket
+                """)
+                _materialise_relation(
+                    con,
+                    scalar_keys,
+                    strategy_keys_table,
+                )
+                logger.debug("%s: keys staged", stage_label)
+
                 for chunk_index in range(num_of_chunks):
                     chunk_started_at = time.perf_counter()
+                    chunk_keys = con.sql(f"""
+                        SELECT unique_id, key
+                        FROM {strategy_keys_table}
+                        WHERE key_bucket = {chunk_index}
+                    """)
 
                     pipeline = create_sql_pipeline(
                         con,
-                        input_rel=cleaned_address_table,
-                        stage_specs=[
-                            _derive_keys_for_strategy(
-                                strategy,
-                                num_of_chunks=num_of_chunks,
-                                chunk_index=chunk_index,
-                            ),
-                            _build_inverted_index_from_keys(strategy),
-                        ],
+                        input_rel=chunk_keys,
+                        stage_specs=[_build_inverted_index_from_scalar_keys(strategy)],
                         pipeline_name=f"Build inverted index ({strategy.name})",
                         pipeline_description=(
-                            f"Derive {strategy.name} keys and aggregate into inverted "
-                            f"index (chunk {chunk_index + 1}/{num_of_chunks})"
+                            f"Aggregate staged {strategy.name} keys into inverted index "
+                            f"(chunk {chunk_index + 1}/{num_of_chunks})"
                         ),
                     )
                     chunk_result = pipeline.run(debug_options if first_insert else None)
@@ -589,6 +636,7 @@ def derive_inverted_index(
                     )
             finally:
                 progress.close()
+                _drop_table_and_registered_aliases(con, strategy_keys_table)
 
             log_stage_complete(
                 stage_label,
@@ -616,6 +664,7 @@ def prepare_data_for_matching(
     derive_distinguishing_wrt_adjacent_records: bool = False,
     *,
     dataset_role: Literal["messy", "canonical"] | None = None,
+    _precleaned_addresses: bool = False,
     debug_options: Optional[DebugOptions] = None,
     show_progress: ShowProgress = "auto",
 ) -> DuckDBPyRelation:
@@ -681,17 +730,20 @@ def prepare_data_for_matching(
     uid = _uid()
     distinguishing_table_name = None
 
-    # Clean data in chunks (without term frequencies)
-    cleaned_address_table = clean_data_pre_term_frequencies(
-        address_table,
-        con,
-        num_of_chunks=num_of_chunks,
-        debug_options=debug_options,
-        show_progress=progress_mode,
-    )
+    if _precleaned_addresses:
+        cleaned_address_table = address_table
+    else:
+        cleaned_address_table = clean_data_pre_term_frequencies(
+            address_table,
+            con,
+            num_of_chunks=num_of_chunks,
+            debug_options=debug_options,
+            show_progress=progress_mode,
+        )
     cleaned_table_name = cleaned_address_table.alias
 
     if derive_distinguishing_wrt_adjacent_records:
+        logger.debug("Deriving adjacent-record distinguishing tokens")
         distinguishing_pipeline = create_sql_pipeline(
             con,
             input_rel=cleaned_address_table,
@@ -712,6 +764,7 @@ def prepare_data_for_matching(
             distinguishing_tokens,
             distinguishing_table_name,
         )
+        logger.debug("Adjacent-record distinguishing tokens derived")
 
     total_rows = cleaned_address_table.count("*").fetchone()[0]
     _create_term_frequency_tables(con, term_frequency_lookup=term_frequency_lookup)
@@ -780,20 +833,18 @@ def prepare_data_for_matching(
     try:
         for chunk_index in range(total_chunks):
             chunk_started_at = time.perf_counter()
+            first_id = chunk_index * chunk_size + 1
+            last_id = min((chunk_index + 1) * chunk_size, total_rows)
             chunk_query = con.sql(f"""
             SELECT cleaned.*{distinguishing_select_sql}
                 FROM {cleaned_table_name} AS cleaned
                 {distinguishing_join_sql}
-                WHERE
-                    (abs(hash(cleaned.original_address_concat)) % {total_chunks})
-                    = {chunk_index}
+                WHERE cleaned.__ukam_row_id BETWEEN {first_id} AND {last_id}
             """)
-            chunk_table = f"__ukam_post_tf_chunk_input_{uid}_{chunk_index}"
-            chunk = _materialise_relation(con, chunk_query, chunk_table)
 
             # Process chunk: apply term frequencies + inverted index blocking in one pass
             processed_chunk = _clean_data_using_precomputed_rel_tok_freq(
-                chunk,
+                chunk_query,
                 con=con,
                 pre_cleaned_addresses=True,
                 additional_stages=inverted_index_stages,
@@ -805,14 +856,6 @@ def prepare_data_for_matching(
                 processed_chunk.create(processed_table)
             else:
                 processed_chunk.insert_into(processed_table)
-
-            # Delete processed rows from the intermediate cleaned table to free memory
-            con.execute(f"""
-                DELETE FROM {cleaned_table_name}
-                WHERE
-                    (abs(hash(original_address_concat)) % {total_chunks})
-                    = {chunk_index}
-            """)
 
             processed_records = min((chunk_index + 1) * chunk_size, total_rows)
             progress.update(
@@ -829,8 +872,6 @@ def prepare_data_for_matching(
                 total_chunks=total_chunks,
                 chunk_elapsed_seconds=time.perf_counter() - chunk_started_at,
             )
-
-            _drop_table_and_registered_aliases(con, chunk_table)
     finally:
         progress.close()
 
@@ -841,16 +882,7 @@ def prepare_data_for_matching(
         progress_mode=progress_mode,
     )
 
-    # Verify the intermediate table is now empty (all chunks processed)
-    remaining_rows = con.sql(f"SELECT COUNT(*) FROM {cleaned_table_name}").fetchone()[0]
-    if remaining_rows != 0:
-        raise ValueError(
-            "Expected intermediate table "
-            f"{cleaned_table_name} to be empty after processing, "
-            f"but found {remaining_rows} rows remaining."
-        )
-
-    # Drop the now-empty intermediate table
+    logger.debug("Finalizing prepared address table")
     con.execute(f"DROP TABLE IF EXISTS {cleaned_table_name}")
     if distinguishing_table_name is not None:
         con.execute(f"DROP TABLE IF EXISTS {distinguishing_table_name}")
@@ -859,15 +891,8 @@ def prepare_data_for_matching(
     if inv_idx_table_name == "__ukam_inverted_index":
         _drop_table_and_registered_aliases(con, inv_idx_table_name)
 
-    prepared_table = f"__ukam_prepared_{uid}"
-    _drop_table_and_registered_aliases(con, prepared_table)
-    con.execute(f"""
-        CREATE TABLE {prepared_table} AS
-        SELECT * EXCLUDE (__ukam_row_id)
-        FROM {processed_table}
-    """)
-    _drop_table_and_registered_aliases(con, processed_table)
-    con.execute(f"ALTER TABLE {prepared_table} RENAME TO {processed_table}")
+    con.execute(f"ALTER TABLE {processed_table} DROP COLUMN __ukam_row_id")
+    logger.debug("Prepared address table finalized")
 
     return con.table(processed_table)
 

--- a/uk_address_matcher/cleaning/steps/inverted_index.py
+++ b/uk_address_matcher/cleaning/steps/inverted_index.py
@@ -312,6 +312,39 @@ def _build_inverted_index_from_keys(strategy: PhysicalIndexStrategy):
     return _stage
 
 
+def _build_inverted_index_from_scalar_keys(strategy: PhysicalIndexStrategy):
+    """Apply a physical strategy's posting cap to pre-unnested canonical keys."""
+    maximum_posting_size = strategy.maximum_posting_size
+
+    @pipeline_stage(
+        name=f"build_inverted_index_{strategy.name}",
+        description=(
+            f"Aggregate staged {strategy.name} keys into inverted index "
+            f"(max {maximum_posting_size} unique_ids per key)"
+        ),
+        tags="inverted_index",
+    )
+    def _stage():
+        return f"""
+        WITH grouped AS (
+            SELECT
+                key,
+                list(DISTINCT unique_id ORDER BY unique_id) AS unique_ids,
+                COUNT(DISTINCT unique_id) AS count_unique_ids
+            FROM {{input}}
+            GROUP BY key
+        )
+        SELECT
+            key,
+            unique_ids,
+            '{strategy.name}' AS index_strategy
+        FROM grouped
+        WHERE count_unique_ids BETWEEN 1 AND {maximum_posting_size}
+        """
+
+    return _stage
+
+
 def _lookup_keys_in_inverted_index(
     strategies: Sequence[InvertedIndexLookupStrategy] | None = None,
 ):

--- a/uk_address_matcher/cleaning/steps/term_frequencies.py
+++ b/uk_address_matcher/cleaning/steps/term_frequencies.py
@@ -115,8 +115,7 @@ def _add_term_frequencies_to_address_tokens_using_registered_df():
     FROM {base}
     """
 
-    # 2. Join to frequencies - we ONLY keep the Frequency (Float) and the Index (Int)
-    # We drop the Token string here. It is dead weight for the sort.
+    # 2. Join to frequencies - keep only the frequency and token position.
     joined_scalars_sql = """
     SELECT
         e.__ukam_row_id,
@@ -127,13 +126,7 @@ def _add_term_frequencies_to_address_tokens_using_registered_df():
         ON e.token = __ukam__tmp_rel_tok_freq.token
     """
 
-    # 3. Aggregate the frequencies back into a per-address array.
-    # A plain `list(rel_freq ORDER BY token_idx)` forces DuckDB to run an
-    # ordered list aggregate, which sorts within every group during the
-    # aggregation and dominates the cleaning plan. Instead we collect a single
-    # `list(struct(idx, freq))` (one aggregate, so idx/freq stay aligned) and
-    # sort it once with `list_sort` (token_idx is the leading struct field and
-    # is unique within a group). This is ~3x faster with identical output.
+    # 3. Aggregate frequencies back into each address's original token order.
     reaggregated_freqs_sql = """
     SELECT
         __ukam_row_id,
@@ -145,9 +138,7 @@ def _add_term_frequencies_to_address_tokens_using_registered_df():
     GROUP BY __ukam_row_id
     """
 
-    # 4. Zip the sorted frequencies back to the ORIGINAL token list
-    # This guarantees order (because the original list is the source of truth)
-    # and constructs the Structs at the very last moment
+    # 4. Zip the frequencies back to the original token list.
     final_sql = """
     SELECT
         base.* EXCLUDE (address_without_numbers_tokenised),
@@ -342,7 +333,12 @@ def _separate_unusual_tokens():
             list_filter(
                 list_select(
                     token_rel_freq_arr,
-                    list_grade_up(list_transform(token_rel_freq_arr, x -> x.rel_freq))
+                    list_grade_up(
+                        list_transform(
+                            token_rel_freq_arr,
+                            (x, i) -> struct_pack(rel_freq := x.rel_freq, token_idx := i)
+                        )
+                    )
                 ),
                 x -> x.rel_freq < 1e-4 AND x.rel_freq >= 5e-5
             ),
@@ -352,7 +348,12 @@ def _separate_unusual_tokens():
             list_filter(
                 list_select(
                     token_rel_freq_arr,
-                    list_grade_up(list_transform(token_rel_freq_arr, x -> x.rel_freq))
+                    list_grade_up(
+                        list_transform(
+                            token_rel_freq_arr,
+                            (x, i) -> struct_pack(rel_freq := x.rel_freq, token_idx := i)
+                        )
+                    )
                 ),
                 x -> x.rel_freq < 1e-7
             ),

--- a/uk_address_matcher/cleaning/steps/token_parsing.py
+++ b/uk_address_matcher/cleaning/steps/token_parsing.py
@@ -19,6 +19,7 @@ from uk_address_matcher.sql_pipeline.steps import CTEStep, pipeline_stage
 def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records(
     *,
     include_input_columns: bool = True,
+    carry_neighbour_tokens: bool = True,
 ):
     """Split each address around its longest suffix shared by a local neighbour."""
     tokenised_addresses_sql = r"""
@@ -30,23 +31,25 @@ def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records(
     FROM {input} AS input_address
     """
 
+    neighbour_value = "__tokens" if carry_neighbour_tokens else "clean_full_address"
+    neighbour_suffix = "tokens" if carry_neighbour_tokens else "address"
     neighbouring_addresses_sql = """
     SELECT
         __ukam_row_id,
         unique_id,
         __tokens,
         lag(unique_id, 1) OVER address_order AS __lag_1_unique_id,
-        lag(clean_full_address, 1) OVER address_order AS __lag_1_address,
+        lag({neighbour_value}, 1) OVER address_order AS __lag_1_{neighbour_suffix},
         lag(unique_id, 2) OVER address_order AS __lag_2_unique_id,
-        lag(clean_full_address, 2) OVER address_order AS __lag_2_address,
+        lag({neighbour_value}, 2) OVER address_order AS __lag_2_{neighbour_suffix},
         lag(unique_id, 3) OVER address_order AS __lag_3_unique_id,
-        lag(clean_full_address, 3) OVER address_order AS __lag_3_address,
+        lag({neighbour_value}, 3) OVER address_order AS __lag_3_{neighbour_suffix},
         lead(unique_id, 1) OVER address_order AS __lead_1_unique_id,
-        lead(clean_full_address, 1) OVER address_order AS __lead_1_address,
+        lead({neighbour_value}, 1) OVER address_order AS __lead_1_{neighbour_suffix},
         lead(unique_id, 2) OVER address_order AS __lead_2_unique_id,
-        lead(clean_full_address, 2) OVER address_order AS __lead_2_address,
+        lead({neighbour_value}, 2) OVER address_order AS __lead_2_{neighbour_suffix},
         lead(unique_id, 3) OVER address_order AS __lead_3_unique_id,
-        lead(clean_full_address, 3) OVER address_order AS __lead_3_address
+        lead({neighbour_value}, 3) OVER address_order AS __lead_3_{neighbour_suffix}
     FROM {tokenised_addresses} AS tokenised
     WINDOW address_order AS (
         ORDER BY
@@ -54,7 +57,9 @@ def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records(
             CAST(unique_id AS VARCHAR),
             __ukam_row_id
     )
-    """
+    """.replace("{neighbour_value}", neighbour_value).replace(
+        "{neighbour_suffix}", neighbour_suffix
+    )
 
     neighbour_names = (
         "lag_1",
@@ -68,7 +73,9 @@ def _separate_distinguishing_start_tokens_from_with_respect_to_adjacent_records(
     for neighbour_name in neighbour_names:
         neighbour_id = f"__{neighbour_name}_unique_id"
         neighbour_tokens = (
-            f"regexp_split_to_array(__{neighbour_name}_address, '\\s+')::VARCHAR[]"
+            f"__{neighbour_name}_tokens"
+            if carry_neighbour_tokens
+            else f"regexp_split_to_array(__{neighbour_name}_address, '\\s+')::VARCHAR[]"
         )
         suffix_length_expressions.append(f"""
         CASE
@@ -560,27 +567,26 @@ def _parse_out_business_unit():
 
     sql = f"""
     SELECT
-        i.*,
-
-        -- Extract the business unit type (UNIT, SUITE, OFFICE, etc.)
+        i.* EXCLUDE (__business_unit_match),
         NULLIF(
-            UPPER(regexp_extract(i.clean_full_address, '{singular_pattern}', 1)),
+            UPPER(i.__business_unit_match.business_unit_type),
             ''
         ) AS business_unit_type,
-
-        -- Extract the business unit identifier (A, 5, 5A, etc.)
         NULLIF(
-            UPPER(regexp_extract(i.clean_full_address, '{singular_pattern}', 2)),
+            UPPER(i.__business_unit_match.business_unit_id),
             ''
         ) AS business_unit_id,
-
-        -- Boolean indicator for having a business unit
-        regexp_matches(
-            i.clean_full_address,
-            '\\b({keywords_pattern})S?\\s+([A-Za-z]?\\d{{1,4}}[A-Za-z]?|[A-Za-z])\\b'
-        ) AS has_business_unit
-
-    FROM {{input}} i
+        i.__business_unit_match.business_unit_type != '' AS has_business_unit
+    FROM (
+        SELECT
+            source.*,
+            regexp_extract(
+                source.clean_full_address,
+                '{singular_pattern}',
+                ['business_unit_type', 'business_unit_id']
+            ) AS __business_unit_match
+        FROM {{input}} AS source
+    ) AS i
     """
     return sql
 

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -59,7 +59,7 @@ _MANAGED_FILES = [
 
 # Parquet write tuning for the prepared artefacts.
 PARQUET_COMPRESSION = "ZSTD"
-PARQUET_COMPRESSION_LEVEL = 15
+PARQUET_COMPRESSION_LEVEL = 6
 INVERTED_INDEX_COMPRESSION_LEVEL = 22
 PARQUET_VERSION = "V2"
 PARQUET_ROW_GROUP_SIZE = 122_880
@@ -492,8 +492,9 @@ def prepare_canonical_folder(
             and `overwrite` is `False`.
     """
     from uk_address_matcher.cleaning.chunking_strategies import (
+        _derive_term_frequencies_from_precleaned,
+        clean_data_pre_term_frequencies,
         derive_inverted_index,
-        derive_term_frequencies_table,
         prepare_data_for_matching,
     )
 
@@ -539,17 +540,19 @@ def prepare_canonical_folder(
             _clear_stale_artefacts(output_folder_path)
 
     # Derive artefacts / cleaned canonical data for export
-    logger.debug("Deriving term frequencies from canonical data")
-    tf_table = derive_term_frequencies_table(
+    logger.debug("Cleaning canonical addresses before term-frequency derivation")
+    precleaned = clean_data_pre_term_frequencies(
         data,
         con=con,
         num_of_chunks=num_of_chunks,
         show_progress=progress_mode,
     )
+    logger.debug("Deriving term frequencies from pre-cleaned canonical data")
+    tf_table = _derive_term_frequencies_from_precleaned(precleaned, con)
 
-    logger.debug("Cleaning canonical addresses")
+    logger.debug("Applying term frequencies to canonical addresses")
     df_clean = prepare_data_for_matching(
-        data,
+        precleaned,
         con=con,
         num_of_chunks=num_of_chunks,
         term_frequency_lookup=tf_table,
@@ -557,9 +560,9 @@ def prepare_canonical_folder(
             derive_distinguishing_wrt_adjacent_records
         ),
         dataset_role="canonical",
+        _precleaned_addresses=True,
         show_progress=progress_mode,
     )
-
     logger.debug("Building inverted index")
     inverted_index = derive_inverted_index(
         df_clean,
@@ -604,7 +607,7 @@ def prepare_canonical_folder(
             con,
             canonical_output_relation,
             addr_path,
-            sort_columns=(*CANONICAL_SORT_COLUMNS, "ukam_address_id"),
+            sort_columns=("ukam_address_id",),
             drop_columns=canonical_drop_columns,
         )
         canonical_paths = [addr_path]
@@ -644,10 +647,10 @@ def prepare_canonical_folder(
                 con,
                 chunk_query,
                 chunk_path,
-                sort_columns=(*CANONICAL_SORT_COLUMNS, "ukam_address_id"),
+                sort_columns=("ukam_address_id",),
                 drop_columns=canonical_drop_columns,
             )
-            chunk_count = chunk_query.count("*").fetchone()[0]
+            chunk_count = last_id - first_id + 1
             canonical_paths.append(chunk_path)
             logger.debug(
                 "Wrote canonical output chunk %d/%d to '%s' (%d rows) - took %s",


### PR DESCRIPTION
## PR Summary

This PR makes various changes to the shape of our preprocessing SQL and attempts to improve overall performance. We've made several expensive changes recently that have dramatically reduced performance from the original 5 minutes to around 13 minutes on my machine.

These have all made a positive impact on our overall accuracy figures and are useful features to extract, but come at a cost to runtime.

The SQL tweaks have reduced our runtime back down to a more manageable 8 mins and 58 seconds. There's probably still room for improvement, but this gets us most of the way.

I've also added in a `## Canonical preparation runtime` section to our docs to record precise timings for the canonical data, detailing my exact setup and precisely how long each stage took. This should help us further refine this in the future, should we need to and adds another layer of transparency to users.

Should we look to add in different performance modes, it should also clearly detail what fat we can trim for users.