### PR TITLE
Use an anti join when finding fallback road candidates

### DIFF
--- a/tests/test_roadlike_place_stage.py
+++ b/tests/test_roadlike_place_stage.py
@@ -44,6 +44,29 @@ def test_roadlike_place_stage_extracts_terminal_first_candidates_and_catalogue(d
     ]
 
 
+def test_roadlike_fallback_exclusion_with_duplicate_and_null_ids(duck_con):
+    duck_con.execute("""
+        CREATE TABLE roadlike_source AS SELECT * FROM (VALUES
+            ('1', '12 HIGH STREET', 'AB1 2CD', ['12']),
+            ('1', '12 HIGH STREET', 'AB1 2CD', ['12']),
+            ('1', '12 ACORN LODGE', 'ZZ1 2CD', ['12']),
+            ('2', '12 ACORN LODGE', 'ZZ1 2CD', ['12']),
+            (NULL, '12 ACORN LODGE', 'ZZ1 2CD', ['12'])
+        ) AS rows(unique_id, clean_full_address, postcode, numeric_tokens)
+    """)
+
+    candidates = duck_con.sql(roadlike_place_candidate_sql("roadlike_source"))
+
+    assert candidates.project("address_id, candidate_phrase").order(
+        "address_id NULLS LAST, candidate_phrase"
+    ).fetchall() == [
+        ("1", "HIGH STREET"),
+        ("1", "HIGH STREET"),
+        ("2", "ACORN LODGE"),
+        (None, "ACORN LODGE"),
+    ]
+
+
 def test_prepared_roadlike_candidates_match_generic_candidates(duck_con):
     source = duck_con.sql("""
         SELECT * FROM (VALUES

--- a/uk_address_matcher/cleaning/steps/roadlike_places.py
+++ b/uk_address_matcher/cleaning/steps/roadlike_places.py
@@ -533,7 +533,7 @@ def roadlike_place_prepared_candidate_sql(
             FROM terminal_candidate_windows
             WHERE NOT regexp_matches(candidate_phrase, {facility_candidate_pattern})
         ), terminal_addresses AS (
-            SELECT DISTINCT address_id
+            SELECT address_id
             FROM terminal_candidates
         ), fallback_candidate_windows AS (
             SELECT
@@ -558,18 +558,17 @@ def roadlike_place_prepared_candidate_sql(
                     address_tokens, starts.start_position + widths.width - 1
                 ) AS terminal_token
             FROM candidate_sources
-            LEFT JOIN terminal_addresses USING (address_id)
+            ANTI JOIN terminal_addresses USING (address_id)
             CROSS JOIN range(
                 numeric_anchor + 1, array_length(address_tokens) + 1
             ) AS starts(start_position)
             CROSS JOIN (VALUES (2), (3)) AS widths(width)
             {fallback_width_join}
-            WHERE terminal_addresses.address_id IS NULL
-                            AND (
-                                        allow_truncated_windows
-                                        OR starts.start_position + widths.width - 1
-                                                <= array_length(address_tokens)
-                            )
+            WHERE (
+                allow_truncated_windows
+                OR starts.start_position + widths.width - 1
+                    <= array_length(address_tokens)
+            )
         {fallback_filter_ctes}
         {candidate_union}
     """


### PR DESCRIPTION
Depends on #498.

Road discovery first looks for phrases ending in a road word such as `STREET`. It then tries other word combinations for addresses that didn't produce a candidate. We currently find those addresses with a left join followed by an `IS NULL` filter.

This changes that to an anti join and removes the separate `DISTINCT` on the IDs being excluded. In the measured plans, DuckDB can exclude those addresses before generating fallback word combinations, which saves work.

On **9.4 million London addresses**, average road-catalogue building time fell from **33.8 to 26.3 seconds: 22% less time**. CPU time fell 22% and peak spill fell 12%. Peak process RAM increased, and bytes written did not consistently improve.

<details>
<summary>Testing and benchmark details</summary>

| Metric | Before | After |
|---|---:|---:|
| Road-catalogue time, two runs | 32.79 / 34.83 s | 27.82 / 24.78 s |
| Candidate table creation, two runs | 28.42 / 30.18 s | 22.91 / 19.83 s |
| CPU time, mean | 87.63 s | 68.57 s |
| Peak DuckDB spill, mean | 9.26 GB | 8.14 GB |
| Peak process RAM (RSS), mean | 1.47 GB | 1.74 GB |
| Process bytes read, mean | 5.74 GB | 4.28 GB |
| Process bytes written, mean | 4.00 GB | 4.22 GB |

The runs alternated before / after / before / after on the same 9,441,086 retained cleaned addresses. The baseline was #498 at `99227c1`; the changed version was `8b6ac4d`. Both used four DuckDB threads, a 1 GB DuckDB memory limit, insertion-order preservation disabled, and Python DuckDB 1.6.0.dev379 / native 2.0.0-alpha39998 on a 16 GiB Mac.

The timed interval calls `derive_roadlike_places()`, including input preparation, statistics collection, candidate creation, catalogue creation, parquet export and cleanup. It excludes address cleaning, road assignment, index building and the rest of `prepare_canonical_folder()`. No builder or cleaning rerun was needed.

The memory limit applies to DuckDB, not total process or machine memory. OS caching and existing swap were uncontrolled. RAM and process I/O were sampled every 0.5 seconds; I/O boundaries are approximate, and these are process counters rather than physical device reads/writes. The write counts varied substantially between runs, so this is not evidence of reduced total writes.

All four 114,257-row catalogues matched exactly in every column, including duplicates and Parquet schema/nullability. One-off checks also compared candidate and catalogue values on duplicate/NULL IDs, missing addresses and facility cases, with and without a supplied catalogue and with district batching. Catalogue row order is unspecified; file bytes may differ.

88 relevant road and preparation tests pass on the alpha. All 401 tests also pass in GitHub CI on Python 3.10–3.13 with the repository’s pinned dependencies; Ruff lint and formatting pass. The only added permanent test checks fallback exclusion with duplicate and NULL IDs.

The narrow road-input projection is already on `main`, introduced in `e3ac19a`, so it is unchanged here. The earlier national 260 → 19–23 second result measured road-input materialisation and statistics collection in a wider bundle. It is not a measurement of this PR.

</details>
