### PR TITLE
Write completed canonical cleaning chunks to parquet

### DIFF
--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -155,15 +155,6 @@ def test_prepare_can_skip_road_blocking_keys(canonical_data, con, tmp_path):
 
     assert prepared.addresses.count("*").fetchone() == (len(CANONICAL_RECORDS),)
     assert not (output_folder / "roadlike_places.parquet").exists()
-    schema = pyarrow_parquet.read_schema(
-        output_folder / "ukam_canonical_addresses.parquet"
-    )
-    # DuckDB versions differ in the nullability metadata written for table columns.
-    con.sql("SELECT 1::INTEGER AS ukam_address_id").create("expected_id")
-    expected_path = tmp_path / "expected_id.parquet"
-    con.table("expected_id").write_parquet(str(expected_path))
-    expected_schema = pyarrow_parquet.read_schema(expected_path)
-    assert schema.field("ukam_address_id") == expected_schema.field("ukam_address_id")
     assert prepared.roadlike_places is None
     assert {
         "road_1_norm",

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -765,7 +765,7 @@ def test_prepare_remote_csv_input_writes_remote_output(
     )
     monkeypatch.setattr(
         chunking_strategies,
-        "_prepare_data_for_matching",
+        "prepare_data_for_matching",
         lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(
@@ -887,7 +887,7 @@ def test_prepare_remote_output_writes_chunked_paths(
     )
     monkeypatch.setattr(
         chunking_strategies,
-        "_prepare_data_for_matching",
+        "prepare_data_for_matching",
         lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -158,7 +158,12 @@ def test_prepare_can_skip_road_blocking_keys(canonical_data, con, tmp_path):
     schema = pyarrow_parquet.read_schema(
         output_folder / "ukam_canonical_addresses.parquet"
     )
-    assert not schema.field("ukam_address_id").nullable
+    # DuckDB versions differ in the nullability metadata written for table columns.
+    con.sql("SELECT 1::INTEGER AS ukam_address_id").create("expected_id")
+    expected_path = tmp_path / "expected_id.parquet"
+    con.table("expected_id").write_parquet(str(expected_path))
+    expected_schema = pyarrow_parquet.read_schema(expected_path)
+    assert schema.field("ukam_address_id") == expected_schema.field("ukam_address_id")
     assert prepared.roadlike_places is None
     assert {
         "road_1_norm",

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -117,9 +117,7 @@ def test_prepare_persists_compact_road_blocking_eligibility(prepared_folder, con
 def test_canonical_chunk_files_are_cleaned_on_success_and_failure(
     canonical_data, con, tmp_path, monkeypatch, fail_after_chunks
 ):
-    canonical_data = canonical_data.select(
-        "*, 'z'::ENUM('z', 'a') AS metadata_category"
-    )
+    canonical_data = canonical_data.select("*, 'z'::ENUM('z', 'a') AS metadata_category")
     spill = tmp_path / "spill with ' quote"
     con.execute("SET temp_directory = ?", [str(spill)])
     original = chunking_strategies.derive_inverted_index

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -117,12 +117,18 @@ def test_prepare_persists_compact_road_blocking_eligibility(prepared_folder, con
 def test_canonical_chunk_files_are_cleaned_on_success_and_failure(
     canonical_data, con, tmp_path, monkeypatch, fail_after_chunks
 ):
+    canonical_data = canonical_data.select(
+        "*, 'z'::ENUM('z', 'a') AS metadata_category"
+    )
     spill = tmp_path / "spill with ' quote"
     con.execute("SET temp_directory = ?", [str(spill)])
     original = chunking_strategies.derive_inverted_index
 
     def inspect_chunks(*args, **kwargs):
         assert list(spill.glob("ukam-prepared-*/*.parquet"))
+        assert str(dict(zip(args[0].columns, args[0].types))["metadata_category"]) == (
+            "ENUM('z', 'a')"
+        )
         if fail_after_chunks:
             raise RuntimeError("injected failure after chunks are written")
         return original(*args, **kwargs)
@@ -151,6 +157,10 @@ def test_prepare_can_skip_road_blocking_keys(canonical_data, con, tmp_path):
 
     assert prepared.addresses.count("*").fetchone() == (len(CANONICAL_RECORDS),)
     assert not (output_folder / "roadlike_places.parquet").exists()
+    schema = pyarrow_parquet.read_schema(
+        output_folder / "ukam_canonical_addresses.parquet"
+    )
+    assert not schema.field("ukam_address_id").nullable
     assert prepared.roadlike_places is None
     assert {
         "road_1_norm",

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -117,19 +117,21 @@ def test_prepare_persists_compact_road_blocking_eligibility(prepared_folder, con
 def test_canonical_chunk_files_are_cleaned_on_success_and_failure(
     canonical_data, con, tmp_path, monkeypatch, fail_after_chunks
 ):
-    canonical_data = canonical_data.select("*, 'z'::ENUM('z', 'a') AS metadata_category")
+    canonical_data = canonical_data.select(
+        "unique_id::ENUM('C3', 'C2', 'C1') AS unique_id, "
+        "'1 high street london' AS address_concat, 'SW1A 1AA' AS postcode"
+    )
     spill = tmp_path / "spill with ' quote"
     con.execute("SET temp_directory = ?", [str(spill)])
     original = chunking_strategies.derive_inverted_index
 
     def inspect_chunks(*args, **kwargs):
         assert list(spill.glob("ukam-prepared-*/*.parquet"))
-        assert str(dict(zip(args[0].columns, args[0].types))["metadata_category"]) == (
-            "ENUM('z', 'a')"
-        )
         if fail_after_chunks:
             raise RuntimeError("injected failure after chunks are written")
-        return original(*args, **kwargs)
+        index = original(*args, **kwargs)
+        assert (["C3", "C2", "C1"],) in index.select("unique_ids").fetchall()
+        return index
 
     monkeypatch.setattr(chunking_strategies, "derive_inverted_index", inspect_chunks)
     if fail_after_chunks:

--- a/tests/test_prepare_canonical.py
+++ b/tests/test_prepare_canonical.py
@@ -113,6 +113,31 @@ def test_prepare_persists_compact_road_blocking_eligibility(prepared_folder, con
     assert prepared.roadlike_places.count("*").fetchone()[0] > 0
 
 
+@pytest.mark.parametrize("fail_after_chunks", [False, True])
+def test_canonical_chunk_files_are_cleaned_on_success_and_failure(
+    canonical_data, con, tmp_path, monkeypatch, fail_after_chunks
+):
+    spill = tmp_path / "spill with ' quote"
+    con.execute("SET temp_directory = ?", [str(spill)])
+    original = chunking_strategies.derive_inverted_index
+
+    def inspect_chunks(*args, **kwargs):
+        assert list(spill.glob("ukam-prepared-*/*.parquet"))
+        if fail_after_chunks:
+            raise RuntimeError("injected failure after chunks are written")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(chunking_strategies, "derive_inverted_index", inspect_chunks)
+    if fail_after_chunks:
+        with pytest.raises(RuntimeError, match="injected failure"):
+            prepare_canonical_folder(canonical_data, tmp_path / "prepared", con=con)
+    else:
+        prepare_canonical_folder(canonical_data, tmp_path / "prepared", con=con)
+        prepared = load_prepared_canonical_data(tmp_path / "prepared", con)
+        assert prepared.addresses.count("*").fetchone() == (len(CANONICAL_RECORDS),)
+    assert not list(spill.glob("ukam-prepared-*"))
+
+
 def test_prepare_can_skip_road_blocking_keys(canonical_data, con, tmp_path):
     output_folder = tmp_path / "without_road_keys"
 
@@ -690,10 +715,13 @@ def test_prepare_overwrite_true_succeeds(con, canonical_data):
 
 
 @pytest.mark.parametrize("add_debug_features", [False, True])
-def test_prepare_remote_csv_input_writes_remote_output(monkeypatch, add_debug_features):
+def test_prepare_remote_csv_input_writes_remote_output(
+    monkeypatch, add_debug_features, tmp_path
+):
     from uk_address_matcher.cleaning import chunking_strategies
 
     con = MagicMock()
+    con.execute.return_value.fetchone.return_value = (str(tmp_path),)
     raw_relation = _fake_relation(
         columns=["unique_id", "address_concat", "postcode"],
         row_count=3,
@@ -724,7 +752,7 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch, add_debug_fe
     )
     monkeypatch.setattr(
         chunking_strategies,
-        "prepare_data_for_matching",
+        "_prepare_data_for_matching",
         lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(
@@ -800,10 +828,13 @@ def test_prepare_remote_csv_input_writes_remote_output(monkeypatch, add_debug_fe
 
 
 @pytest.mark.parametrize("add_debug_features", [False, True])
-def test_prepare_remote_output_writes_chunked_paths(monkeypatch, add_debug_features):
+def test_prepare_remote_output_writes_chunked_paths(
+    monkeypatch, add_debug_features, tmp_path
+):
     from uk_address_matcher.cleaning import chunking_strategies
 
     con = MagicMock()
+    con.execute.return_value.fetchone.return_value = (str(tmp_path),)
     raw_relation = _fake_relation(
         columns=["unique_id", "address_concat", "postcode"],
         row_count=3,
@@ -843,7 +874,7 @@ def test_prepare_remote_output_writes_chunked_paths(monkeypatch, add_debug_featu
     )
     monkeypatch.setattr(
         chunking_strategies,
-        "prepare_data_for_matching",
+        "_prepare_data_for_matching",
         lambda *args, **kwargs: clean_relation,
     )
     monkeypatch.setattr(

--- a/tests/test_roadlike_place_stage.py
+++ b/tests/test_roadlike_place_stage.py
@@ -44,6 +44,29 @@ def test_roadlike_place_stage_extracts_terminal_first_candidates_and_catalogue(d
     ]
 
 
+def test_roadlike_fallback_exclusion_with_duplicate_and_null_ids(duck_con):
+    duck_con.execute("""
+        CREATE TABLE roadlike_source AS SELECT * FROM (VALUES
+            ('1', '12 HIGH STREET', 'AB1 2CD', ['12']),
+            ('1', '12 HIGH STREET', 'AB1 2CD', ['12']),
+            ('1', '12 ACORN LODGE', 'ZZ1 2CD', ['12']),
+            ('2', '12 ACORN LODGE', 'ZZ1 2CD', ['12']),
+            (NULL, '12 ACORN LODGE', 'ZZ1 2CD', ['12'])
+        ) AS rows(unique_id, clean_full_address, postcode, numeric_tokens)
+    """)
+
+    candidates = duck_con.sql(roadlike_place_candidate_sql("roadlike_source"))
+
+    assert candidates.project("address_id, candidate_phrase").order(
+        "address_id NULLS LAST, candidate_phrase"
+    ).fetchall() == [
+        ("1", "HIGH STREET"),
+        ("1", "HIGH STREET"),
+        ("2", "ACORN LODGE"),
+        (None, "ACORN LODGE"),
+    ]
+
+
 def test_prepared_roadlike_candidates_match_generic_candidates(duck_con):
     source = duck_con.sql("""
         SELECT * FROM (VALUES

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional
 
-from duckdb import ColumnExpression, DuckDBPyConnection, DuckDBPyRelation
+from duckdb import DuckDBPyConnection, DuckDBPyRelation
 
 from uk_address_matcher.cleaning.pipelines import (
     QUEUE_FOR_TF_DERIVATION,
@@ -1135,14 +1135,7 @@ def prepare_data_for_matching(
 
             if _parquet_directory is not None:
                 if chunk_index == 0:
-                    # Restore types that Parquet widens, such as ENUM and TIMESTAMP_S.
-                    chunk_columns = [
-                        ColumnExpression(name).cast(dtype).alias(name)
-                        for name, dtype in zip(
-                            processed_chunk.columns, processed_chunk.types
-                        )
-                        if name != "__ukam_row_id"
-                    ]
+                    unique_id_type = processed_chunk.select("unique_id").types[0]
                 processed_chunk = processed_chunk.select("* EXCLUDE (__ukam_row_id)")
                 chunk_path = str(_parquet_directory / f"{chunk_index:05d}.parquet")
                 escaped_path = chunk_path.replace("'", "''")
@@ -1193,8 +1186,9 @@ def prepare_data_for_matching(
     if _parquet_directory is None:
         con.execute(f"ALTER TABLE {processed_table} DROP COLUMN __ukam_row_id")
     else:
+        # Preserve ID ordering in the index, including the declared order of ENUMs.
         con.read_parquet(str(_parquet_directory / "*.parquet")).select(
-            *chunk_columns
+            f"* REPLACE (CAST(unique_id AS {unique_id_type}) AS unique_id)"
         ).create_view(processed_table)
     logger.debug("Prepared address table finalized")
 

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional
 
-from duckdb import DuckDBPyConnection, DuckDBPyRelation
+from duckdb import ColumnExpression, DuckDBPyConnection, DuckDBPyRelation
 
 from uk_address_matcher.cleaning.pipelines import (
     QUEUE_FOR_TF_DERIVATION,
@@ -1164,6 +1164,15 @@ def _prepare_data_for_matching(
             )
 
             if parquet_directory is not None:
+                if chunk_index == 0:
+                    # Restore types that Parquet widens, such as ENUM and TIMESTAMP_S.
+                    chunk_columns = [
+                        ColumnExpression(name).cast(dtype).alias(name)
+                        for name, dtype in zip(
+                            processed_chunk.columns, processed_chunk.types
+                        )
+                        if name != "__ukam_row_id"
+                    ]
                 chunk_path = str(parquet_directory / f"{chunk_index:05d}.parquet")
                 escaped_path = chunk_path.replace("'", "''")
                 con.execute(f"""
@@ -1214,7 +1223,7 @@ def _prepare_data_for_matching(
         con.execute(f"ALTER TABLE {processed_table} DROP COLUMN __ukam_row_id")
     else:
         con.read_parquet(str(parquet_directory / "*.parquet")).select(
-            "* EXCLUDE (__ukam_row_id)"
+            *chunk_columns
         ).create_view(processed_table)
     logger.debug("Prepared address table finalized")
 

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -1005,6 +1005,39 @@ def prepare_data_for_matching(
         # Using pre-baked term frequencies (default):
         df_prepared = prepare_data_for_matching(df_addresses, con)
     """
+    return _prepare_data_for_matching(
+        address_table,
+        con,
+        num_of_chunks=num_of_chunks,
+        term_frequency_lookup=term_frequency_lookup,
+        inverted_index=inverted_index,
+        _inverted_index_strategies=_inverted_index_strategies,
+        inverted_index_n=inverted_index_n,
+        derive_distinguishing_wrt_adjacent_records=derive_distinguishing_wrt_adjacent_records,
+        dataset_role=dataset_role,
+        _precleaned_addresses=_precleaned_addresses,
+        debug_options=debug_options,
+        show_progress=show_progress,
+    )
+
+
+def _prepare_data_for_matching(
+    address_table: DuckDBPyRelation,
+    con: DuckDBPyConnection,
+    num_of_chunks: int = 10,
+    term_frequency_lookup: Optional[DuckDBPyRelation] = None,
+    inverted_index: Optional[DuckDBPyRelation] = None,
+    _inverted_index_strategies: list[InvertedIndexLookupStrategy] | None = None,
+    inverted_index_n: Optional[int] = None,
+    derive_distinguishing_wrt_adjacent_records: bool = False,
+    *,
+    dataset_role: Literal["messy", "canonical"] | None = None,
+    _precleaned_addresses: bool = False,
+    debug_options: Optional[DebugOptions] = None,
+    show_progress: ShowProgress = "auto",
+    parquet_directory: Path | None = None,
+) -> DuckDBPyRelation:
+    """Prepare chunks; the caller owns any supplied Parquet directory's lifetime."""
     progress_mode = resolve_progress_mode(show_progress)
     uid = _uid()
     distinguishing_table_name = None
@@ -1130,7 +1163,14 @@ def prepare_data_for_matching(
                 debug_options=debug_options if chunk_index == 0 else None,
             )
 
-            if chunk_index == 0:
+            if parquet_directory is not None:
+                chunk_path = str(parquet_directory / f"{chunk_index:05d}.parquet")
+                escaped_path = chunk_path.replace("'", "''")
+                con.execute(f"""
+                    COPY ({processed_chunk.sql_query()}) TO '{escaped_path}'
+                    (FORMAT PARQUET, COMPRESSION ZSTD, COMPRESSION_LEVEL 1)
+                """)
+            elif chunk_index == 0:
                 con.execute(f"DROP TABLE IF EXISTS {processed_table}")
                 processed_chunk.create(processed_table)
             else:
@@ -1170,10 +1210,17 @@ def prepare_data_for_matching(
     if inv_idx_table_name == "__ukam_inverted_index":
         _drop_table_and_registered_aliases(con, inv_idx_table_name)
 
-    con.execute(f"ALTER TABLE {processed_table} DROP COLUMN __ukam_row_id")
+    if parquet_directory is None:
+        con.execute(f"ALTER TABLE {processed_table} DROP COLUMN __ukam_row_id")
+    else:
+        con.read_parquet(str(parquet_directory / "*.parquet")).select(
+            "* EXCLUDE (__ukam_row_id)"
+        ).create_view(processed_table)
     logger.debug("Prepared address table finalized")
 
-    return con.table(processed_table)
+    if parquet_directory is None:
+        return con.table(processed_table)
+    return con.sql(f"SELECT * FROM {processed_table}")
 
 
 __all__ = [

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -946,6 +946,7 @@ def prepare_data_for_matching(
     _precleaned_addresses: bool = False,
     debug_options: Optional[DebugOptions] = None,
     show_progress: ShowProgress = "auto",
+    _parquet_directory: Path | None = None,
 ) -> DuckDBPyRelation:
     """Prepare address data for matching.
 
@@ -977,6 +978,8 @@ def prepare_data_for_matching(
             interactive terminal and otherwise logs stage boundaries.
             ``"stages"`` logs only stage boundaries; ``"off"`` suppresses
             progress output.
+        _parquet_directory: Internal chunk storage for canonical preparation.
+            The caller owns the directory and must keep it alive while reading.
 
     Returns:
         Cleaned address data with computed term frequencies, including numeric
@@ -1005,39 +1008,6 @@ def prepare_data_for_matching(
         # Using pre-baked term frequencies (default):
         df_prepared = prepare_data_for_matching(df_addresses, con)
     """
-    return _prepare_data_for_matching(
-        address_table,
-        con,
-        num_of_chunks=num_of_chunks,
-        term_frequency_lookup=term_frequency_lookup,
-        inverted_index=inverted_index,
-        _inverted_index_strategies=_inverted_index_strategies,
-        inverted_index_n=inverted_index_n,
-        derive_distinguishing_wrt_adjacent_records=derive_distinguishing_wrt_adjacent_records,
-        dataset_role=dataset_role,
-        _precleaned_addresses=_precleaned_addresses,
-        debug_options=debug_options,
-        show_progress=show_progress,
-    )
-
-
-def _prepare_data_for_matching(
-    address_table: DuckDBPyRelation,
-    con: DuckDBPyConnection,
-    num_of_chunks: int = 10,
-    term_frequency_lookup: Optional[DuckDBPyRelation] = None,
-    inverted_index: Optional[DuckDBPyRelation] = None,
-    _inverted_index_strategies: list[InvertedIndexLookupStrategy] | None = None,
-    inverted_index_n: Optional[int] = None,
-    derive_distinguishing_wrt_adjacent_records: bool = False,
-    *,
-    dataset_role: Literal["messy", "canonical"] | None = None,
-    _precleaned_addresses: bool = False,
-    debug_options: Optional[DebugOptions] = None,
-    show_progress: ShowProgress = "auto",
-    parquet_directory: Path | None = None,
-) -> DuckDBPyRelation:
-    """Prepare chunks; the caller owns any supplied Parquet directory's lifetime."""
     progress_mode = resolve_progress_mode(show_progress)
     uid = _uid()
     distinguishing_table_name = None
@@ -1163,7 +1133,7 @@ def _prepare_data_for_matching(
                 debug_options=debug_options if chunk_index == 0 else None,
             )
 
-            if parquet_directory is not None:
+            if _parquet_directory is not None:
                 if chunk_index == 0:
                     # Restore types that Parquet widens, such as ENUM and TIMESTAMP_S.
                     chunk_columns = [
@@ -1174,7 +1144,7 @@ def _prepare_data_for_matching(
                         if name != "__ukam_row_id"
                     ]
                 processed_chunk = processed_chunk.select("* EXCLUDE (__ukam_row_id)")
-                chunk_path = str(parquet_directory / f"{chunk_index:05d}.parquet")
+                chunk_path = str(_parquet_directory / f"{chunk_index:05d}.parquet")
                 escaped_path = chunk_path.replace("'", "''")
                 con.execute(f"""
                     COPY ({processed_chunk.sql_query()}) TO '{escaped_path}'
@@ -1220,15 +1190,15 @@ def _prepare_data_for_matching(
     if inv_idx_table_name == "__ukam_inverted_index":
         _drop_table_and_registered_aliases(con, inv_idx_table_name)
 
-    if parquet_directory is None:
+    if _parquet_directory is None:
         con.execute(f"ALTER TABLE {processed_table} DROP COLUMN __ukam_row_id")
     else:
-        con.read_parquet(str(parquet_directory / "*.parquet")).select(
+        con.read_parquet(str(_parquet_directory / "*.parquet")).select(
             *chunk_columns
         ).create_view(processed_table)
     logger.debug("Prepared address table finalized")
 
-    if parquet_directory is None:
+    if _parquet_directory is None:
         return con.table(processed_table)
     return con.sql(f"SELECT * FROM {processed_table}")
 

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -1173,6 +1173,7 @@ def _prepare_data_for_matching(
                         )
                         if name != "__ukam_row_id"
                     ]
+                processed_chunk = processed_chunk.select("* EXCLUDE (__ukam_row_id)")
                 chunk_path = str(parquet_directory / f"{chunk_index:05d}.parquet")
                 escaped_path = chunk_path.replace("'", "''")
                 con.execute(f"""

--- a/uk_address_matcher/cleaning/steps/roadlike_places.py
+++ b/uk_address_matcher/cleaning/steps/roadlike_places.py
@@ -533,7 +533,7 @@ def roadlike_place_prepared_candidate_sql(
             FROM terminal_candidate_windows
             WHERE NOT regexp_matches(candidate_phrase, {facility_candidate_pattern})
         ), terminal_addresses AS (
-            SELECT DISTINCT address_id
+            SELECT address_id
             FROM terminal_candidates
         ), fallback_candidate_windows AS (
             SELECT
@@ -558,18 +558,17 @@ def roadlike_place_prepared_candidate_sql(
                     address_tokens, starts.start_position + widths.width - 1
                 ) AS terminal_token
             FROM candidate_sources
-            LEFT JOIN terminal_addresses USING (address_id)
+            ANTI JOIN terminal_addresses USING (address_id)
             CROSS JOIN range(
                 numeric_anchor + 1, array_length(address_tokens) + 1
             ) AS starts(start_position)
             CROSS JOIN (VALUES (2), (3)) AS widths(width)
             {fallback_width_join}
-            WHERE terminal_addresses.address_id IS NULL
-                            AND (
-                                        allow_truncated_windows
-                                        OR starts.start_position + widths.width - 1
-                                                <= array_length(address_tokens)
-                            )
+            WHERE (
+                allow_truncated_windows
+                OR starts.start_position + widths.width - 1
+                    <= array_length(address_tokens)
+            )
         {fallback_filter_ctes}
         {candidate_union}
     """

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -626,10 +626,6 @@ def prepare_canonical_folder(
             logger.debug("Canonical road blocking keys derived")
         else:
             roadlike_places = None
-            # Preserve the final Parquet nullability metadata without road enrichment.
-            export_table = f"__ukam_canonical_export_{uuid4().hex}"
-            df_clean.create(export_table)
-            df_clean = con.table(export_table)
 
         canonical_output_relation = df_clean
         addr_count = df_clean.count("*").fetchone()[0]

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -523,10 +523,10 @@ def prepare_canonical_folder(
     from uk_address_matcher.cleaning.chunking_strategies import (
         _add_canonical_road_blocking_keys,
         _derive_term_frequencies_from_precleaned,
+        _prepare_data_for_matching,
         clean_data_pre_term_frequencies,
         derive_inverted_index,
         derive_roadlike_places,
-        _prepare_data_for_matching,
     )
 
     output_is_remote = is_remote_folder_reference(output_folder)
@@ -584,8 +584,10 @@ def prepare_canonical_folder(
     temp_root = con.execute("SELECT current_setting('temp_directory')").fetchone()[0]
     if temp_root:
         Path(temp_root).mkdir(parents=True, exist_ok=True)
-    # Keep chunks until all dependent files have been written, including on error.
-    with TemporaryDirectory(prefix="ukam-prepared-", dir=temp_root or None) as chunk_directory:
+    # Keep chunks until export finishes; remove them on success or failure.
+    with TemporaryDirectory(
+        prefix="ukam-prepared-", dir=temp_root or None
+    ) as chunk_directory:
         logger.debug("Applying term frequencies to canonical addresses")
         df_clean = _prepare_data_for_matching(
             precleaned,
@@ -682,7 +684,9 @@ def prepare_canonical_folder(
             if not output_is_remote:
                 Path(chunk_dir).mkdir(parents=True, exist_ok=True)
 
-            output_chunk_size = (addr_count + output_chunk_count - 1) // output_chunk_count
+            output_chunk_size = (
+                addr_count + output_chunk_count - 1
+            ) // output_chunk_count
             canonical_paths = []
             for chunk_index in range(output_chunk_count):
                 started_at = time.perf_counter()
@@ -702,7 +706,8 @@ def prepare_canonical_folder(
                         _chunk_file_name(chunk_index, output_chunk_count),
                     )
                     if output_is_remote
-                    else Path(chunk_dir) / _chunk_file_name(chunk_index, output_chunk_count)
+                    else Path(chunk_dir)
+                    / _chunk_file_name(chunk_index, output_chunk_count)
                 )
                 _write_parquet_artefact(
                     con,

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -626,6 +626,10 @@ def prepare_canonical_folder(
             logger.debug("Canonical road blocking keys derived")
         else:
             roadlike_places = None
+            # Preserve the final Parquet nullability metadata without road enrichment.
+            export_table = f"__ukam_canonical_export_{uuid4().hex}"
+            df_clean.create(export_table)
+            df_clean = con.table(export_table)
 
         canonical_output_relation = df_clean
         addr_count = df_clean.count("*").fetchone()[0]

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -523,10 +523,10 @@ def prepare_canonical_folder(
     from uk_address_matcher.cleaning.chunking_strategies import (
         _add_canonical_road_blocking_keys,
         _derive_term_frequencies_from_precleaned,
-        _prepare_data_for_matching,
         clean_data_pre_term_frequencies,
         derive_inverted_index,
         derive_roadlike_places,
+        prepare_data_for_matching,
     )
 
     output_is_remote = is_remote_folder_reference(output_folder)
@@ -589,7 +589,7 @@ def prepare_canonical_folder(
         prefix="ukam-prepared-", dir=temp_root or None
     ) as chunk_directory:
         logger.debug("Applying term frequencies to canonical addresses")
-        df_clean = _prepare_data_for_matching(
+        df_clean = prepare_data_for_matching(
             precleaned,
             con=con,
             num_of_chunks=num_of_chunks,
@@ -599,7 +599,7 @@ def prepare_canonical_folder(
             ),
             dataset_role="canonical",
             _precleaned_addresses=True,
-            parquet_directory=Path(chunk_directory),
+            _parquet_directory=Path(chunk_directory),
             show_progress=progress_mode,
         )
         logger.debug("Building inverted index")

--- a/uk_address_matcher/prepare_canonical.py
+++ b/uk_address_matcher/prepare_canonical.py
@@ -9,6 +9,7 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -525,7 +526,7 @@ def prepare_canonical_folder(
         clean_data_pre_term_frequencies,
         derive_inverted_index,
         derive_roadlike_places,
-        prepare_data_for_matching,
+        _prepare_data_for_matching,
     )
 
     output_is_remote = is_remote_folder_reference(output_folder)
@@ -580,208 +581,214 @@ def prepare_canonical_folder(
     logger.debug("Deriving term frequencies from pre-cleaned canonical data")
     tf_table = _derive_term_frequencies_from_precleaned(precleaned, con)
 
-    logger.debug("Applying term frequencies to canonical addresses")
-    df_clean = prepare_data_for_matching(
-        precleaned,
-        con=con,
-        num_of_chunks=num_of_chunks,
-        term_frequency_lookup=tf_table,
-        derive_distinguishing_wrt_adjacent_records=(
-            derive_distinguishing_wrt_adjacent_records
-        ),
-        dataset_role="canonical",
-        _precleaned_addresses=True,
-        show_progress=progress_mode,
-    )
-    logger.debug("Building inverted index")
-    inverted_index = derive_inverted_index(
-        df_clean,
-        con=con,
-        num_of_chunks=num_of_chunks,
-        show_progress=progress_mode,
-    )
-
-    if derive_road_blocking_keys:
-        logger.debug("Deriving canonical road blocking keys")
-        roadlike_places = derive_roadlike_places(
-            df_clean,
-            con,
+    temp_root = con.execute("SELECT current_setting('temp_directory')").fetchone()[0]
+    if temp_root:
+        Path(temp_root).mkdir(parents=True, exist_ok=True)
+    # Keep chunks until all dependent files have been written, including on error.
+    with TemporaryDirectory(prefix="ukam-prepared-", dir=temp_root or None) as chunk_directory:
+        logger.debug("Applying term frequencies to canonical addresses")
+        df_clean = _prepare_data_for_matching(
+            precleaned,
+            con=con,
+            num_of_chunks=num_of_chunks,
+            term_frequency_lookup=tf_table,
+            derive_distinguishing_wrt_adjacent_records=(
+                derive_distinguishing_wrt_adjacent_records
+            ),
+            dataset_role="canonical",
+            _precleaned_addresses=True,
+            parquet_directory=Path(chunk_directory),
             show_progress=progress_mode,
         )
-        df_clean = _add_canonical_road_blocking_keys(
+        logger.debug("Building inverted index")
+        inverted_index = derive_inverted_index(
             df_clean,
-            con,
+            con=con,
             num_of_chunks=num_of_chunks,
-            roadlike_places=roadlike_places,
+            show_progress=progress_mode,
         )
-        logger.debug("Canonical road blocking keys derived")
-    else:
-        roadlike_places = None
 
-    canonical_output_relation = df_clean
-    addr_count = df_clean.count("*").fetchone()[0]
+        if derive_road_blocking_keys:
+            logger.debug("Deriving canonical road blocking keys")
+            roadlike_places = derive_roadlike_places(
+                df_clean,
+                con,
+                show_progress=progress_mode,
+            )
+            df_clean = _add_canonical_road_blocking_keys(
+                df_clean,
+                con,
+                num_of_chunks=num_of_chunks,
+                roadlike_places=roadlike_places,
+            )
+            logger.debug("Canonical road blocking keys derived")
+        else:
+            roadlike_places = None
 
-    # Write parquet files
-    tf_path = (
-        join_remote_path(output_folder_uri, PREPARED_TERM_FREQUENCIES_FILENAME)
-        if output_is_remote
-        else output_folder_path / PREPARED_TERM_FREQUENCIES_FILENAME
-    )
-    idx_path = (
-        join_remote_path(output_folder_uri, PREPARED_INVERTED_INDEX_FILENAME)
-        if output_is_remote
-        else output_folder_path / PREPARED_INVERTED_INDEX_FILENAME
-    )
-    roadlike_places_path = (
-        join_remote_path(output_folder_uri, ROADLIKE_PLACES_FILENAME)
-        if output_is_remote
-        else output_folder_path / ROADLIKE_PLACES_FILENAME
-    )
+        canonical_output_relation = df_clean
+        addr_count = df_clean.count("*").fetchone()[0]
 
-    _write_parquet_artefact(con, tf_table, tf_path)
-    _write_parquet_artefact(
-        con,
-        inverted_index,
-        idx_path,
-        order_by=INVERTED_INDEX_ORDER_BY,
-        compression_level=INVERTED_INDEX_COMPRESSION_LEVEL,
-    )
-    if roadlike_places is not None:
-        _write_parquet_artefact(con, roadlike_places, roadlike_places_path)
-
-    canonical_paths: list[str | Path]
-    chunk_output_location: str | Path | None = None
-    if output_chunk_count == 1:
-        addr_path = (
-            join_remote_path(output_folder_uri, PREPARED_ADDRESSES_FILENAME)
+        # Write parquet files
+        tf_path = (
+            join_remote_path(output_folder_uri, PREPARED_TERM_FREQUENCIES_FILENAME)
             if output_is_remote
-            else output_folder_path / PREPARED_ADDRESSES_FILENAME
+            else output_folder_path / PREPARED_TERM_FREQUENCIES_FILENAME
         )
+        idx_path = (
+            join_remote_path(output_folder_uri, PREPARED_INVERTED_INDEX_FILENAME)
+            if output_is_remote
+            else output_folder_path / PREPARED_INVERTED_INDEX_FILENAME
+        )
+        roadlike_places_path = (
+            join_remote_path(output_folder_uri, ROADLIKE_PLACES_FILENAME)
+            if output_is_remote
+            else output_folder_path / ROADLIKE_PLACES_FILENAME
+        )
+
+        _write_parquet_artefact(con, tf_table, tf_path)
         _write_parquet_artefact(
             con,
-            canonical_output_relation,
-            addr_path,
-            sort_columns=("ukam_address_id",),
-            drop_columns=canonical_drop_columns,
+            inverted_index,
+            idx_path,
+            order_by=INVERTED_INDEX_ORDER_BY,
+            compression_level=INVERTED_INDEX_COMPRESSION_LEVEL,
         )
-        canonical_paths = [addr_path]
-    else:
-        chunk_dir = (
-            join_remote_path(output_folder_uri, PREPARED_ADDRESSES_CHUNK_DIRNAME)
-            if output_is_remote
-            else output_folder_path / PREPARED_ADDRESSES_CHUNK_DIRNAME
-        )
-        chunk_output_location = chunk_dir
-        if not output_is_remote:
-            Path(chunk_dir).mkdir(parents=True, exist_ok=True)
+        if roadlike_places is not None:
+            _write_parquet_artefact(con, roadlike_places, roadlike_places_path)
 
-        output_chunk_size = (addr_count + output_chunk_count - 1) // output_chunk_count
-        canonical_paths = []
-        for chunk_index in range(output_chunk_count):
-            started_at = time.perf_counter()
-            first_id = chunk_index * output_chunk_size + 1
-            last_id = min(
-                (chunk_index + 1) * output_chunk_size,
-                addr_count,
-            )
-            chunk_query = con.sql(f"""
-                SELECT *
-                FROM ({canonical_output_relation.sql_query()}) AS canonical
-                WHERE canonical.ukam_address_id BETWEEN {first_id} AND {last_id}
-            """)
-            chunk_path = (
-                join_remote_path(
-                    str(chunk_dir),
-                    _chunk_file_name(chunk_index, output_chunk_count),
-                )
+        canonical_paths: list[str | Path]
+        chunk_output_location: str | Path | None = None
+        if output_chunk_count == 1:
+            addr_path = (
+                join_remote_path(output_folder_uri, PREPARED_ADDRESSES_FILENAME)
                 if output_is_remote
-                else Path(chunk_dir) / _chunk_file_name(chunk_index, output_chunk_count)
+                else output_folder_path / PREPARED_ADDRESSES_FILENAME
             )
             _write_parquet_artefact(
                 con,
-                chunk_query,
-                chunk_path,
+                canonical_output_relation,
+                addr_path,
                 sort_columns=("ukam_address_id",),
                 drop_columns=canonical_drop_columns,
             )
-            chunk_count = last_id - first_id + 1
-            canonical_paths.append(chunk_path)
+            canonical_paths = [addr_path]
+        else:
+            chunk_dir = (
+                join_remote_path(output_folder_uri, PREPARED_ADDRESSES_CHUNK_DIRNAME)
+                if output_is_remote
+                else output_folder_path / PREPARED_ADDRESSES_CHUNK_DIRNAME
+            )
+            chunk_output_location = chunk_dir
+            if not output_is_remote:
+                Path(chunk_dir).mkdir(parents=True, exist_ok=True)
+
+            output_chunk_size = (addr_count + output_chunk_count - 1) // output_chunk_count
+            canonical_paths = []
+            for chunk_index in range(output_chunk_count):
+                started_at = time.perf_counter()
+                first_id = chunk_index * output_chunk_size + 1
+                last_id = min(
+                    (chunk_index + 1) * output_chunk_size,
+                    addr_count,
+                )
+                chunk_query = con.sql(f"""
+                    SELECT *
+                    FROM ({canonical_output_relation.sql_query()}) AS canonical
+                    WHERE canonical.ukam_address_id BETWEEN {first_id} AND {last_id}
+                """)
+                chunk_path = (
+                    join_remote_path(
+                        str(chunk_dir),
+                        _chunk_file_name(chunk_index, output_chunk_count),
+                    )
+                    if output_is_remote
+                    else Path(chunk_dir) / _chunk_file_name(chunk_index, output_chunk_count)
+                )
+                _write_parquet_artefact(
+                    con,
+                    chunk_query,
+                    chunk_path,
+                    sort_columns=("ukam_address_id",),
+                    drop_columns=canonical_drop_columns,
+                )
+                chunk_count = last_id - first_id + 1
+                canonical_paths.append(chunk_path)
+                logger.debug(
+                    "Wrote canonical output chunk %d/%d to '%s' (%d rows) - took %s",
+                    chunk_index + 1,
+                    output_chunk_count,
+                    chunk_path,
+                    chunk_count,
+                    _format_elapsed(time.perf_counter() - started_at),
+                )
+
+        # Compute row counts once (avoids repeated full scans)
+        tf_count = tf_table.count("*").fetchone()[0]
+        idx_count = inverted_index.count("*").fetchone()[0]
+
+        logger.debug(
+            "Wrote artefacts to '%s': %d addresses, %d term frequencies, %d index rows",
+            output_folder,
+            addr_count,
+            tf_count,
+            idx_count,
+        )
+
+        if output_chunk_count > 1:
             logger.debug(
-                "Wrote canonical output chunk %d/%d to '%s' (%d rows) - took %s",
-                chunk_index + 1,
+                "Wrote %d canonical output chunks to '%s'",
                 output_chunk_count,
-                chunk_path,
-                chunk_count,
-                _format_elapsed(time.perf_counter() - started_at),
+                chunk_output_location,
             )
 
-    # Compute row counts once (avoids repeated full scans)
-    tf_count = tf_table.count("*").fetchone()[0]
-    idx_count = inverted_index.count("*").fetchone()[0]
+        artefact_columns: dict[str, list[str]] = {
+            PREPARED_TERM_FREQUENCIES_FILENAME: tf_table.columns,
+            PREPARED_INVERTED_INDEX_FILENAME: inverted_index.columns,
+        }
+        if roadlike_places is not None:
+            artefact_columns[ROADLIKE_PLACES_FILENAME] = roadlike_places.columns
+        for canonical_path in canonical_paths:
+            relative_name = (
+                relative_remote_path(output_folder_uri, str(canonical_path))
+                if output_is_remote
+                else str(Path(canonical_path).relative_to(output_folder_path))
+            )
+            artefact_columns[relative_name] = [
+                c for c in df_clean.columns if c not in canonical_drop_columns
+            ]
 
-    logger.debug(
-        "Wrote artefacts to '%s': %d addresses, %d term frequencies, %d index rows",
-        output_folder,
-        addr_count,
-        tf_count,
-        idx_count,
-    )
+        manifest_row_counts = {
+            "canonical_addresses": addr_count,
+            "term_frequencies": tf_count,
+            "inverted_index": idx_count,
+            "canonical_output_chunks": output_chunk_count,
+        }
+        artefact_paths: list[str | Path] = [*canonical_paths, tf_path, idx_path]
+        if roadlike_places is not None:
+            roadlike_count = roadlike_places.count("*").fetchone()[0]
+            manifest_row_counts["roadlike_places"] = roadlike_count
+            artefact_paths.append(roadlike_places_path)
 
-    if output_chunk_count > 1:
-        logger.debug(
-            "Wrote %d canonical output chunks to '%s'",
-            output_chunk_count,
-            chunk_output_location,
-        )
+        if output_is_remote:
+            _write_manifest_remote(
+                output_folder_uri,
+                con=con,
+                artefact_paths=[str(path) for path in artefact_paths],
+                artefact_columns=artefact_columns,
+                row_counts=manifest_row_counts,
+                preparation_options={"add_debug_features": add_debug_features},
+            )
+        else:
+            _write_manifest_local(
+                output_folder_path,
+                con=con,
+                artefact_paths=[Path(path) for path in artefact_paths],
+                artefact_columns=artefact_columns,
+                row_counts=manifest_row_counts,
+                preparation_options={"add_debug_features": add_debug_features},
+            )
 
-    artefact_columns: dict[str, list[str]] = {
-        PREPARED_TERM_FREQUENCIES_FILENAME: tf_table.columns,
-        PREPARED_INVERTED_INDEX_FILENAME: inverted_index.columns,
-    }
-    if roadlike_places is not None:
-        artefact_columns[ROADLIKE_PLACES_FILENAME] = roadlike_places.columns
-    for canonical_path in canonical_paths:
-        relative_name = (
-            relative_remote_path(output_folder_uri, str(canonical_path))
-            if output_is_remote
-            else str(Path(canonical_path).relative_to(output_folder_path))
-        )
-        artefact_columns[relative_name] = [
-            c for c in df_clean.columns if c not in canonical_drop_columns
-        ]
-
-    manifest_row_counts = {
-        "canonical_addresses": addr_count,
-        "term_frequencies": tf_count,
-        "inverted_index": idx_count,
-        "canonical_output_chunks": output_chunk_count,
-    }
-    artefact_paths: list[str | Path] = [*canonical_paths, tf_path, idx_path]
-    if roadlike_places is not None:
-        roadlike_count = roadlike_places.count("*").fetchone()[0]
-        manifest_row_counts["roadlike_places"] = roadlike_count
-        artefact_paths.append(roadlike_places_path)
-
-    if output_is_remote:
-        _write_manifest_remote(
-            output_folder_uri,
-            con=con,
-            artefact_paths=[str(path) for path in artefact_paths],
-            artefact_columns=artefact_columns,
-            row_counts=manifest_row_counts,
-            preparation_options={"add_debug_features": add_debug_features},
-        )
-    else:
-        _write_manifest_local(
-            output_folder_path,
-            con=con,
-            artefact_paths=[Path(path) for path in artefact_paths],
-            artefact_columns=artefact_columns,
-            row_counts=manifest_row_counts,
-            preparation_options={"add_debug_features": add_debug_features},
-        )
-
-    logger.info("Prepared canonical artefacts written to '%s'", output_folder)
+        logger.info("Prepared canonical artefacts written to '%s'", output_folder)
 
 
 def _write_manifest_local(


### PR DESCRIPTION
We clean canonical addresses one chunk at a time, but append the finished chunks to a DuckDB table. By the time we build the inverted index, that table holds the whole cleaned dataset and is still competing for memory.

This PR makes `prepare_canonical_folder()` write each finished chunk to a temporary parquet file instead. DuckDB reads the files through a view. They stay available until preparation finishes, then are removed, including when preparation fails.

In a national cleaning-and-index test with **73 million rows**, the original code ran out of memory at the start of index construction in both attempts. This change completed both attempts with the same settings. Cleaning wrote **48% fewer bytes** and used **23% less temporary disk space**. Average cleaning time was essentially unchanged, but it used **24% more CPU time**. Peak process RAM did not fall.

<details>
<summary>Testing and benchmark details</summary>

| Metric | Before | After |
|---|---:|---:|
| Cleaning time, two runs | 9.74 / 9.66 min | 10.35 / 8.94 min |
| Cleaning CPU time, mean | 1,079 s | 1,341 s |
| Bytes read during cleaning, mean | 73.08 GB | 77.60 GB |
| Bytes written during cleaning, mean | 51.70 GB | 26.95 GB |
| Peak cleaning temporary files, mean | 46.20 GB | 35.78 GB |
| Peak cleaning process RAM (RSS), mean | 7.83 GB | 8.40 GB |
| Index construction | Out of memory twice | Completed twice: 4.70 / 4.79 min |
| Peak index temporary files | 40.61 / 41.18 GB **before failure** | 18.07 / 17.27 GB for completed runs |

Temporary-file figures include both DuckDB spill and the new chunk parquets, measured together. The failed index runs are incomplete baselines, so these results do not establish an index speedup.

The runs alternated original / changed / original / changed, using current main (`a867aed`) and this patch (benchmark revision `ebec237`). Both used a 16 GiB Mac, four DuckDB threads, 100 chunks, insertion-order preservation disabled, and the default 12.7 GiB memory allowance. DuckDB was Python 1.6.0.dev379 / native 2.0.0-alpha39998. OS caching and swap were shared and uncontrolled; the unchanged neighbour-token step also varied substantially between runs.

We reused the initial cleaning and corpus frequencies, restoring identical cached inputs for each run. The measured interval covered the remaining cleaning, index construction, writing the comparison files and cleanup. Road building and the final public canonical export were outside this comparison. This is not a complete `prepare_canonical_folder()` runtime comparison.

157 preparation, cleaning and progress tests pass on the DuckDB alpha. GitHub’s full 400-test suite passes on Python 3.10–3.13 with the repository’s pinned DuckDB 1.5.0; Ruff passes. The added test checks temporary-file cleanup on success and failure, and preserves the declared order of enum IDs in an index entry.

A complete small preparation run with road building enabled produced exactly the same four final output schemas and values. National checks covered all 36 cleaned columns across 73,058,999 rows, including nested values and ID order: 34 columns against the retained validated national output, original address text against the shared input, and candidate-ID lists against the existing self-ID rule. All 62,903,433 index rows matched the retained reference exactly. The two changed runs also matched each other exactly.

Only the original `unique_id` type is restored when the temporary files are read, because it determines ID ordering within the index. Other columns use the types read from Parquet. A separate 1,000-row complete preparation check with enum and timestamp metadata produced identical schemas and values in all four final outputs without the blanket casts. Some fields can be marked nullable instead of required, including in the final address files when road building is disabled. This does not introduce nulls or change field values or types. We accept that metadata difference and export directly without making a table copy just to preserve the flags. A separate 1,000-row before/after check covered both single-file and three-file output: all values, types and canonical row order matched; eight columns became nullable. A three-address matching check also returned identical results. All metadata differences are recorded explicitly.

Most of the diff in `prepare_canonical.py` is indentation: the existing exports now sit inside the temporary directory's lifetime. The existing `prepare_data_for_matching()` function takes an optional internal `_parquet_directory` keyword; ordinary calls still return a materialised table.

</details>

Follow-up: #499 uses an anti join for road fallback candidates and is stacked on this PR.
